### PR TITLE
Password argument for profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+##Unreleased
+
+### Added
+
+- Read password from environment variable, if not prompt for password.
+
 ## 0.7.2 - 2020-06-11
 
 ### Fixed

--- a/src/code42cli/sdk_client.py
+++ b/src/code42cli/sdk_client.py
@@ -1,3 +1,4 @@
+import os
 import py42.sdk
 import py42.settings.debug as debug
 import py42.settings
@@ -5,12 +6,15 @@ import py42.settings
 from code42cli.logger import get_main_cli_logger
 
 py42.settings.items_per_page = 500
+PY42_PASSWORD_KEY = u"PY42_PASS"
+
 
 def create_sdk(profile, is_debug_mode):
     if is_debug_mode:
         py42.settings.debug.level = debug.DEBUG
     try:
-        password = profile.get_password()
+        password = os.environ[PY42_PASSWORD_KEY] if PY42_PASSWORD_KEY in os.environ.keys() \
+            else profile.get_password()
         return py42.sdk.from_local_account(profile.authority_url, profile.username, password)
     except Exception:
         logger = get_main_cli_logger()

--- a/tests/test_sdk_client.py
+++ b/tests/test_sdk_client.py
@@ -1,8 +1,10 @@
+import os
+
 import py42.sdk
 import py42.settings.debug as debug
 import pytest
 
-from code42cli.sdk_client import create_sdk, validate_connection
+from code42cli.sdk_client import create_sdk, validate_connection, PY42_PASSWORD_KEY
 from .conftest import create_mock_profile
 
 
@@ -53,3 +55,11 @@ def test_validate_connection_when_sdk_does_not_raise_returns_true(mock_sdk_facto
 def test_validate_connection_uses_given_credentials(mock_sdk_factory):
     assert validate_connection("Authority", "Test", "Password")
     mock_sdk_factory.assert_called_once_with("Authority", "Test", "Password")
+
+
+def test_create_sdk_reads_password_from_environment_variable(profile, mock_sdk_factory):
+    os.environ[PY42_PASSWORD_KEY] = "abc"
+    profile.username = "test profile"
+    profile.authority_url = "url"
+    create_sdk(profile, True)
+    mock_sdk_factory.assert_called_once_with("url", "test profile", "abc")


### PR DESCRIPTION
Changed solution.

A use case to have a password as an argument as it is needed for tests, doesn't seem quite right. Hence changed solution to read password from environment variable if available, if not then default to prompt for password as it is now. 

This would suffice for integration tests. If this is accepted may be we might not need the subsequent task on the same.
 