### PR TITLE
Feature/output formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 - `--password` option added to `profile create` and `profile update` commands, enabling creating profiles while bypassing the interactive password prompt.
 - Profiles can now save multiple alert and file event checkpoints. The name of the checkpoint to be used for a given query should be passed to `-c` (`--use-checkpoint`).
 - `-y/--assume-yes` option added to `profile delete` and `profile delete-all` commands to not require interactive prompt.
+- Below subcommands accept argument `--format/-f` to display result in formats `csv`, `table`, `json`, `formatted-json`:
+    - `code42 alert-rules list`
+    - `code42 legal-hold list`
+    - `code42 legal-hold show`
+    - `code42 security-data saved-search list`
 
 ### Removed
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
         "keyring==18.0.1",
         "keyrings.alt==3.2.0",
         "py42>=1.7.0",
-        "texttable>=1.6.2",
     ],
     extras_require={
         "dev": [

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         "keyring==18.0.1",
         "keyrings.alt==3.2.0",
         "py42>=1.7.0",
+        "texttable>=1.6.2",
     ],
     extras_require={
         "dev": [

--- a/src/code42cli/cmds/alert_rules.py
+++ b/src/code42cli/cmds/alert_rules.py
@@ -83,7 +83,8 @@ def list_alert_rules(state, format=None):
     selected_rules = _get_all_rules_metadata(state.sdk)
     if selected_rules:
         if format:
-            format(selected_rules, _HEADER_KEYS_MAP)
+            formatted_output = format(selected_rules, _HEADER_KEYS_MAP)
+            echo(formatted_output)
         else:
             rows, column_size = find_format_width(selected_rules, _HEADER_KEYS_MAP)
             format_to_table(rows, column_size)

--- a/src/code42cli/cmds/alert_rules.py
+++ b/src/code42cli/cmds/alert_rules.py
@@ -14,6 +14,7 @@ from code42cli.errors import InvalidRuleTypeError
 from code42cli.file_readers import read_csv_arg
 from code42cli.options import OrderedGroup
 from code42cli.options import sdk_options
+from code42cli.output_formats import output_option
 from code42cli.util import find_format_width
 from code42cli.util import format_to_table
 
@@ -75,13 +76,17 @@ def remove_user(state, rule_id, username):
 
 
 @alert_rules.command("list")
+@output_option
 @sdk_options()
-def list_alert_rules(state):
+def list_alert_rules(state, format=None):
     """Fetch existing alert rules."""
     selected_rules = _get_all_rules_metadata(state.sdk)
     if selected_rules:
-        rows, column_size = find_format_width(selected_rules, _HEADER_KEYS_MAP)
-        format_to_table(rows, column_size)
+        if format:
+            format(selected_rules, _HEADER_KEYS_MAP)
+        else:
+            rows, column_size = find_format_width(selected_rules, _HEADER_KEYS_MAP)
+            format_to_table(rows, column_size)
 
 
 @alert_rules.command()

--- a/src/code42cli/cmds/alert_rules.py
+++ b/src/code42cli/cmds/alert_rules.py
@@ -14,7 +14,7 @@ from code42cli.errors import InvalidRuleTypeError
 from code42cli.file_readers import read_csv_arg
 from code42cli.options import OrderedGroup
 from code42cli.options import sdk_options
-from code42cli.output_formats import output_option
+from code42cli.output_formats import format_option
 
 
 class AlertRuleTypes:
@@ -74,7 +74,7 @@ def remove_user(state, rule_id, username):
 
 
 @alert_rules.command("list")
-@output_option
+@format_option
 @sdk_options()
 def list_alert_rules(state, format=None):
     """Fetch existing alert rules."""

--- a/src/code42cli/cmds/alert_rules.py
+++ b/src/code42cli/cmds/alert_rules.py
@@ -15,8 +15,6 @@ from code42cli.file_readers import read_csv_arg
 from code42cli.options import OrderedGroup
 from code42cli.options import sdk_options
 from code42cli.output_formats import output_option
-from code42cli.util import find_format_width
-from code42cli.util import format_to_table
 
 
 class AlertRuleTypes:
@@ -82,12 +80,9 @@ def list_alert_rules(state, format=None):
     """Fetch existing alert rules."""
     selected_rules = _get_all_rules_metadata(state.sdk)
     if selected_rules:
-        if format:
-            formatted_output = format(selected_rules, _HEADER_KEYS_MAP)
-            echo(formatted_output)
-        else:
-            rows, column_size = find_format_width(selected_rules, _HEADER_KEYS_MAP)
-            format_to_table(rows, column_size)
+        formatted_output = format(selected_rules, _HEADER_KEYS_MAP)
+        echo(formatted_output, nl=False)
+        echo("")
 
 
 @alert_rules.command()

--- a/src/code42cli/cmds/alert_rules.py
+++ b/src/code42cli/cmds/alert_rules.py
@@ -81,8 +81,7 @@ def list_alert_rules(state, format=None):
     selected_rules = _get_all_rules_metadata(state.sdk)
     if selected_rules:
         formatted_output = format(selected_rules, _HEADER_KEYS_MAP)
-        echo(formatted_output, nl=False)
-        echo("")
+        echo(formatted_output)
 
 
 @alert_rules.command()

--- a/src/code42cli/cmds/enums.py
+++ b/src/code42cli/cmds/enums.py
@@ -1,8 +1,8 @@
 class OutputFormat:
-    ASCII = "ASCII-TABLE"
+    TABLE = "TABLE"
     CSV = "CSV"
     JSON = "JSON"
     RAW = "RAW-JSON"
 
     def __iter__(self):
-        return iter([self.ASCII, self.CSV, self.JSON, self.RAW])
+        return iter([self.TABLE, self.CSV, self.JSON, self.RAW])

--- a/src/code42cli/cmds/enums.py
+++ b/src/code42cli/cmds/enums.py
@@ -1,0 +1,8 @@
+class OutputFormat:
+    ASCII = "ASCII-TABLE"
+    CSV = "CSV"
+    JSON = "JSON"
+    RAW = "RAW-JSON"
+
+    def __iter__(self):
+        return iter([self.ASCII, self.CSV, self.JSON, self.RAW])

--- a/src/code42cli/cmds/legal_hold.py
+++ b/src/code42cli/cmds/legal_hold.py
@@ -77,7 +77,9 @@ def _list(state):
     matters = _get_all_active_matters(state.sdk)
     if matters:
         rows, column_size = find_format_width(matters, _MATTER_KEYS_MAP)
-        format_to_table(rows, column_size)
+        output = format_to_table(rows, column_size)
+        echo(output, nl=False)
+        echo("")
 
 
 @legal_hold.command()

--- a/src/code42cli/cmds/legal_hold.py
+++ b/src/code42cli/cmds/legal_hold.py
@@ -17,9 +17,9 @@ from code42cli.errors import UserNotInLegalHoldError
 from code42cli.file_readers import read_csv_arg
 from code42cli.options import OrderedGroup
 from code42cli.options import sdk_options
-from code42cli.util import find_format_width
+from code42cli.output_formats import output_option
 from code42cli.util import format_string_list_to_columns
-from code42cli.util import format_to_table
+
 
 _MATTER_KEYS_MAP = OrderedDict()
 _MATTER_KEYS_MAP["legalHoldUid"] = "Matter ID"
@@ -71,13 +71,13 @@ def remove_user(state, matter_id, username):
 
 
 @legal_hold.command("list")
+@output_option
 @sdk_options()
-def _list(state):
+def _list(state, format=None):
     """Fetch existing legal hold matters."""
     matters = _get_all_active_matters(state.sdk)
     if matters:
-        rows, column_size = find_format_width(matters, _MATTER_KEYS_MAP)
-        output = format_to_table(rows, column_size)
+        output = format(matters, _MATTER_KEYS_MAP)
         echo(output, nl=False)
         echo("")
 
@@ -86,8 +86,9 @@ def _list(state):
 @click.argument("matter-id")
 @click.option("--include-inactive", is_flag=True)
 @click.option("--include-policy", is_flag=True)
+@output_option
 @sdk_options()
-def show(state, matter_id, include_inactive=False, include_policy=False):
+def show(state, matter_id, include_inactive=False, include_policy=False, format=None):
     """Display details of a given legal hold matter."""
     matter = _check_matter_is_accessible(state.sdk, matter_id)
     matter["creator_username"] = matter["creator"]["username"]
@@ -105,10 +106,10 @@ def show(state, matter_id, include_inactive=False, include_policy=False):
         member["user"]["username"] for member in memberships if not member["active"]
     ]
 
-    rows, column_size = find_format_width([matter], _MATTER_KEYS_MAP)
-
+    output = format([matter], _MATTER_KEYS_MAP)
+    echo(output, nl=False)
     echo("")
-    format_to_table(rows, column_size)
+
     _print_matter_members(active_usernames, member_type="active")
 
     if include_inactive:

--- a/src/code42cli/cmds/legal_hold.py
+++ b/src/code42cli/cmds/legal_hold.py
@@ -17,7 +17,7 @@ from code42cli.errors import UserNotInLegalHoldError
 from code42cli.file_readers import read_csv_arg
 from code42cli.options import OrderedGroup
 from code42cli.options import sdk_options
-from code42cli.output_formats import output_option
+from code42cli.output_formats import format_option
 from code42cli.util import format_string_list_to_columns
 
 
@@ -71,7 +71,7 @@ def remove_user(state, matter_id, username):
 
 
 @legal_hold.command("list")
-@output_option
+@format_option
 @sdk_options()
 def _list(state, format=None):
     """Fetch existing legal hold matters."""
@@ -85,7 +85,7 @@ def _list(state, format=None):
 @click.argument("matter-id")
 @click.option("--include-inactive", is_flag=True)
 @click.option("--include-policy", is_flag=True)
-@output_option
+@format_option
 @sdk_options()
 def show(state, matter_id, include_inactive=False, include_policy=False, format=None):
     """Display details of a given legal hold matter."""

--- a/src/code42cli/cmds/legal_hold.py
+++ b/src/code42cli/cmds/legal_hold.py
@@ -78,8 +78,7 @@ def _list(state, format=None):
     matters = _get_all_active_matters(state.sdk)
     if matters:
         output = format(matters, _MATTER_KEYS_MAP)
-        echo(output, nl=False)
-        echo("")
+        echo(output)
 
 
 @legal_hold.command()
@@ -107,8 +106,7 @@ def show(state, matter_id, include_inactive=False, include_policy=False, format=
     ]
 
     output = format([matter], _MATTER_KEYS_MAP)
-    echo(output, nl=False)
-    echo("")
+    echo(output)
 
     _print_matter_members(active_usernames, member_type="active")
 

--- a/src/code42cli/cmds/securitydata.py
+++ b/src/code42cli/cmds/securitydata.py
@@ -217,8 +217,7 @@ def _list(state, format=None):
     response = state.sdk.securitydata.savedsearches.get()
     header = {"name": "Name", "id": "Id"}
     output = format(response["searches"], header)
-    echo(output, nl=False)
-    echo("")
+    echo(output)
 
 
 @saved_search.command()

--- a/src/code42cli/cmds/securitydata.py
+++ b/src/code42cli/cmds/securitydata.py
@@ -15,7 +15,7 @@ from code42cli.logger import get_main_cli_logger
 from code42cli.options import incompatible_with
 from code42cli.options import OrderedGroup
 from code42cli.options import sdk_options
-from code42cli.output_formats import format_option
+from code42cli.output_formats import format_option as format_output
 
 
 logger = get_main_cli_logger()
@@ -210,7 +210,7 @@ def saved_search(state):
 
 
 @saved_search.command("list")
-@format_option
+@format_output
 @sdk_options()
 def _list(state, format=None):
     """List available saved searches."""

--- a/src/code42cli/cmds/securitydata.py
+++ b/src/code42cli/cmds/securitydata.py
@@ -215,7 +215,9 @@ def _list(state):
     """List available saved searches."""
     response = state.sdk.securitydata.savedsearches.get()
     header = {"name": "Name", "id": "Id"}
-    format_to_table(*find_format_width(response["searches"], header))
+    output = format_to_table(*find_format_width(response["searches"], header))
+    echo(output, nl=False)
+    echo("")
 
 
 @saved_search.command()

--- a/src/code42cli/cmds/securitydata.py
+++ b/src/code42cli/cmds/securitydata.py
@@ -1,3 +1,4 @@
+from _collections import OrderedDict
 from pprint import pformat
 
 import click
@@ -19,6 +20,10 @@ from code42cli.output_formats import format_option as format_output
 
 
 logger = get_main_cli_logger()
+
+_HEADER_KEYS_MAP = OrderedDict()
+_HEADER_KEYS_MAP["name"] = "Name"
+_HEADER_KEYS_MAP["id"] = "Id"
 
 search_options = searchopt.create_search_options("file events")
 
@@ -215,10 +220,9 @@ def saved_search(state):
 def _list(state, format=None):
     """List available saved searches."""
     response = state.sdk.securitydata.savedsearches.get()
-    header = {"name": "Name", "id": "Id"}
     result = response["searches"]
     if result:
-        output = format(result, header)
+        output = format(result, _HEADER_KEYS_MAP)
         echo(output)
 
 

--- a/src/code42cli/cmds/securitydata.py
+++ b/src/code42cli/cmds/securitydata.py
@@ -15,7 +15,7 @@ from code42cli.logger import get_main_cli_logger
 from code42cli.options import incompatible_with
 from code42cli.options import OrderedGroup
 from code42cli.options import sdk_options
-from code42cli.output_formats import output_option
+from code42cli.output_formats import format_option
 
 
 logger = get_main_cli_logger()
@@ -210,7 +210,7 @@ def saved_search(state):
 
 
 @saved_search.command("list")
-@output_option
+@format_option
 @sdk_options()
 def _list(state, format=None):
     """List available saved searches."""

--- a/src/code42cli/cmds/securitydata.py
+++ b/src/code42cli/cmds/securitydata.py
@@ -216,8 +216,10 @@ def _list(state, format=None):
     """List available saved searches."""
     response = state.sdk.securitydata.savedsearches.get()
     header = {"name": "Name", "id": "Id"}
-    output = format(response["searches"], header)
-    echo(output)
+    result = response["searches"]
+    if result:
+        output = format(result, header)
+        echo(output)
 
 
 @saved_search.command()

--- a/src/code42cli/cmds/securitydata.py
+++ b/src/code42cli/cmds/securitydata.py
@@ -15,8 +15,8 @@ from code42cli.logger import get_main_cli_logger
 from code42cli.options import incompatible_with
 from code42cli.options import OrderedGroup
 from code42cli.options import sdk_options
-from code42cli.util import find_format_width
-from code42cli.util import format_to_table
+from code42cli.output_formats import output_option
+
 
 logger = get_main_cli_logger()
 
@@ -210,12 +210,13 @@ def saved_search(state):
 
 
 @saved_search.command("list")
+@output_option
 @sdk_options()
-def _list(state):
+def _list(state, format=None):
     """List available saved searches."""
     response = state.sdk.securitydata.savedsearches.get()
     header = {"name": "Name", "id": "Id"}
-    output = format_to_table(*find_format_width(response["searches"], header))
+    output = format(response["searches"], header)
     echo(output, nl=False)
     echo("")
 

--- a/src/code42cli/output_formats.py
+++ b/src/code42cli/output_formats.py
@@ -1,9 +1,10 @@
 import json
 
 import click
-from texttable import Texttable
 
 from code42cli.cmds.enums import OutputFormat
+from code42cli.util import find_format_width
+from code42cli.util import format_to_table
 
 
 def output_format(_, __, value):
@@ -12,10 +13,12 @@ def output_format(_, __, value):
             return to_csv
         if value == OutputFormat.RAW:
             return to_json
-        if value == OutputFormat.ASCII:
-            return to_ascii_table
+        if value == OutputFormat.TABLE:
+            return to_table
         if value == OutputFormat.JSON:
             return to_formatted_json
+    # default option
+    return to_table
 
 
 output_option = click.option(
@@ -39,20 +42,9 @@ def to_csv(output, header):
     return "\n".join(lines)
 
 
-def to_ascii_table(output, header):
-    table = Texttable()
-    table.set_cols_align(["c" for _ in header.keys()])
-    table.set_cols_valign(["m" for _ in header.keys()])
-    table.set_max_width(0)
-
-    rows = []
-    columns = header.values()
-    rows.append(columns)
-
-    for row in output:
-        rows.append([str(row[key]) for key in header.keys()])
-    table.add_rows(rows)
-    return table.draw() + "\n"
+def to_table(output, header):
+    rows, column_size = find_format_width(output, header)
+    return format_to_table(rows, column_size)
 
 
 def to_json(output, header=None):

--- a/src/code42cli/output_formats.py
+++ b/src/code42cli/output_formats.py
@@ -8,13 +8,13 @@ from code42cli.cmds.enums import OutputFormat
 
 def output_format(_, __, value):
     if value is not None:
-        if value is OutputFormat.CSV:
+        if value == OutputFormat.CSV:
             return to_csv
-        if value is OutputFormat.RAW:
+        if value == OutputFormat.RAW:
             return to_json
-        if value is OutputFormat.ASCII:
+        if value == OutputFormat.ASCII:
             return to_ascii_table
-        if value is OutputFormat.JSON:
+        if value == OutputFormat.JSON:
             return to_formatted_json
 
 
@@ -31,12 +31,12 @@ def to_csv(output, header):
     columns = ",".join(header.values())
 
     lines = []
+    lines.append(columns)
     for row in output:
         items = [str(row[key]) for key in header.keys()]
         line = ",".join(items)
         lines.append(line)
-    click.echo(columns)
-    click.echo("\n".join(lines))
+    return "\n".join(lines)
 
 
 def to_ascii_table(output, header):
@@ -52,14 +52,14 @@ def to_ascii_table(output, header):
     for row in output:
         rows.append([str(row[key]) for key in header.keys()])
     table.add_rows(rows)
-    click.echo(table.draw() + "\n")
+    return table.draw() + "\n"
 
 
 def to_json(output, header=None):
     # Todo Whether to filter results by header, and verify default output is json
-    click.echo(output)
+    return json.dumps(output)
 
 
 def to_formatted_json(output, header=None):
     # Todo Whether to filter results by header
-    click.echo(json.dumps(output, indent=4))
+    return json.dumps(output, indent=4)

--- a/src/code42cli/output_formats.py
+++ b/src/code42cli/output_formats.py
@@ -1,0 +1,65 @@
+import json
+
+import click
+from texttable import Texttable
+
+from code42cli.cmds.enums import OutputFormat
+
+
+def output_format(_, __, value):
+    if value is not None:
+        if value is OutputFormat.CSV:
+            return to_csv
+        if value is OutputFormat.RAW:
+            return to_json
+        if value is OutputFormat.ASCII:
+            return to_ascii_table
+        if value is OutputFormat.JSON:
+            return to_formatted_json
+
+
+output_option = click.option(
+    "-f",
+    "--format",
+    type=click.Choice(OutputFormat(), case_sensitive=False),
+    help="The output format of the result.",
+    callback=output_format,
+)
+
+
+def to_csv(output, header):
+    columns = ",".join(header.values())
+
+    lines = []
+    for row in output:
+        items = [str(row[key]) for key in header.keys()]
+        line = ",".join(items)
+        lines.append(line)
+    click.echo(columns)
+    click.echo("\n".join(lines))
+
+
+def to_ascii_table(output, header):
+    table = Texttable()
+    table.set_cols_align(["c" for _ in header.keys()])
+    table.set_cols_valign(["m" for _ in header.keys()])
+    table.set_max_width(0)
+
+    rows = []
+    columns = header.values()
+    rows.append(columns)
+
+    for row in output:
+        rows.append([str(row[key]) for key in header.keys()])
+    table.add_rows(rows)
+    click.echo(table.draw() + "\n")
+
+
+def to_json(output, header=None):
+    # Todo Whether to filter results by header, and verify default output is json
+    click.echo(output)
+
+
+def to_formatted_json(output, header=None):
+    # Todo Whether to filter results by header
+    click.echo(json.dumps(output, indent=4))

--- a/src/code42cli/output_formats.py
+++ b/src/code42cli/output_formats.py
@@ -47,11 +47,13 @@ def to_table(output, header):
     return format_to_table(rows, column_size)
 
 
+def _filter(output, header):
+    return [{header[key]: row[key] for key in header.keys()} for row in output]
+
+
 def to_json(output, header=None):
-    # Todo Whether to filter results by header, and verify default output is json
-    return json.dumps(output)
+    return json.dumps(_filter(output, header))
 
 
 def to_formatted_json(output, header=None):
-    # Todo Whether to filter results by header
-    return json.dumps(output, indent=4)
+    return json.dumps(_filter(output, header), indent=4)

--- a/src/code42cli/output_formats.py
+++ b/src/code42cli/output_formats.py
@@ -25,7 +25,7 @@ format_option = click.option(
     "-f",
     "--format",
     type=click.Choice(OutputFormat(), case_sensitive=False),
-    help="The output format of the result.",
+    help="The output format of the result. Defaults to table format.",
     callback=output_format,
 )
 

--- a/src/code42cli/output_formats.py
+++ b/src/code42cli/output_formats.py
@@ -21,7 +21,7 @@ def output_format(_, __, value):
     return to_table
 
 
-output_option = click.option(
+format_option = click.option(
     "-f",
     "--format",
     type=click.Choice(OutputFormat(), case_sensitive=False),

--- a/src/code42cli/util.py
+++ b/src/code42cli/util.py
@@ -68,7 +68,7 @@ def find_format_width(record, header):
 
 
 def format_to_table(rows, column_size):
-    """Prints result in left justified format in a tabular form."""
+    """Formats given rows into a string of left justified table."""
     lines = []
     for row in rows:
         line = ""

--- a/src/code42cli/util.py
+++ b/src/code42cli/util.py
@@ -69,10 +69,13 @@ def find_format_width(record, header):
 
 def format_to_table(rows, column_size):
     """Prints result in left justified format in a tabular form."""
+    lines = []
     for row in rows:
+        line = ""
         for key in row.keys():
-            echo(str(row[key]).ljust(column_size[key] + _PADDING_SIZE), nl=False)
-        echo("")
+            line += str(row[key]).ljust(column_size[key] + _PADDING_SIZE)
+        lines.append(line)
+    return "\n".join(lines)
 
 
 def format_string_list_to_columns(string_list, max_width=None):

--- a/tests/cmds/test_alert_rules.py
+++ b/tests/cmds/test_alert_rules.py
@@ -25,6 +25,19 @@ TEST_SYSTEM_RULE_RESPONSE = {
     ]
 }
 
+TEST_RULE_RESPONSE = {
+    "ruleMetadata": [
+        {
+            "observerRuleId": TEST_RULE_ID,
+            "type": "FED_FILE_TYPE_MISMATCH",
+            "isEnabled": True,
+            "ruleSource": "NOTVALID",
+            "name": "Test",
+            "severity": "high",
+        }
+    ]
+}
+
 TEST_USER_RULE_RESPONSE = {
     "ruleMetadata": [
         {
@@ -275,3 +288,19 @@ def test_remove_bulk_users_uses_expected_arguments(runner, mocker, cli_state):
             cli, ["alert-rules", "bulk", "add", "test_remove.csv"], obj=cli_state
         )
     assert bulk_processor.call_args[0][1] == [{"rule_id": "test", "username": "value"}]
+
+
+def test_list_cmd_prints_no_rules_found_when_f_is_passed_and_response_is_empty(
+    runner, cli_state
+):
+    cli_state.sdk.alerts.rules.get_all.return_value = [TEST_EMPTY_RULE_RESPONSE]
+    result = runner.invoke(cli, ["alert-rules", "list", "-f", "csv"], obj=cli_state)
+    assert cli_state.sdk.alerts.rules.get_all.call_count == 1
+    assert "No alert rules found" in result.output
+
+
+def test_list_cmd_formats_to_csv_when_format_is_passed(runner, cli_state):
+    cli_state.sdk.alerts.rules.get_all.return_value = [TEST_RULE_RESPONSE]
+    result = runner.invoke(cli, ["alert-rules", "list", "-f", "csv"], obj=cli_state)
+    assert cli_state.sdk.alerts.rules.get_all.call_count == 1
+    assert "RuleId,Name,Severity,Type,Source,Enabled" in result.output

--- a/tests/cmds/test_securitydata.py
+++ b/tests/cmds/test_securitydata.py
@@ -19,6 +19,19 @@ END_TIMESTAMP = 1580450400.0
 CURSOR_TIMESTAMP = 1579500000.0
 
 
+TEST_LIST_RESPONSE = {
+    "searches": [
+        {
+            "id": "a083f08d-8f33-4cbd-81c4-8d1820b61185",
+            "name": "test-events",
+            "notes": "py42 is here",
+        },
+    ]
+}
+
+TEST_EMPTY_LIST_RESPONSE = {"searches": []}
+
+
 @pytest.fixture
 def file_event_extractor(mocker):
     mock = mocker.patch(
@@ -691,3 +704,24 @@ def test_search_with_or_query_flag_produces_expected_query(runner, cli_state):
         str(cli_state.sdk.securitydata.search_file_events.call_args[0][0])
     )
     assert actual_query == expected_query
+
+
+def test_saved_search_list_with_format_option_returns_csv_formatted_response(
+    runner, cli_state
+):
+    cli_state.sdk.securitydata.savedsearches.get.return_value = TEST_LIST_RESPONSE
+    result = runner.invoke(
+        cli, ["security-data", "saved-search", "list", "-f", "csv"], obj=cli_state
+    )
+    assert "Name,Id" in result.output
+    assert "test-events,a083f08d-8f33-4cbd-81c4-8d1820b61185" in result.output
+
+
+def test_saved_search_list_with_format_option_does_not_return_when_response_is_empty(
+    runner, cli_state
+):
+    cli_state.sdk.securitydata.savedsearches.get.return_value = TEST_EMPTY_LIST_RESPONSE
+    result = runner.invoke(
+        cli, ["security-data", "saved-search", "list", "-f", "csv"], obj=cli_state
+    )
+    assert "Name,Id" not in result.output

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -98,10 +98,14 @@ TEST_HEADER["ruleSource"] = "Source"
 TEST_HEADER["isEnabled"] = "Enabled"
 
 
-TABLE_OUTPUT = """RuleId                                 Name                     Severity   Type                          Source     Enabled   
-d12d54f0-5160-47a8-a48f-7d5fa5b051c5   outside td               HIGH       FED_CLOUD_SHARE_PERMISSIONS   Alerting   True      
-8b393324-c34c-44ac-9f79-4313601dd859   Test different filters   MEDIUM     FED_ENDPOINT_EXFILTRATION     Alerting   True      
-5eabed1d-a406-4dfc-af81-f7485ee09b19   Test Alerts using CLI    HIGH       FED_ENDPOINT_EXFILTRATION     Alerting   True      """
+TABLE_OUTPUT = "\n".join(
+    [
+        """RuleId                                 Name                     Severity   Type                          Source     Enabled   """,
+        """d12d54f0-5160-47a8-a48f-7d5fa5b051c5   outside td               HIGH       FED_CLOUD_SHARE_PERMISSIONS   Alerting   True      """,
+        """8b393324-c34c-44ac-9f79-4313601dd859   Test different filters   MEDIUM     FED_ENDPOINT_EXFILTRATION     Alerting   True      """,
+        """5eabed1d-a406-4dfc-af81-f7485ee09b19   Test Alerts using CLI    HIGH       FED_ENDPOINT_EXFILTRATION     Alerting   True      """,
+    ]
+)
 
 CSV_OUTPUT = """RuleId,Name,Severity,Type,Source,Enabled
 d12d54f0-5160-47a8-a48f-7d5fa5b051c5,outside td,HIGH,FED_CLOUD_SHARE_PERMISSIONS,Alerting,True

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -2,10 +2,10 @@ import json
 from collections import OrderedDict
 
 from code42cli.output_formats import output_format
-from code42cli.output_formats import to_ascii_table
 from code42cli.output_formats import to_csv
 from code42cli.output_formats import to_formatted_json
 from code42cli.output_formats import to_json
+from code42cli.output_formats import to_table
 
 
 TEST_DATA = [
@@ -70,16 +70,10 @@ TEST_HEADER["type"] = "Type"
 TEST_HEADER["ruleSource"] = "Source"
 TEST_HEADER["isEnabled"] = "Enabled"
 
-ASCII_OUTPUT = """+--------------------------------------+------------------------+----------+-----------------------------+----------+---------+
-|                RuleId                |          Name          | Severity |            Type             |  Source  | Enabled |
-+======================================+========================+==========+=============================+==========+=========+
-| d12d54f0-5160-47a8-a48f-7d5fa5b051c5 |       outside td       |   HIGH   | FED_CLOUD_SHARE_PERMISSIONS | Alerting |  True   |
-+--------------------------------------+------------------------+----------+-----------------------------+----------+---------+
-| 8b393324-c34c-44ac-9f79-4313601dd859 | Test different filters |  MEDIUM  |  FED_ENDPOINT_EXFILTRATION  | Alerting |  True   |
-+--------------------------------------+------------------------+----------+-----------------------------+----------+---------+
-| 5eabed1d-a406-4dfc-af81-f7485ee09b19 | Test Alerts using CLI  |   HIGH   |  FED_ENDPOINT_EXFILTRATION  | Alerting |  True   |
-+--------------------------------------+------------------------+----------+-----------------------------+----------+---------+
-"""
+TABLE_OUTPUT = """RuleId                                 Name                     Severity   Type                          Source     Enabled   
+d12d54f0-5160-47a8-a48f-7d5fa5b051c5   outside td               HIGH       FED_CLOUD_SHARE_PERMISSIONS   Alerting   True      
+8b393324-c34c-44ac-9f79-4313601dd859   Test different filters   MEDIUM     FED_ENDPOINT_EXFILTRATION     Alerting   True      
+5eabed1d-a406-4dfc-af81-f7485ee09b19   Test Alerts using CLI    HIGH       FED_ENDPOINT_EXFILTRATION     Alerting   True      """
 
 CSV_OUTPUT = """RuleId,Name,Severity,Type,Source,Enabled
 d12d54f0-5160-47a8-a48f-7d5fa5b051c5,outside td,HIGH,FED_CLOUD_SHARE_PERMISSIONS,Alerting,True
@@ -92,9 +86,10 @@ def test_to_csv_formats_data_to_csv_format():
     assert formatted_output == CSV_OUTPUT
 
 
-def test_to_ascii_table_formats_data_to_ascii_table_format():
-    formatted_output = to_ascii_table(TEST_DATA, TEST_HEADER)
-    assert formatted_output == ASCII_OUTPUT
+def test_to_table_formats_data_to_table_format():
+    formatted_output = to_table(TEST_DATA, TEST_HEADER)
+    print(formatted_output)
+    assert formatted_output == TABLE_OUTPUT
 
 
 def test_to_json():
@@ -117,11 +112,16 @@ def test_output_format_returns_to_json_function_when_raw_json_format_option_is_p
     assert id(format_function) == id(to_json)
 
 
-def test_output_format_returns_to_ascii_table_function_when_ascii_table_format_option_is_passed():
-    format_function = output_format(None, None, "ASCII-TABLE")
-    assert id(format_function) == id(to_ascii_table)
+def test_output_format_returns_to_table_function_when_ascii_table_format_option_is_passed():
+    format_function = output_format(None, None, "TABLE")
+    assert id(format_function) == id(to_table)
 
 
 def test_output_format_returns_to_csv_function_when_csv_format_option_is_passed():
     format_function = output_format(None, None, "CSV")
     assert id(format_function) == id(to_csv)
+
+
+def test_output_format_returns_to_table_function_when_no_format_option_is_passed():
+    format_function = output_format(None, None, None)
+    assert id(format_function) == id(to_table)

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -62,6 +62,33 @@ TEST_DATA = [
     },
 ]
 
+FILTERED_OUTPUT = [
+    {
+        "RuleId": "d12d54f0-5160-47a8-a48f-7d5fa5b051c5",
+        "Name": "outside td",
+        "Severity": "HIGH",
+        "Type": "FED_CLOUD_SHARE_PERMISSIONS",
+        "Source": "Alerting",
+        "Enabled": True,
+    },
+    {
+        "RuleId": "8b393324-c34c-44ac-9f79-4313601dd859",
+        "Name": "Test different filters",
+        "Severity": "MEDIUM",
+        "Type": "FED_ENDPOINT_EXFILTRATION",
+        "Source": "Alerting",
+        "Enabled": True,
+    },
+    {
+        "RuleId": "5eabed1d-a406-4dfc-af81-f7485ee09b19",
+        "Name": "Test Alerts using CLI",
+        "Severity": "HIGH",
+        "Type": "FED_ENDPOINT_EXFILTRATION",
+        "Source": "Alerting",
+        "Enabled": True,
+    },
+]
+
 TEST_HEADER = OrderedDict()
 TEST_HEADER["observerRuleId"] = "RuleId"
 TEST_HEADER["name"] = "Name"
@@ -69,6 +96,7 @@ TEST_HEADER["severity"] = "Severity"
 TEST_HEADER["type"] = "Type"
 TEST_HEADER["ruleSource"] = "Source"
 TEST_HEADER["isEnabled"] = "Enabled"
+
 
 TABLE_OUTPUT = """RuleId                                 Name                     Severity   Type                          Source     Enabled   
 d12d54f0-5160-47a8-a48f-7d5fa5b051c5   outside td               HIGH       FED_CLOUD_SHARE_PERMISSIONS   Alerting   True      
@@ -93,13 +121,13 @@ def test_to_table_formats_data_to_table_format():
 
 
 def test_to_json():
-    formatted_output = to_json(TEST_DATA)
-    assert formatted_output == json.dumps(TEST_DATA)
+    formatted_output = to_json(TEST_DATA, TEST_HEADER)
+    assert formatted_output == json.dumps(FILTERED_OUTPUT)
 
 
 def test_to_formatted_json():
-    formatted_output = to_formatted_json(TEST_DATA)
-    assert formatted_output == json.dumps(TEST_DATA, indent=4)
+    formatted_output = to_formatted_json(TEST_DATA, TEST_HEADER)
+    assert formatted_output == json.dumps(FILTERED_OUTPUT, indent=4)
 
 
 def test_output_format_returns_to_formatted_json_function_when_json_format_option_is_passed():

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -1,0 +1,127 @@
+import json
+from collections import OrderedDict
+
+from code42cli.output_formats import output_format
+from code42cli.output_formats import to_ascii_table
+from code42cli.output_formats import to_csv
+from code42cli.output_formats import to_formatted_json
+from code42cli.output_formats import to_json
+
+
+TEST_DATA = [
+    {
+        "type$": "RULE_METADATA",
+        "modifiedBy": "test.user+partners@code42.com",
+        "modifiedAt": "2020-06-22T16:26:16.3875180Z",
+        "name": "outside td",
+        "description": "",
+        "severity": "HIGH",
+        "isSystem": False,
+        "isEnabled": True,
+        "ruleSource": "Alerting",
+        "tenantId": "1d71796f-af5b-4231-9d8e-df6434da4663",
+        "observerRuleId": "d12d54f0-5160-47a8-a48f-7d5fa5b051c5",
+        "type": "FED_CLOUD_SHARE_PERMISSIONS",
+        "id": "5157f1df-cb3e-4755-92a2-0f42c7841020",
+        "createdBy": "test.user+partners@code42.com",
+        "createdAt": "2020-06-22T16:26:16.3875180Z",
+    },
+    {
+        "type$": "RULE_METADATA",
+        "modifiedBy": "testuser@code42.com",
+        "modifiedAt": "2020-07-16T08:09:44.4345110Z",
+        "name": "Test different filters",
+        "description": "Test different filters",
+        "severity": "MEDIUM",
+        "isSystem": False,
+        "isEnabled": True,
+        "ruleSource": "Alerting",
+        "tenantId": "1d71796f-af5b-4231-9d8e-df6434da4663",
+        "observerRuleId": "8b393324-c34c-44ac-9f79-4313601dd859",
+        "type": "FED_ENDPOINT_EXFILTRATION",
+        "id": "88354829-0958-4d60-a20d-69a53cf603b6",
+        "createdBy": "test.user+partners@code42.com",
+        "createdAt": "2020-05-20T11:56:41.2324240Z",
+    },
+    {
+        "type$": "RULE_METADATA",
+        "modifiedBy": "testuser@code42.com",
+        "modifiedAt": "2020-05-28T16:19:19.5250970Z",
+        "name": "Test Alerts using CLI",
+        "description": "spatel",
+        "severity": "HIGH",
+        "isSystem": False,
+        "isEnabled": True,
+        "ruleSource": "Alerting",
+        "tenantId": "1d71796f-af5b-4231-9d8e-df6434da4663",
+        "observerRuleId": "5eabed1d-a406-4dfc-af81-f7485ee09b19",
+        "type": "FED_ENDPOINT_EXFILTRATION",
+        "id": "b2cb33e6-6683-4822-be1d-8de5ef87728e",
+        "createdBy": "testuser@code42.com",
+        "createdAt": "2020-05-18T11:47:16.6109560Z",
+    },
+]
+
+TEST_HEADER = OrderedDict()
+TEST_HEADER["observerRuleId"] = "RuleId"
+TEST_HEADER["name"] = "Name"
+TEST_HEADER["severity"] = "Severity"
+TEST_HEADER["type"] = "Type"
+TEST_HEADER["ruleSource"] = "Source"
+TEST_HEADER["isEnabled"] = "Enabled"
+
+ASCII_OUTPUT = """+--------------------------------------+------------------------+----------+-----------------------------+----------+---------+
+|                RuleId                |          Name          | Severity |            Type             |  Source  | Enabled |
++======================================+========================+==========+=============================+==========+=========+
+| d12d54f0-5160-47a8-a48f-7d5fa5b051c5 |       outside td       |   HIGH   | FED_CLOUD_SHARE_PERMISSIONS | Alerting |  True   |
++--------------------------------------+------------------------+----------+-----------------------------+----------+---------+
+| 8b393324-c34c-44ac-9f79-4313601dd859 | Test different filters |  MEDIUM  |  FED_ENDPOINT_EXFILTRATION  | Alerting |  True   |
++--------------------------------------+------------------------+----------+-----------------------------+----------+---------+
+| 5eabed1d-a406-4dfc-af81-f7485ee09b19 | Test Alerts using CLI  |   HIGH   |  FED_ENDPOINT_EXFILTRATION  | Alerting |  True   |
++--------------------------------------+------------------------+----------+-----------------------------+----------+---------+
+"""
+
+CSV_OUTPUT = """RuleId,Name,Severity,Type,Source,Enabled
+d12d54f0-5160-47a8-a48f-7d5fa5b051c5,outside td,HIGH,FED_CLOUD_SHARE_PERMISSIONS,Alerting,True
+8b393324-c34c-44ac-9f79-4313601dd859,Test different filters,MEDIUM,FED_ENDPOINT_EXFILTRATION,Alerting,True
+5eabed1d-a406-4dfc-af81-f7485ee09b19,Test Alerts using CLI,HIGH,FED_ENDPOINT_EXFILTRATION,Alerting,True"""
+
+
+def test_to_csv_formats_data_to_csv_format():
+    formatted_output = to_csv(TEST_DATA, TEST_HEADER)
+    assert formatted_output == CSV_OUTPUT
+
+
+def test_to_ascii_table_formats_data_to_ascii_table_format():
+    formatted_output = to_ascii_table(TEST_DATA, TEST_HEADER)
+    assert formatted_output == ASCII_OUTPUT
+
+
+def test_to_json():
+    formatted_output = to_json(TEST_DATA)
+    assert formatted_output == json.dumps(TEST_DATA)
+
+
+def test_to_formatted_json():
+    formatted_output = to_formatted_json(TEST_DATA)
+    assert formatted_output == json.dumps(TEST_DATA, indent=4)
+
+
+def test_output_format_returns_to_formatted_json_function_when_json_format_option_is_passed():
+    format_function = output_format(None, None, "JSON")
+    assert id(format_function) == id(to_formatted_json)
+
+
+def test_output_format_returns_to_json_function_when_raw_json_format_option_is_passed():
+    format_function = output_format(None, None, "RAW-JSON")
+    assert id(format_function) == id(to_json)
+
+
+def test_output_format_returns_to_ascii_table_function_when_ascii_table_format_option_is_passed():
+    format_function = output_format(None, None, "ASCII-TABLE")
+    assert id(format_function) == id(to_ascii_table)
+
+
+def test_output_format_returns_to_csv_function_when_csv_format_option_is_passed():
+    format_function = output_format(None, None, "CSV")
+    assert id(format_function) == id(to_csv)


### PR DESCRIPTION
**Description of Change**

Added support for [global output formats](https://jira.corp.code42.com/browse/INTEG-1053)

Added option for command `code42 alert-rules list`

**Issues Resolved**
[1053](https://jira.corp.code42.com/browse/INTEG-1053)

**Testing guidelines:**
`code42 alert-rules list -f csv`
`code42 alert-rules list -f json`
`code42 alert-rules list -f ascii-table`
`code42 alert-rules list -f raw-json`

Added same option for commands:
`code42 security-data  saved-search list`
`code42 legal-hold list`
`code42 legal-hold show`

**PR Checklist**
Did you remember to do the below?

- [x]  Add unit tests to verify this change

- [x] Add an entry to CHANGELOG.md describing this change

- [x] Add docstrings for any new public parameters / methods / classes
