### PR TITLE
argparse uses `repr` on the choices when throwing an error…

### DIFF
--- a/src/code42cli/profile/profile.py
+++ b/src/code42cli/profile/profile.py
@@ -26,13 +26,13 @@ def init(subcommand_parser):
         Args:
             subcommand_parser: The subparsers group created by the parent parser.
     """
-    parser_profile = subcommand_parser.add_parser(u"profile")
+    parser_profile = subcommand_parser.add_parser("profile")
     parser_profile.set_defaults(func=show_profile)
     profile_subparsers = parser_profile.add_subparsers()
 
-    parser_for_show_command = profile_subparsers.add_parser(u"show")
-    parser_for_set_command = profile_subparsers.add_parser(u"set")
-    parser_for_reset_password = profile_subparsers.add_parser(u"reset-pw")
+    parser_for_show_command = profile_subparsers.add_parser("show")
+    parser_for_set_command = profile_subparsers.add_parser("set")
+    parser_for_reset_password = profile_subparsers.add_parser("reset-pw")
 
     parser_for_show_command.set_defaults(func=show_profile)
     parser_for_set_command.set_defaults(func=set_profile)

--- a/src/code42cli/securitydata/subcommands/print_out.py
+++ b/src/code42cli/securitydata/subcommands/print_out.py
@@ -10,7 +10,7 @@ def init(subcommand_parser):
         Args:
             subcommand_parser: The subparsers group created by the parent parser.
     """
-    parser = subcommand_parser.add_parser(u"print")
+    parser = subcommand_parser.add_parser("print")
     parser.set_defaults(func=print_out)
     search_args.add_arguments_to_parser(parser)
     main_args.add_arguments_to_parser(parser)

--- a/src/code42cli/securitydata/subcommands/write_to.py
+++ b/src/code42cli/securitydata/subcommands/write_to.py
@@ -10,7 +10,7 @@ def init(subcommand_parser):
         Args:
             subcommand_parser: The subparsers group created by the parent parser.
     """
-    parser = subcommand_parser.add_parser(u"write-to")
+    parser = subcommand_parser.add_parser("write-to")
     parser.set_defaults(func=write_to)
     _add_filename_subcommand(parser)
     search_args.add_arguments_to_parser(parser)


### PR DESCRIPTION
which causes our u-prefixed string literals to print out with the prefix when running the code42cli on python2:

```
# code42 securitydata notvalid
usage: code42 securitydata [-h] {send-to,write-to,print,clear-checkpoint} ...
code42 securitydata: error: invalid choice: 'notvalid' (choose from 'send-to', u'write-to', u'print', 'clear-checkpoint')
```

So I'm removing those from the relevant strings.