### PR TITLE
add --password option to `profile create` and `profile update` commands

### DIFF
--- a/src/code42cli/cmds/profile.py
+++ b/src/code42cli/cmds/profile.py
@@ -83,7 +83,7 @@ def create(name, server, username, password, disable_ssl_errors):
 def update(name, server, username, password, disable_ssl_errors):
     """Update an existing profile."""
     c42profile = cliprofile.get_profile(name)
-    cliprofile.update_profile(profile.name, server, username, disable_ssl_errors)
+    cliprofile.update_profile(c42profile.name, server, username, disable_ssl_errors)
     if password:
         _set_pw(name, password)
     else:

--- a/src/code42cli/cmds/profile.py
+++ b/src/code42cli/cmds/profile.py
@@ -21,14 +21,18 @@ name_option = click.option(
     "-n",
     "--name",
     required=True,
-    type=str,
     help="The name of the Code42 CLI profile to use when executing this command.",
 )
 server_option = click.option(
-    "-s", "--server", required=True, type=str, help="The url and port of the Code42 server."
+    "-s", "--server", required=True, help="The url and port of the Code42 server."
 )
 username_option = click.option(
-    "-u", "--username", required=True, type=str, help="The username of the Code42 API user."
+    "-u", "--username", required=True, help="The username of the Code42 API user."
+)
+password_option = click.option(
+    "--password",
+    help="The password for the Code42 API user. Only recommended if command needs to be run without "
+    "prompt interactions.",
 )
 disable_ssl_option = click.option(
     "--disable-ssl-errors",
@@ -57,11 +61,15 @@ def show(profile_name):
 @name_option
 @server_option
 @username_option
+@password_option
 @disable_ssl_option
-def create(name, server, username, disable_ssl_errors=False):
+def create(name, server, username, password, disable_ssl_errors):
     """Create profile settings. The first profile created will be the default."""
     cliprofile.create_profile(name, server, username, disable_ssl_errors)
-    _prompt_for_allow_password_set(name)
+    if password:
+        _set_pw(name, password)
+    else:
+        _prompt_for_allow_password_set(name)
     echo("Successfully created profile '{}'.".format(name))
 
 
@@ -69,20 +77,26 @@ def create(name, server, username, disable_ssl_errors=False):
 @name_option
 @server_option
 @username_option
+@password_option
 @disable_ssl_option
-def update(name=None, server=None, username=None, disable_ssl_errors=None):
+def update(name, server, username, password, disable_ssl_errors):
     """Update an existing profile."""
     profile = cliprofile.get_profile(name)
     cliprofile.update_profile(profile.name, server, username, disable_ssl_errors)
-    _prompt_for_allow_password_set(profile.name)
+    if password:
+        _set_pw(name, password)
+    else:
+        _prompt_for_allow_password_set(profile.name)
     echo("Profile '{}' has been updated.".format(profile.name))
 
 
 @profile.command()
 @profile_name_arg
-def reset_pw(profile_name=None):
+def reset_pw(profile_name):
     """Change the stored password for a profile."""
-    _reset_pw(profile_name)
+    password = getpass()
+    _set_pw(profile_name, password)
+    echo("Password updated for profile '{}'".format(profile_name))
 
 
 @profile.command("list")
@@ -100,6 +114,7 @@ def _list():
 def use(profile_name):
     """Set a profile as the default."""
     cliprofile.switch_default_profile(profile_name)
+    echo("{} has been set as the default profile.".format(profile_name))
 
 
 @profile.command()
@@ -135,7 +150,8 @@ def delete_all():
 
 def _prompt_for_allow_password_set(profile_name):
     if does_user_agree("Would you like to set a password? (y/n): "):
-        _reset_pw(profile_name)
+        password = getpass()
+        _set_pw(profile_name, password)
 
 
 def _reset_pw(profile_name):
@@ -147,3 +163,13 @@ def _reset_pw(profile_name):
         secho("Password not stored!", bold=True)
         raise
     cliprofile.set_password(new_password, c42profile.name)
+
+
+def _set_pw(profile_name, password):
+    c42profile = cliprofile.get_profile(profile_name)
+    try:
+        validate_connection(c42profile.authority_url, c42profile.username, password)
+    except Exception:
+        secho("Password not stored!", bold=True)
+        raise
+    cliprofile.set_password(password, c42profile.name)

--- a/src/code42cli/cmds/profile.py
+++ b/src/code42cli/cmds/profile.py
@@ -32,8 +32,8 @@ username_option = click.option(
 )
 password_option = click.option(
     "--password",
-    help="The password for the Code42 API user. Only recommended if command needs to be run without "
-    "prompt interactions.",
+    help="The password for the Code42 API user. If this option is omitted, interactive prompts "
+    "will be used to obtain the password.",
 )
 disable_ssl_option = click.option(
     "--disable-ssl-errors",

--- a/src/code42cli/cmds/profile.py
+++ b/src/code42cli/cmds/profile.py
@@ -94,7 +94,9 @@ def update(name, server, username, password, disable_ssl_errors):
 @profile.command()
 @profile_name_arg
 def reset_pw(profile_name):
-    """Change the stored password for a profile."""
+    """\b
+    Change the stored password for a profile. Only affects what's stored in the local profile, 
+    does not make any changes to the Code42 user account."""
     password = getpass()
     _set_pw(profile_name, password)
     echo("Password updated for profile '{}'".format(profile_name))

--- a/src/code42cli/cmds/profile.py
+++ b/src/code42cli/cmds/profile.py
@@ -155,17 +155,6 @@ def _prompt_for_allow_password_set(profile_name):
         _set_pw(profile_name, password)
 
 
-def _reset_pw(profile_name):
-    c42profile = cliprofile.get_profile(profile_name)
-    new_password = getpass()
-    try:
-        validate_connection(c42profile.authority_url, c42profile.username, new_password)
-    except Exception:
-        secho("Password not stored!", bold=True)
-        raise
-    cliprofile.set_password(new_password, c42profile.name)
-
-
 def _set_pw(profile_name, password):
     c42profile = cliprofile.get_profile(profile_name)
     try:

--- a/src/code42cli/config.py
+++ b/src/code42cli/config.py
@@ -83,7 +83,6 @@ class ConfigAccessor(object):
             raise NoConfigProfileError(new_default_name)
         self._internal[self.DEFAULT_PROFILE] = new_default_name
         self._save()
-        echo("{} has been set as the default profile.".format(new_default_name))
 
     def delete_profile(self, name):
         """Deletes a profile."""
@@ -149,7 +148,6 @@ class ConfigAccessor(object):
             return
 
         self._save()
-        echo("Successfully saved profile '{}'.".format(profile.name))
 
         default_profile = self._internal.get(self.DEFAULT_PROFILE)
         if default_profile is None or default_profile == self.DEFAULT_VALUE:

--- a/tests/cmds/test_profile.py
+++ b/tests/cmds/test_profile.py
@@ -301,6 +301,6 @@ def test_list_profiles_when_no_profiles_outputs_no_profiles_message(
 
 
 def test_use_profile(runner, mock_cliprofile_namespace, profile):
-    runner.invoke(cli, ["profile", "use", profile.name])
+    result = runner.invoke(cli, ["profile", "use", profile.name])
     mock_cliprofile_namespace.switch_default_profile.assert_called_once_with(profile.name)
     assert "{} has been set as the default profile.".format(profile.name) in result.output

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,10 +1,7 @@
-from __future__ import with_statement
+from configparser import ConfigParser
 
 import pytest
-from configparser import ConfigParser
-import logging
 
-from code42cli import PRODUCT_NAME
 from code42cli.config import ConfigAccessor, NoConfigProfileError
 from .conftest import MockSection
 
@@ -143,14 +140,6 @@ class TestConfigAccessor(object):
         accessor.switch_default_profile(_TEST_SECOND_PROFILE_NAME)
         assert mock_saver.call_count
 
-    def test_switch_default_profile_outputs_confirmation(
-        self, capsys, config_parser_for_multiple_profiles, mock_saver
-    ):
-        accessor = ConfigAccessor(config_parser_for_multiple_profiles)
-        accessor.switch_default_profile(_TEST_SECOND_PROFILE_NAME)
-        output = capsys.readouterr()
-        assert "set as the default profile" in output.out
-
     def test_create_profile_when_given_default_name_does_not_create(self, config_parser_for_create):
         accessor = ConfigAccessor(config_parser_for_create)
         with pytest.raises(Exception):
@@ -188,16 +177,6 @@ class TestConfigAccessor(object):
 
         accessor.create_profile(_TEST_PROFILE_NAME, "example.com", "bar", False)
         assert mock_saver.call_count
-
-    def test_create_profile_when_not_existing_outputs_confirmation(
-        self, capsys, config_parser_for_create, mock_saver
-    ):
-        mock_internal = create_internal_object(False)
-        setup_parser_one_profile(mock_internal, mock_internal, config_parser_for_create)
-        accessor = ConfigAccessor(config_parser_for_create)
-        accessor.create_profile(_TEST_PROFILE_NAME, "example.com", "bar", False)
-        output = capsys.readouterr()
-        assert "Successfully saved" in output.out
 
     def test_update_profile_when_no_profile_exists_raises_exception(
         self, config_parser_for_multiple_profiles


### PR DESCRIPTION
This PR allows the password to be passed on profile creation and update commands, bypassing the interactive prompt.