### PR TITLE
Add -y option for bypassing prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 ### Added
 
 - Profile can now save multiple alert and file event checkpoints. The name of the checkpoint to be used for a given query should be passed to `-c` (`--use-checkpoint`).
-- `-y/--assume-yes` option added to profile deletion commands to not require interactive prompt.
+- `-y/--assume-yes` option added to `profile delete` and `profile delete-all` commands to not require interactive prompt.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 ### Added
 
 - Profile can now save multiple alert and file event checkpoints. The name of the checkpoint to be used for a given query should be passed to `-c` (`--use-checkpoint`).
+- `-y/--assume-yes` option added to profile deletion commands to not require interactive prompt.
 
 ### Removed
 

--- a/src/code42cli/cmds/profile.py
+++ b/src/code42cli/cmds/profile.py
@@ -5,6 +5,7 @@ from click import echo, secho
 
 import code42cli.profile as cliprofile
 from code42cli.errors import Code42CLIError
+from code42cli.options import yes_option
 from code42cli.profile import CREATE_PROFILE_HELP
 from code42cli.sdk_client import validate_connection
 from code42cli.util import does_user_agree
@@ -103,6 +104,7 @@ def use(profile_name):
 
 
 @profile.command()
+@yes_option
 @profile_name_arg
 def delete(profile_name):
     """Deletes a profile and its stored password (if any)."""
@@ -118,6 +120,7 @@ def delete(profile_name):
 
 
 @profile.command()
+@yes_option
 def delete_all():
     """Deletes all profiles and saved passwords (if any)."""
     existing_profiles = cliprofile.get_all_profiles()

--- a/src/code42cli/cmds/profile.py
+++ b/src/code42cli/cmds/profile.py
@@ -108,15 +108,12 @@ def use(profile_name):
 @profile_name_arg
 def delete(profile_name):
     """Deletes a profile and its stored password (if any)."""
+    message = "\nDeleting this profile will also delete any stored passwords and checkpoints. Are you sure? (y/n): "
     if cliprofile.is_default_profile(profile_name):
-        echo("\n{} is currently the default profile!".format(profile_name))
-    if not does_user_agree(
-        "\nDeleting this profile will also delete any stored passwords and checkpoints. "
-        "Are you sure? (y/n): "
-    ):
-        return
-    cliprofile.delete_profile(profile_name)
-    echo("Profile '{}' has been deleted.".format(profile_name))
+        message = "\n'{0}' is currently the default profile!\n{1}".format(profile_name, message)
+    if does_user_agree(message):
+        cliprofile.delete_profile(profile_name)
+        echo("Profile '{}' has been deleted.".format(profile_name))
 
 
 @profile.command()

--- a/src/code42cli/cmds/profile.py
+++ b/src/code42cli/cmds/profile.py
@@ -125,10 +125,11 @@ def delete_all():
     """Deletes all profiles and saved passwords (if any)."""
     existing_profiles = cliprofile.get_all_profiles()
     if existing_profiles:
-        echo("\nAre you sure you want to delete the following profiles?")
-        for profile in existing_profiles:
-            echo("\t{}".format(profile.name))
-        if does_user_agree("\nThis will also delete any stored passwords and checkpoints. (y/n): "):
+        message = (
+            "\nAre you sure you want to delete the following profiles?\n\t{}"
+            "\n\nThis will also delete any stored passwords and checkpoints. (y/n): "
+        ).format("\n\t".join([profile.name for profile in existing_profiles]))
+        if does_user_agree(message):
             for profile in existing_profiles:
                 cliprofile.delete_profile(profile.name)
                 echo("Profile '{}' has been deleted.".format(profile.name))

--- a/src/code42cli/options.py
+++ b/src/code42cli/options.py
@@ -6,6 +6,15 @@ from code42cli.errors import Code42CLIError
 from code42cli.profile import get_profile
 from code42cli.sdk_client import create_sdk
 
+yes_option = click.option(
+    "-y",
+    "--assume-yes",
+    is_flag=True,
+    expose_value=False,
+    callback=lambda ctx, param, value: ctx.obj.set_assume_yes(value),
+    help='Assume "yes" as answer to all prompts and run non-interactively.',
+)
+
 
 class CLIState(object):
     def __init__(self):
@@ -16,7 +25,7 @@ class CLIState(object):
         self.debug = False
         self._sdk = None
         self.search_filters = []
-        self.cursor_class = None
+        self.assume_yes = False
 
     @property
     def profile(self):
@@ -33,6 +42,9 @@ class CLIState(object):
         if self._sdk is None:
             self._sdk = create_sdk(self.profile, self.debug)
         return self._sdk
+
+    def set_assume_yes(self, param):
+        self.assume_yes = param
 
 
 def set_profile(ctx, param, value):

--- a/src/code42cli/util.py
+++ b/src/code42cli/util.py
@@ -5,8 +5,7 @@ from functools import wraps
 from os import path
 from signal import signal, getsignal, SIGINT
 
-import click
-from click import echo, style
+from click import echo, style, get_current_context
 
 _PADDING_SIZE = 3
 
@@ -15,7 +14,7 @@ def does_user_agree(prompt):
     """Prompts the user and checks if they said yes. If command has the `yes_option` flag, and 
     `-y/--yes` is passed, this will always return `True`.
     """
-    ctx = click.get_current_context()
+    ctx = get_current_context()
     if ctx.obj.assume_yes:
         return True
     ans = input(prompt)

--- a/src/code42cli/util.py
+++ b/src/code42cli/util.py
@@ -5,13 +5,19 @@ from functools import wraps
 from os import path
 from signal import signal, getsignal, SIGINT
 
+import click
 from click import echo, style
 
 _PADDING_SIZE = 3
 
 
 def does_user_agree(prompt):
-    """Prompts the user and checks if they said yes."""
+    """Prompts the user and checks if they said yes. If command has the `yes_option` flag, and 
+    `-y/--yes` is passed, this will always return `True`.
+    """
+    ctx = click.get_current_context()
+    if ctx.obj.assume_yes:
+        return True
     ans = input(prompt)
     ans = ans.strip().lower()
     return ans == "y"

--- a/tests/cmds/test_profile.py
+++ b/tests/cmds/test_profile.py
@@ -202,7 +202,7 @@ def test_delete_profile_outputs_success(runner, mock_cliprofile_namespace, user_
     assert "Profile 'mockdefault' has been deleted." in result.output
 
 
-def test_delete_all_warns_if_profiles_exist(runner, user_agreement, mock_cliprofile_namespace):
+def test_delete_all_warns_if_profiles_exist(runner, mock_cliprofile_namespace):
     mock_cliprofile_namespace.get_all_profiles.return_value = [
         create_mock_profile("test1"),
         create_mock_profile("test2"),
@@ -211,6 +211,17 @@ def test_delete_all_warns_if_profiles_exist(runner, user_agreement, mock_cliprof
     assert "Are you sure you want to delete the following profiles?" in result.output
     assert "test1" in result.output
     assert "test2" in result.output
+
+
+def test_delete_all_does_not_warn_if_assume_yes_flag(runner, mock_cliprofile_namespace):
+    mock_cliprofile_namespace.get_all_profiles.return_value = [
+        create_mock_profile("test1"),
+        create_mock_profile("test2"),
+    ]
+    result = runner.invoke(cli, ["profile", "delete-all", "-y"])
+    assert "Are you sure you want to delete the following profiles?" not in result.output
+    assert "Profile '{}' has been deleted.".format("test1") in result.output
+    assert "Profile '{}' has been deleted.".format("test2") in result.output
 
 
 def test_delete_all_profiles_does_nothing_if_user_doesnt_agree(

--- a/tests/cmds/test_profile.py
+++ b/tests/cmds/test_profile.py
@@ -182,12 +182,10 @@ def test_update_profile_if_user_agrees_and_valid_connection_sets_password(
     mock_cliprofile_namespace.set_password.assert_called_once_with("newpassword", mocker.ANY)
 
 
-def test_delete_profile_warns_if_deleting_default(
-    runner, user_agreement, mock_cliprofile_namespace
-):
+def test_delete_profile_warns_if_deleting_default(runner, mock_cliprofile_namespace):
     mock_cliprofile_namespace.is_default_profile.return_value = True
     result = runner.invoke(cli, ["profile", "delete", "mockdefault"])
-    assert "mockdefault is currently the default profile!" in result.output
+    assert "'mockdefault' is currently the default profile!" in result.output
 
 
 def test_delete_profile_does_nothing_if_user_doesnt_agree(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,6 +118,7 @@ def cli_state(mocker, sdk, profile):
     mock_state._sdk = sdk
     mock_state.profile = profile
     mock_state.search_filters = []
+    mock_state.assume_yes = False
     return mock_state
 
 

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,8 +1,4 @@
 import pytest
-import logging
-
-from click.testing import CliRunner
-from code42cli.main import cli
 
 import code42cli.profile as cliprofile
 from code42cli import PRODUCT_NAME

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -6,22 +6,47 @@ from code42cli.util import does_user_agree, find_format_width
 TEST_HEADER = {u"key1": u"Column 1", u"key2": u"Column 10", u"key3": u"Column 100"}
 
 
+@pytest.fixture
+def context_with_assume_yes(mocker, cli_state):
+    ctx = mocker.MagicMock()
+    ctx.obj = cli_state
+    cli_state.assume_yes = True
+    return mocker.patch("code42cli.util.get_current_context", return_value=ctx)
+
+
+@pytest.fixture
+def context_without_assume_yes(mocker, cli_state):
+    ctx = mocker.MagicMock()
+    ctx.obj = cli_state
+    cli_state.assume_yes = False
+    return mocker.patch("code42cli.util.get_current_context", return_value=ctx)
+
+
 _NAMESPACE = "{}.util".format(PRODUCT_NAME)
 
 
-def test_does_user_agree_when_user_says_y_returns_true(mocker):
+def test_does_user_agree_when_user_says_y_returns_true(mocker, context_without_assume_yes):
     mocker.patch("builtins.input", return_value="y")
     assert does_user_agree("Test Prompt")
 
 
-def test_does_user_agree_when_user_says_capital_y_returns_true(mocker):
+def test_does_user_agree_when_user_says_capital_y_returns_true(mocker, context_without_assume_yes):
     mocker.patch("builtins.input", return_value="Y")
     assert does_user_agree("Test Prompt")
 
 
-def test_does_user_agree_when_user_says_n_returns_false(mocker):
+def test_does_user_agree_when_user_says_n_returns_false(mocker, context_without_assume_yes):
     mocker.patch("builtins.input", return_value="n")
     assert not does_user_agree("Test Prompt")
+
+
+def test_does_user_agree_when_assume_yes_argument_passed_returns_true_and_does_not_print_prompt(
+    mocker, context_with_assume_yes, capsys
+):
+    result = does_user_agree("Test Prompt")
+    output = capsys.readouterr()
+    assert result
+    assert output.out == output.err == ""
 
 
 def test_find_format_width_when_zero_records_sets_width_to_header_length():


### PR DESCRIPTION
The new click.Option `code42cli.options.yes_option` can be added to any command and it will set the `assume_yes` property of the CLIState context object to `True` when `-y/--assume-yes` flag is passed. This flag is now checked by `does_user_agree` and if `True` it will bypass the prompting and just return `True`.