### PR TITLE
Feature/output formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
     each time the CLI is run with a profile configured this way, as it is not recommended.
 
 - The `path` positional argument for bulk `generate-template` commands is now an option (`--p/-p`).
+- Below `search` subcommands accept argument `--format/-f` to display result in formats `csv`, `table`, `json`, `formatted-json`:
+    By default only root/top level items from the response will be displayed, to view all items, that contains nested data, pass `--include-all` option.
+    - `code42 alerts search`
+    - `code42 security-data search`
+    - `code42 security-data search --saved-search`
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,11 +32,10 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 - The `path` positional argument for bulk `generate-template` commands is now an option (`--p/-p`).
 - Below `search` subcommands accept argument `--format/-f` to display result in formats `csv`, `table`, `json`, `raw-json`:
-    - BREAKING CHANGE: Default output format is changed to `table` format from `raw-json`, returns a paginated response.
-    A predefined set of fields would be displayed by default, pass `--include-all` to view all non-nested top-level data.
+    - Default output format is changed to `table` format from `raw-json`, returns a paginated response.
+    A predefined properties would be displayed by default, pass `--include-all` to view all non-nested top-level properties.
     - `code42 alerts search`
     - `code42 security-data search`
-    - `code42 security-data search --saved-search`
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 - The `path` positional argument for bulk `generate-template` commands is now an option (`--p/-p`).
 - Below `search` subcommands accept argument `--format/-f` to display result in formats `csv`, `table`, `json`, `raw-json`:
-    - BREAKING CHANGE: Default output format is changed to `table` format from `raw-json`, returns a paginated response
+    - BREAKING CHANGE: Default output format is changed to `table` format from `raw-json`, returns a paginated response.
     A predefined set of fields would be displayed by default, pass `--include-all` to view all non-nested top-level data.
     - `code42 alerts search`
     - `code42 security-data search`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
     each time the CLI is run with a profile configured this way, as it is not recommended.
 
 - The `path` positional argument for bulk `generate-template` commands is now an option (`--p/-p`).
-- Below `search` subcommands accept argument `--format/-f` to display result in formats `csv`, `table`, `json`, `formatted-json`:
+- Below `search` subcommands accept argument `--format/-f` to display result in formats `csv`, `table`, `json`, `raw-json`:
+    - BREAKING CHANGE: Default output format is changed to `table` format from `raw-json` 
     By default only root/top level items from the response will be displayed, to view all items, that contains nested data, pass `--include-all` option.
     - `code42 alerts search`
     - `code42 security-data search`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 - The `path` positional argument for bulk `generate-template` commands is now an option (`--p/-p`).
 - Below `search` subcommands accept argument `--format/-f` to display result in formats `csv`, `table`, `json`, `raw-json`:
-    - BREAKING CHANGE: Default output format is changed to `table` format from `raw-json` 
+    - BREAKING CHANGE: Default output format is changed to `table` format from `raw-json`, returns a paginated response
     By default only root/top level items from the response will be displayed, to view all items, that contains nested data, pass `--include-all` option.
     - `code42 alerts search`
     - `code42 security-data search`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 - The `path` positional argument for bulk `generate-template` commands is now an option (`--p/-p`).
 - Below `search` subcommands accept argument `--format/-f` to display result in formats `csv`, `table`, `json`, `raw-json`:
     - BREAKING CHANGE: Default output format is changed to `table` format from `raw-json`, returns a paginated response
-    By default only root/top level items from the response will be displayed, to view all items, that contains nested data, pass `--include-all` option.
+    A predefined set of fields would be displayed by default, pass `--include-all` to view all non-nested top-level data.
     - `code42 alerts search`
     - `code42 security-data search`
     - `code42 security-data search --saved-search`

--- a/src/code42cli/cmds/alerts.py
+++ b/src/code42cli/cmds/alerts.py
@@ -11,7 +11,7 @@ import code42cli.cmds.search.options as searchopt
 import code42cli.errors as errors
 import code42cli.options as opt
 from code42cli.cmds.search.cursor_store import AlertCursorStore
-from code42cli.output_formats import format_option
+from code42cli.output_formats import extraction_format_option as format_option
 
 search_options = searchopt.create_search_options("alerts")
 
@@ -170,12 +170,7 @@ def clear_checkpoint(state, checkpoint_name):
     "--or-query", is_flag=True, cls=searchopt.AdvancedQueryAndSavedSearchIncompatible
 )
 @opt.sdk_options()
-@click.option(
-    "--display",
-    multiple=True,
-    default=_OPTIONAL_OPTIONS,
-    type=click.Choice(_OPTIONAL_OPTIONS),
-)
+@click.option("--include-all", default=False, is_flag=True)
 def search(
     cli_state,
     format,
@@ -184,7 +179,7 @@ def search(
     advanced_query,
     use_checkpoint,
     or_query,
-    display,
+    include_all,
     **kwargs
 ):
     """Search for alerts."""
@@ -195,8 +190,7 @@ def search(
         format,
         cursor,
         use_checkpoint,
-        format_header=_HEADERS_KEY_MAP,
-        optional_fields=_optionally_display(display),
+        display_all=include_all,
     )
     extractor = _get_alert_extractor(cli_state.sdk, handlers)
     extractor.use_or_query = or_query

--- a/src/code42cli/cmds/alerts.py
+++ b/src/code42cli/cmds/alerts.py
@@ -168,7 +168,7 @@ def clear_checkpoint(state, checkpoint_name):
     "--include-all",
     default=False,
     is_flag=True,
-    help="Display complete list of data items from the first level of the nested response.",
+    help="Display simple properties of the primary level of the nested response.",
 )
 def search(
     cli_state,

--- a/src/code42cli/cmds/alerts.py
+++ b/src/code42cli/cmds/alerts.py
@@ -158,7 +158,7 @@ def clear_checkpoint(state, checkpoint_name):
     "--include-all",
     default=False,
     is_flag=True,
-    help="Display complete list of data items or only from top level of nested response.",
+    help="Display complete list of data items from the first level of the nested response.",
 )
 def search(
     cli_state,

--- a/src/code42cli/cmds/alerts.py
+++ b/src/code42cli/cmds/alerts.py
@@ -22,7 +22,14 @@ _HEADERS_KEY_MAP["createdAt"] = "Observed Date"
 _HEADERS_KEY_MAP["state"] = "Status"
 _HEADERS_KEY_MAP["severity"] = "Severity"
 # _HEADERS_KEY_MAP["description"] = "Description"
-
+_OPTIONAL_OPTIONS = [
+    "sources",
+    "exposure_types",
+    "file_count",
+    "file_detail",
+    "file_size",
+    "ip",
+]
 
 severity_option = click.option(
     "--severity",
@@ -166,13 +173,19 @@ def clear_checkpoint(state, checkpoint_name):
 @click.option(
     "--display",
     multiple=True,
-    default=["sources", "exposure_types", "file_count", "file_detail", "file_size", "ip"],
-    type=click.Choice(
-        ["sources", "exposure_types", "file_count", "file_detail", "file_size", "ip"]
-    ),
+    default=_OPTIONAL_OPTIONS,
+    type=click.Choice(_OPTIONAL_OPTIONS),
 )
 def search(
-    cli_state, format, begin, end, advanced_query, use_checkpoint, or_query, display, **kwargs
+    cli_state,
+    format,
+    begin,
+    end,
+    advanced_query,
+    use_checkpoint,
+    or_query,
+    display,
+    **kwargs
 ):
     """Search for alerts."""
     cursor = _get_alert_cursor_store(cli_state.profile.name) if use_checkpoint else None
@@ -183,7 +196,7 @@ def search(
         cursor,
         use_checkpoint,
         format_header=_HEADERS_KEY_MAP,
-        optional_fields = _optionally_display(display)
+        optional_fields=_optionally_display(display),
     )
     extractor = _get_alert_extractor(cli_state.sdk, handlers)
     extractor.use_or_query = or_query
@@ -240,10 +253,8 @@ def _display_file_detail(event):
     data = event["observations"][0]["data"]
     event["file_detail"] = ""
     for file_detail in data["files"]:
-        event["file_detail"] += "{0}##{1}##{2}".format(
-            file_detail["name"],
-            file_detail["path"],
-            file_detail["category"]
+        event["file_detail"] += "{}##{}##{}".format(
+            file_detail["name"], file_detail["path"], file_detail["category"]
         )
     return event
 
@@ -261,7 +272,7 @@ _OPTIONAL_DISPLAY_FUNCTIONS = {
     "file_categories": _display_file_categories,
     "file_detail": _display_file_detail,
     "file_size": _display_file_size,
-    "ip": _display_ip
+    "ip": _display_ip,
 }
 
 

--- a/src/code42cli/cmds/alerts.py
+++ b/src/code42cli/cmds/alerts.py
@@ -154,7 +154,12 @@ def clear_checkpoint(state, checkpoint_name):
     "--or-query", is_flag=True, cls=searchopt.AdvancedQueryAndSavedSearchIncompatible
 )
 @opt.sdk_options()
-@click.option("--include-all", default=False, is_flag=True)
+@click.option(
+    "--include-all",
+    default=False,
+    is_flag=True,
+    help="Display complete list of data items or only from top level of nested response.",
+)
 def search(
     cli_state,
     format,

--- a/src/code42cli/cmds/alerts.py
+++ b/src/code42cli/cmds/alerts.py
@@ -1,3 +1,5 @@
+from _collections import OrderedDict
+
 import click
 import py42.sdk.queries.alerts.filters as f
 from c42eventextractor.extractors import AlertExtractor
@@ -11,6 +13,14 @@ import code42cli.options as opt
 from code42cli.cmds.search.cursor_store import AlertCursorStore
 from code42cli.output_formats import extraction_format_option as format_option
 
+
+SEARCH_DEFAULT_HEADER = OrderedDict()
+SEARCH_DEFAULT_HEADER["name"] = "RuleName"
+SEARCH_DEFAULT_HEADER["actor"] = "Username"
+SEARCH_DEFAULT_HEADER["createdAt"] = "ObservedDate"
+SEARCH_DEFAULT_HEADER["state"] = "Status"
+SEARCH_DEFAULT_HEADER["severity"] = "Severity"
+SEARCH_DEFAULT_HEADER["description"] = "Description"
 
 search_options = searchopt.create_search_options("alerts")
 
@@ -180,6 +190,7 @@ def search(
         use_checkpoint,
         include_all=include_all,
         output_format=format,
+        output_header=SEARCH_DEFAULT_HEADER,
     )
     extractor = _get_alert_extractor(cli_state.sdk, handlers)
     extractor.use_or_query = or_query

--- a/src/code42cli/cmds/alerts.py
+++ b/src/code42cli/cmds/alerts.py
@@ -10,7 +10,7 @@ import code42cli.errors as errors
 import code42cli.options as opt
 from code42cli.cmds.search.cursor_store import AlertCursorStore
 from code42cli.output_formats import extraction_format_option as format_option
-from code42cli.output_formats import get_format_header
+
 
 search_options = searchopt.create_search_options("alerts")
 
@@ -174,7 +174,12 @@ def search(
     """Search for alerts."""
     cursor = _get_alert_cursor_store(cli_state.profile.name) if use_checkpoint else None
     handlers = ext.create_handlers(
-        cli_state.sdk, AlertExtractor, cursor, use_checkpoint,
+        cli_state.sdk,
+        AlertExtractor,
+        cursor,
+        use_checkpoint,
+        include_all=include_all,
+        output_format=format,
     )
     extractor = _get_alert_extractor(cli_state.sdk, handlers)
     extractor.use_or_query = or_query
@@ -188,9 +193,6 @@ def search(
         extractor.extract(*cli_state.search_filters)
     if handlers.TOTAL_EVENTS == 0 and not errors.ERRORED:
         echo("No results found.")
-    else:
-        output = _process_events(format, include_all, handlers.EVENTS)
-        click.echo_via_pager(output)
 
 
 def _get_alert_extractor(sdk, handlers):
@@ -199,8 +201,3 @@ def _get_alert_extractor(sdk, handlers):
 
 def _get_alert_cursor_store(profile_name):
     return AlertCursorStore(profile_name)
-
-
-def _process_events(output_format, include_all, events):
-    format_header = get_format_header(include_all, events[0])
-    return output_format(events, format_header)

--- a/src/code42cli/cmds/alerts.py
+++ b/src/code42cli/cmds/alerts.py
@@ -10,6 +10,7 @@ import code42cli.errors as errors
 import code42cli.options as opt
 from code42cli.cmds.search.cursor_store import AlertCursorStore
 from code42cli.output_formats import extraction_format_option as format_option
+from code42cli.output_formats import get_format_header
 
 search_options = searchopt.create_search_options("alerts")
 
@@ -183,7 +184,7 @@ def search(
     if handlers.TOTAL_EVENTS == 0 and not errors.ERRORED:
         echo("No results found.")
     else:
-        output = process_events(format, include_all, handlers.EVENTS)
+        output = _process_events(format, include_all, handlers.EVENTS)
         click.echo_via_pager(output)
 
 
@@ -195,15 +196,6 @@ def _get_alert_cursor_store(profile_name):
     return AlertCursorStore(profile_name)
 
 
-def process_events(output_format, include_all, events):
-
-    format_header = (
-        {key: key.capitalize() for key in events[0].keys()}
-        if include_all
-        else {
-            key: key.capitalize()
-            for key in events[0].keys()
-            if type(events[0][key]) == str
-        }
-    )
+def _process_events(output_format, include_all, events):
+    format_header = get_format_header(include_all, events[0])
     return output_format(events, format_header)

--- a/src/code42cli/cmds/alerts.py
+++ b/src/code42cli/cmds/alerts.py
@@ -1,5 +1,3 @@
-from _collections import OrderedDict
-
 import click
 import py42.sdk.queries.alerts.filters as f
 from c42eventextractor.extractors import AlertExtractor
@@ -15,21 +13,6 @@ from code42cli.output_formats import extraction_format_option as format_option
 
 search_options = searchopt.create_search_options("alerts")
 
-_HEADERS_KEY_MAP = OrderedDict()
-_HEADERS_KEY_MAP["name"] = "Rule Name"
-_HEADERS_KEY_MAP["actor"] = "Username"
-_HEADERS_KEY_MAP["createdAt"] = "Observed Date"
-_HEADERS_KEY_MAP["state"] = "Status"
-_HEADERS_KEY_MAP["severity"] = "Severity"
-# _HEADERS_KEY_MAP["description"] = "Description"
-_OPTIONAL_OPTIONS = [
-    "sources",
-    "exposure_types",
-    "file_count",
-    "file_detail",
-    "file_size",
-    "ip",
-]
 
 severity_option = click.option(
     "--severity",
@@ -212,65 +195,3 @@ def _get_alert_extractor(sdk, handlers):
 
 def _get_alert_cursor_store(profile_name):
     return AlertCursorStore(profile_name)
-
-
-def _display_sources(event):
-    # Assuming here and all other `_include` function that only 'observations' contain a
-    # single record.
-    sources = event["observations"][0]["data"]["sources"]
-    event["sources"] = "##".join(sources)
-    return event
-
-
-def _display_exposure_types(event):
-
-    exposure_types = event["observations"][0]["data"]["exposureTypes"]
-    event["exposure_types"] = "##".join(exposure_types)
-    return event
-
-
-def _display_file_count(event):
-    event["file_count"] = event["observations"][0]["data"]["fileCount"]
-    return event
-
-
-def _display_file_categories(event):
-    pass
-
-
-def _display_file_size(event):
-    event["file_size"] = event["observations"][0]["data"]["totalFileSize"]
-    return event
-
-
-def _display_file_detail(event):
-    data = event["observations"][0]["data"]
-    event["file_detail"] = ""
-    for file_detail in data["files"]:
-        event["file_detail"] += "{}##{}##{}".format(
-            file_detail["name"], file_detail["path"], file_detail["category"]
-        )
-    return event
-
-
-def _display_ip(event):
-    ips = event["observations"][0]["data"]["sendingIpAddresses"]
-    event["ip"] = "##".join(ips)
-    return event
-
-
-_OPTIONAL_DISPLAY_FUNCTIONS = {
-    "sources": _display_sources,
-    "exposure_types": _display_exposure_types,
-    "file_count": _display_file_count,
-    "file_categories": _display_file_categories,
-    "file_detail": _display_file_detail,
-    "file_size": _display_file_size,
-    "ip": _display_ip,
-}
-
-
-def _optionally_display(display_options):
-    for option in display_options:
-        _HEADERS_KEY_MAP[option] = option.capitalize()
-    return [_OPTIONAL_DISPLAY_FUNCTIONS[option] for option in display_options]

--- a/src/code42cli/cmds/search/extraction.py
+++ b/src/code42cli/cmds/search/extraction.py
@@ -82,7 +82,7 @@ def create_handlers(
                 }
             )
 
-            click.echo(output_format(events, format_header))
+            click.echo_via_pager(output_format(events, format_header))
 
             last_event_timestamp = extractor._get_timestamp_from_item(events[-1])
             handlers.record_cursor_position(last_event_timestamp)

--- a/src/code42cli/cmds/search/extraction.py
+++ b/src/code42cli/cmds/search/extraction.py
@@ -78,7 +78,11 @@ def create_handlers(
         def paginate():
             yield _process_events(output_format, include_all, events, output_header)
 
-        click.echo_via_pager(paginate)
+        if len(events) > 10:
+            click.echo_via_pager(paginate)
+        else:
+            for page in paginate():
+                click.echo(page)
 
         # To make sure the extractor records correct timestamp event when `CTRL-C` is pressed.
         if total_events:

--- a/src/code42cli/cmds/search/extraction.py
+++ b/src/code42cli/cmds/search/extraction.py
@@ -14,7 +14,7 @@ from code42cli.util import warn_interrupt
 logger = get_main_cli_logger()
 
 _ALERT_DETAIL_BATCH_SIZE = 100
-_EVENT_COUNT_PER_PAGE = 10
+_EVENT_COUNT_PER_PAGE = 100
 
 
 def _get_alert_details(sdk, alert_summary_list):
@@ -88,10 +88,6 @@ def create_handlers(
                 output_format, include_all, events_per_page, output_header
             )
             click.echo_via_pager(output)
-
-        if total_events:
-            last_event_timestamp = extractor._get_timestamp_from_item(events[-1])
-            handlers.record_cursor_position(last_event_timestamp)
 
     handlers.handle_response = handle_response
     return handlers

--- a/src/code42cli/cmds/search/extraction.py
+++ b/src/code42cli/cmds/search/extraction.py
@@ -30,8 +30,13 @@ def _get_alert_details(sdk, alert_summary_list):
 
 
 def create_handlers(
-    sdk, extractor_class, output_format, cursor_store, checkpoint_name, format_header,
-    optional_fields=None
+    sdk,
+    extractor_class,
+    output_format,
+    cursor_store,
+    checkpoint_name,
+    format_header,
+    optional_fields=None,
 ):
     extractor = extractor_class(sdk, ExtractionHandlers())
     handlers = ExtractionHandlers()
@@ -69,8 +74,9 @@ def create_handlers(
         event = None
         transformed_events = []
         for event in events:
-            for optional_field in optional_fields:
-                event = optional_field(event)
+            if optional_fields:
+                for optional_field in optional_fields:
+                    event = optional_field(event)
             transformed_events.append(event)
         output = output_format(transformed_events, format_header)
         click.echo(output)

--- a/src/code42cli/cmds/search/extraction.py
+++ b/src/code42cli/cmds/search/extraction.py
@@ -31,7 +31,7 @@ def _get_alert_details(sdk, alert_summary_list):
     return results
 
 
-def _pager(events, page_size):
+def _paginate(events, page_size):
     while len(events) > page_size:
         yield events[:page_size]
         del events[:page_size]
@@ -83,7 +83,7 @@ def create_handlers(
         total_events = len(events)
         handlers.TOTAL_EVENTS += total_events
 
-        for events_per_page in _pager(events, _EVENT_COUNT_PER_PAGE):
+        for events_per_page in _paginate(events, _EVENT_COUNT_PER_PAGE):
             output = _process_events(
                 output_format, include_all, events_per_page, output_header
             )

--- a/src/code42cli/cmds/search/extraction.py
+++ b/src/code42cli/cmds/search/extraction.py
@@ -30,7 +30,8 @@ def _get_alert_details(sdk, alert_summary_list):
 
 
 def create_handlers(
-    sdk, extractor_class, output_format, cursor_store, checkpoint_name, format_header
+    sdk, extractor_class, output_format, cursor_store, checkpoint_name, format_header,
+    optional_fields=None
 ):
     extractor = extractor_class(sdk, ExtractionHandlers())
     handlers = ExtractionHandlers()
@@ -66,7 +67,12 @@ def create_handlers(
                 handlers.handle_error(ex)
         handlers.TOTAL_EVENTS += len(events)
         event = None
-        output = output_format(events, format_header)
+        transformed_events = []
+        for event in events:
+            for optional_field in optional_fields:
+                event = optional_field(event)
+            transformed_events.append(event)
+        output = output_format(transformed_events, format_header)
         click.echo(output)
         if event:
             last_event_timestamp = extractor._get_timestamp_from_item(event)

--- a/src/code42cli/cmds/search/extraction.py
+++ b/src/code42cli/cmds/search/extraction.py
@@ -80,6 +80,11 @@ def create_handlers(
 
         click.echo_via_pager(paginate)
 
+        # To make sure the extractor records correct timestamp event when `CTRL-C` is pressed.
+        if total_events:
+            last_event_timestamp = extractor._get_timestamp_from_item(events[-1])
+            handlers.record_cursor_position(last_event_timestamp)
+
     handlers.handle_response = handle_response
     return handlers
 

--- a/src/code42cli/cmds/search/extraction.py
+++ b/src/code42cli/cmds/search/extraction.py
@@ -1,5 +1,6 @@
 import json
 
+import click
 from c42eventextractor import ExtractionHandlers
 from click import secho
 from py42.sdk.queries.query_filter import QueryFilterTimestampField
@@ -28,7 +29,9 @@ def _get_alert_details(sdk, alert_summary_list):
     return results
 
 
-def create_handlers(sdk, extractor_class, output_logger, cursor_store, checkpoint_name):
+def create_handlers(
+    sdk, extractor_class, output_format, cursor_store, checkpoint_name, format_header
+):
     extractor = extractor_class(sdk, ExtractionHandlers())
     handlers = ExtractionHandlers()
     handlers.TOTAL_EVENTS = 0
@@ -63,8 +66,8 @@ def create_handlers(sdk, extractor_class, output_logger, cursor_store, checkpoin
                 handlers.handle_error(ex)
         handlers.TOTAL_EVENTS += len(events)
         event = None
-        for event in events:
-            output_logger.info(event)
+        output = output_format(events, format_header)
+        click.echo(output)
         if event:
             last_event_timestamp = extractor._get_timestamp_from_item(event)
             handlers.record_cursor_position(last_event_timestamp)

--- a/src/code42cli/cmds/search/extraction.py
+++ b/src/code42cli/cmds/search/extraction.py
@@ -1,6 +1,5 @@
 import json
 
-import click
 from c42eventextractor import ExtractionHandlers
 from click import secho
 from py42.sdk.queries.query_filter import QueryFilterTimestampField
@@ -30,12 +29,7 @@ def _get_alert_details(sdk, alert_summary_list):
 
 
 def create_handlers(
-    sdk,
-    extractor_class,
-    output_format,
-    cursor_store,
-    checkpoint_name,
-    display_all=False,
+    sdk, extractor_class, cursor_store, checkpoint_name,
 ):
     extractor = extractor_class(sdk, ExtractionHandlers())
     handlers = ExtractionHandlers()
@@ -69,21 +63,10 @@ def create_handlers(
                 events = _get_alert_details(sdk, events)
             except Exception as ex:
                 handlers.handle_error(ex)
-
-        handlers.TOTAL_EVENTS += len(events)
-        if len(events):
-            format_header = (
-                {key: key.capitalize() for key in events[0].keys()}
-                if display_all
-                else {
-                    key: key.capitalize()
-                    for key in events[0].keys()
-                    if type(events[0][key]) == str
-                }
-            )
-
-            click.echo_via_pager(output_format(events, format_header))
-
+        total_events = len(events)
+        handlers.TOTAL_EVENTS += total_events
+        handlers.EVENTS = events
+        if total_events:
             last_event_timestamp = extractor._get_timestamp_from_item(events[-1])
             handlers.record_cursor_position(last_event_timestamp)
 

--- a/src/code42cli/cmds/securitydata.py
+++ b/src/code42cli/cmds/securitydata.py
@@ -295,4 +295,4 @@ def _display_optional_fields(field):
 def _optionally_display(display_options):
     for option in display_options:
         _SEARCH_RESPONSE_HEADER[option] = option.capitalize()
-    # return [ _display_optional_fields(option) for option in display_options]
+    return [_display_optional_fields(option) for option in display_options]

--- a/src/code42cli/cmds/securitydata.py
+++ b/src/code42cli/cmds/securitydata.py
@@ -24,41 +24,6 @@ _HEADER_KEYS_MAP = OrderedDict()
 _HEADER_KEYS_MAP["name"] = "Name"
 _HEADER_KEYS_MAP["id"] = "Id"
 
-_SEARCH_RESPONSE_HEADER = OrderedDict()
-_SEARCH_RESPONSE_HEADER["eventId"] = "Event Id"
-_SEARCH_RESPONSE_HEADER["eventType"] = "Type"
-_SEARCH_RESPONSE_HEADER["eventTimestamp"] = "Observed Date"
-
-_OPTIONAL_FIELDS = [
-    "filePath",
-    "fileName",
-    "fileType",
-    "fileSize",
-    "fileOwner",
-    "md5Checksum",
-    "sha256Checksum",
-    "deviceUserName",
-    "osHostName",
-    "domainName",
-    "publicIpAddress",
-    "privateIpAddresses",
-    "deviceUid",
-    "userUid",
-    "source",
-    "exposure",
-    "processOwner",
-    "processName",
-    "tabUrl",
-    "remoteActivity",
-    "trusted",
-    "operatingSystemUser",
-    "outsideActiveHours",
-    "mimeTypeByBytes",
-    "mimeTypeByExtension",
-    "mimeTypeMismatch",
-    "windowTitle",
-]
-
 
 search_options = searchopt.create_search_options("file events")
 
@@ -276,18 +241,3 @@ def _get_file_event_extractor(sdk, handlers):
 
 def _get_file_event_cursor_store(profile_name):
     return FileEventCursorStore(profile_name)
-
-
-def _display_optional_fields(field):
-    def process_event(event):
-        if type(event[field]) == list:
-            event[field] = "##".join(event[field])
-        return event
-
-    return process_event
-
-
-def _optionally_display(display_options):
-    for option in display_options:
-        _SEARCH_RESPONSE_HEADER[option] = option.capitalize()
-    return [_display_optional_fields(option) for option in display_options]

--- a/src/code42cli/cmds/securitydata.py
+++ b/src/code42cli/cmds/securitydata.py
@@ -191,7 +191,12 @@ def search(
     )
 
     handlers = ext.create_handlers(
-        state.sdk, FileEventExtractor, cursor, use_checkpoint,
+        state.sdk,
+        FileEventExtractor,
+        cursor,
+        use_checkpoint,
+        include_all,
+        output_format=format,
     )
     extractor = _get_file_event_extractor(state.sdk, handlers)
     extractor.use_or_query = or_query
@@ -208,9 +213,6 @@ def search(
         extractor.extract(*state.search_filters)
     if handlers.TOTAL_EVENTS == 0 and not errors.ERRORED:
         echo("No results found.")
-    else:
-        output = _process_events(format, include_all, handlers.EVENTS)
-        click.echo_via_pager(output)
 
 
 @security_data.group(cls=OrderedGroup)

--- a/src/code42cli/cmds/securitydata.py
+++ b/src/code42cli/cmds/securitydata.py
@@ -182,7 +182,7 @@ def clear_checkpoint(state, checkpoint_name):
     "--include-all",
     default=False,
     is_flag=True,
-    help="Display complete list of data items from the first level of the nested response.",
+    help="Display simple properties of the primary level of the nested response.",
 )
 def search(
     state,

--- a/src/code42cli/cmds/securitydata.py
+++ b/src/code42cli/cmds/securitydata.py
@@ -261,7 +261,3 @@ def _get_file_event_extractor(sdk, handlers):
 def _get_file_event_cursor_store(profile_name):
     return FileEventCursorStore(profile_name)
 
-
-def _process_events(output_format, include_all, events):
-    format_header = get_dynamic_header(include_all, events[0])
-    return output_format(events, format_header)

--- a/src/code42cli/cmds/securitydata.py
+++ b/src/code42cli/cmds/securitydata.py
@@ -171,7 +171,7 @@ def clear_checkpoint(state, checkpoint_name):
     "--include-all",
     default=False,
     is_flag=True,
-    help="Display complete list of data items or only from top level of nested response.",
+    help="Display complete list of data items from the first level of the nested response.",
 )
 def search(
     state,

--- a/src/code42cli/cmds/securitydata.py
+++ b/src/code42cli/cmds/securitydata.py
@@ -27,7 +27,8 @@ _HEADER_KEYS_MAP["name"] = "Name"
 _HEADER_KEYS_MAP["id"] = "Id"
 
 SEARCH_DEFAULT_HEADER = OrderedDict()
-SEARCH_DEFAULT_HEADER["eventId"] = "EventId"
+SEARCH_DEFAULT_HEADER["filePath"] = "FilePath"
+SEARCH_DEFAULT_HEADER["fileName"] = "FileName"
 SEARCH_DEFAULT_HEADER["eventType"] = "Type"
 SEARCH_DEFAULT_HEADER["eventTimestamp"] = "EventTimestamp"
 SEARCH_DEFAULT_HEADER["fileCategory"] = "FileCategory"
@@ -35,8 +36,7 @@ SEARCH_DEFAULT_HEADER["fileSize"] = "FileSize"
 SEARCH_DEFAULT_HEADER["fileOwner"] = "FileOwner"
 SEARCH_DEFAULT_HEADER["md5Checksum"] = "MD5Checksum"
 SEARCH_DEFAULT_HEADER["sha256Checksum"] = "SHA256Checksum"
-SEARCH_DEFAULT_HEADER["filePath"] = "FilePath"
-SEARCH_DEFAULT_HEADER["fileName"] = "FileName"
+
 
 search_options = searchopt.create_search_options("file events")
 

--- a/src/code42cli/cmds/securitydata.py
+++ b/src/code42cli/cmds/securitydata.py
@@ -17,7 +17,7 @@ from code42cli.options import OrderedGroup
 from code42cli.options import sdk_options
 from code42cli.output_formats import extraction_format_option
 from code42cli.output_formats import format_option
-from code42cli.output_formats import get_format_header
+from code42cli.output_formats import get_dynamic_header
 
 
 logger = get_main_cli_logger()
@@ -26,6 +26,17 @@ _HEADER_KEYS_MAP = OrderedDict()
 _HEADER_KEYS_MAP["name"] = "Name"
 _HEADER_KEYS_MAP["id"] = "Id"
 
+SEARCH_DEFAULT_HEADER = OrderedDict()
+SEARCH_DEFAULT_HEADER["eventId"] = "EventId"
+SEARCH_DEFAULT_HEADER["eventType"] = "Type"
+SEARCH_DEFAULT_HEADER["eventTimestamp"] = "EventTimestamp"
+SEARCH_DEFAULT_HEADER["fileCategory"] = "FileCategory"
+SEARCH_DEFAULT_HEADER["fileSize"] = "FileSize"
+SEARCH_DEFAULT_HEADER["fileOwner"] = "FileOwner"
+SEARCH_DEFAULT_HEADER["md5Checksum"] = "MD5Checksum"
+SEARCH_DEFAULT_HEADER["sha256Checksum"] = "SHA256Checksum"
+SEARCH_DEFAULT_HEADER["filePath"] = "FilePath"
+SEARCH_DEFAULT_HEADER["fileName"] = "FileName"
 
 search_options = searchopt.create_search_options("file events")
 
@@ -197,6 +208,7 @@ def search(
         use_checkpoint,
         include_all,
         output_format=format,
+        output_header=SEARCH_DEFAULT_HEADER,
     )
     extractor = _get_file_event_extractor(state.sdk, handlers)
     extractor.use_or_query = or_query
@@ -251,5 +263,5 @@ def _get_file_event_cursor_store(profile_name):
 
 
 def _process_events(output_format, include_all, events):
-    format_header = get_format_header(include_all, events[0])
+    format_header = get_dynamic_header(include_all, events[0])
     return output_format(events, format_header)

--- a/src/code42cli/cmds/securitydata.py
+++ b/src/code42cli/cmds/securitydata.py
@@ -15,8 +15,8 @@ from code42cli.logger import get_main_cli_logger
 from code42cli.options import incompatible_with
 from code42cli.options import OrderedGroup
 from code42cli.options import sdk_options
+from code42cli.output_formats import extraction_format_option
 from code42cli.output_formats import format_option
-
 
 logger = get_main_cli_logger()
 
@@ -172,7 +172,7 @@ def file_event_options(f):
     f = process_owner_option(f)
     f = tab_url_option(f)
     f = include_non_exposure_option(f)
-    f = format_option(f)
+    f = extraction_format_option(f)
     f = saved_search_option(f)
     return f
 
@@ -200,12 +200,7 @@ def clear_checkpoint(state, checkpoint_name):
     "--or-query", is_flag=True, cls=searchopt.AdvancedQueryAndSavedSearchIncompatible
 )
 @sdk_options()
-@click.option(
-    "--display",
-    multiple=True,
-    default=_OPTIONAL_FIELDS,
-    type=click.Choice(_OPTIONAL_FIELDS),
-)
+@click.option("--include-all", default=False, is_flag=True)
 def search(
     state,
     format,
@@ -215,21 +210,21 @@ def search(
     use_checkpoint,
     saved_search,
     or_query,
-    display,
+    include_all,
     **kwargs
 ):
     """Search for file events."""
     cursor = (
         _get_file_event_cursor_store(state.profile.name) if use_checkpoint else None
     )
+
     handlers = ext.create_handlers(
         state.sdk,
         FileEventExtractor,
         format,
         cursor,
         use_checkpoint,
-        format_header=_SEARCH_RESPONSE_HEADER,
-        optional_fields=_optionally_display(display),
+        display_all=include_all,
     )
     extractor = _get_file_event_extractor(state.sdk, handlers)
     extractor.use_or_query = or_query

--- a/src/code42cli/cmds/securitydata.py
+++ b/src/code42cli/cmds/securitydata.py
@@ -167,7 +167,12 @@ def clear_checkpoint(state, checkpoint_name):
     "--or-query", is_flag=True, cls=searchopt.AdvancedQueryAndSavedSearchIncompatible
 )
 @sdk_options()
-@click.option("--include-all", default=False, is_flag=True)
+@click.option(
+    "--include-all",
+    default=False,
+    is_flag=True,
+    help="Display complete list of data items or only from top level of nested response.",
+)
 def search(
     state,
     format,

--- a/src/code42cli/cmds/securitydata.py
+++ b/src/code42cli/cmds/securitydata.py
@@ -17,6 +17,8 @@ from code42cli.options import OrderedGroup
 from code42cli.options import sdk_options
 from code42cli.output_formats import extraction_format_option
 from code42cli.output_formats import format_option
+from code42cli.output_formats import get_format_header
+
 
 logger = get_main_cli_logger()
 
@@ -202,7 +204,7 @@ def search(
     if handlers.TOTAL_EVENTS == 0 and not errors.ERRORED:
         echo("No results found.")
     else:
-        output = process_events(format, include_all, handlers.EVENTS)
+        output = _process_events(format, include_all, handlers.EVENTS)
         click.echo_via_pager(output)
 
 
@@ -241,14 +243,6 @@ def _get_file_event_cursor_store(profile_name):
     return FileEventCursorStore(profile_name)
 
 
-def process_events(output_format, include_all, events):
-    format_header = (
-        {key: key.capitalize() for key in events[0].keys()}
-        if include_all
-        else {
-            key: key.capitalize()
-            for key in events[0].keys()
-            if type(events[0][key]) == str
-        }
-    )
+def _process_events(output_format, include_all, events):
+    format_header = get_format_header(include_all, events[0])
     return output_format(events, format_header)

--- a/src/code42cli/cmds/securitydata.py
+++ b/src/code42cli/cmds/securitydata.py
@@ -26,8 +26,8 @@ _HEADER_KEYS_MAP["name"] = "Name"
 _HEADER_KEYS_MAP["id"] = "Id"
 
 SEARCH_DEFAULT_HEADER = OrderedDict()
-SEARCH_DEFAULT_HEADER["filePath"] = "FilePath"
 SEARCH_DEFAULT_HEADER["fileName"] = "FileName"
+SEARCH_DEFAULT_HEADER["filePath"] = "FilePath"
 SEARCH_DEFAULT_HEADER["eventType"] = "Type"
 SEARCH_DEFAULT_HEADER["eventTimestamp"] = "EventTimestamp"
 SEARCH_DEFAULT_HEADER["fileCategory"] = "FileCategory"

--- a/src/code42cli/cmds/securitydata.py
+++ b/src/code42cli/cmds/securitydata.py
@@ -17,7 +17,6 @@ from code42cli.options import OrderedGroup
 from code42cli.options import sdk_options
 from code42cli.output_formats import extraction_format_option
 from code42cli.output_formats import format_option
-from code42cli.output_formats import get_dynamic_header
 
 
 logger = get_main_cli_logger()
@@ -260,4 +259,3 @@ def _get_file_event_extractor(sdk, handlers):
 
 def _get_file_event_cursor_store(profile_name):
     return FileEventCursorStore(profile_name)
-

--- a/src/code42cli/output_formats.py
+++ b/src/code42cli/output_formats.py
@@ -93,13 +93,9 @@ def to_formatted_json(output, header=None):
     return json.dumps(_filter(output, header), indent=4)
 
 
-def get_format_header(include_all, header_items):
-    return (
-        {key: key.capitalize() for key in header_items.keys()}
-        if include_all
-        else {
-            key: key.capitalize()
-            for key in header_items.keys()
-            if type(header_items[key]) == str
-        }
-    )
+def get_dynamic_header(header_items):
+    return {
+        key: key.capitalize()
+        for key in header_items.keys()
+        if type(header_items[key]) == str
+    }

--- a/src/code42cli/output_formats.py
+++ b/src/code42cli/output_formats.py
@@ -30,11 +30,11 @@ def extraction_output_format(_, __, value):
         if value == OutputFormat.RAW:
             return to_json
         if value == OutputFormat.TABLE:
-            return to_table
+            return to_event_table
         if value == OutputFormat.JSON:
             return to_formatted_json
     # default option
-    return to_table
+    return to_event_table
 
 
 format_option = click.option(
@@ -59,7 +59,7 @@ def to_dynamic_csv(output, header):
     string_io = io.StringIO()
     writer = csv.DictWriter(string_io, fieldnames=header)
     filtered_output = [{key: row[key] for key in header} for row in output]
-    writer.writeheader()
+    # writer.writeheader()
     writer.writerows(filtered_output)
     return string_io.getvalue()
 
@@ -74,6 +74,11 @@ def to_csv(output, header):
         lines.append(line)
 
     return "\n".join(lines)
+
+
+def to_event_table(output, header):
+    rows, column_size = find_format_width(output, header, False)
+    return format_to_table(rows, column_size)
 
 
 def to_table(output, header):

--- a/src/code42cli/output_formats.py
+++ b/src/code42cli/output_formats.py
@@ -91,3 +91,15 @@ def to_json(output, header=None):
 
 def to_formatted_json(output, header=None):
     return json.dumps(_filter(output, header), indent=4)
+
+
+def get_format_header(include_all, header_items):
+    return (
+        {key: key.capitalize() for key in header_items.keys()}
+        if include_all
+        else {
+            key: key.capitalize()
+            for key in header_items.keys()
+            if type(header_items[key]) == str
+        }
+    )

--- a/src/code42cli/output_formats.py
+++ b/src/code42cli/output_formats.py
@@ -86,12 +86,8 @@ def _filter(output, header):
 
 
 def to_json(output, header=None):
-    # TODO To remove after approval
-    # return json.dumps(output)
-    return json.dumps(_filter(output, header))
+    return json.dumps(output)
 
 
 def to_formatted_json(output, header=None):
-    # TODO To remove after approval
-    # return json.dumps(output, indent=4)
     return json.dumps(_filter(output, header), indent=4)

--- a/src/code42cli/output_formats.py
+++ b/src/code42cli/output_formats.py
@@ -30,11 +30,11 @@ def extraction_output_format(_, __, value):
         if value == OutputFormat.RAW:
             return to_json
         if value == OutputFormat.TABLE:
-            return to_event_table
+            return to_table
         if value == OutputFormat.JSON:
             return to_formatted_json
     # default option
-    return to_event_table
+    return to_table
 
 
 format_option = click.option(
@@ -59,7 +59,7 @@ def to_dynamic_csv(output, header):
     string_io = io.StringIO()
     writer = csv.DictWriter(string_io, fieldnames=header)
     filtered_output = [{key: row[key] for key in header} for row in output]
-    # writer.writeheader()
+    writer.writeheader()
     writer.writerows(filtered_output)
     return string_io.getvalue()
 
@@ -74,11 +74,6 @@ def to_csv(output, header):
         lines.append(line)
 
     return "\n".join(lines)
-
-
-def to_event_table(output, header):
-    rows, column_size = find_format_width(output, header, False)
-    return format_to_table(rows, column_size)
 
 
 def to_table(output, header):

--- a/src/code42cli/util.py
+++ b/src/code42cli/util.py
@@ -38,7 +38,7 @@ def get_user_project_path(*subdirs):
     return result_path
 
 
-def find_format_width(record, header):
+def find_format_width(record, header, include_header=True):
     """Fetches needed keys/items to be displayed based on header keys.
 
     Finds the largest string against each column so as to decide the padding size for the column.
@@ -47,11 +47,14 @@ def find_format_width(record, header):
         record (list of dict), data to be formatted.
         header (dict), key-value where keys should map to keys of record dict and
           value is the corresponding column name to be displayed on the cli.
+        include_header (bool), include header in output, defaults to True.
 
     Returns:
         tuple (list of dict, dict), i.e Filtered records, padding size of columns.
     """
-    rows = [header]
+    rows = []
+    if include_header:
+        rows.append(header)
 
     # Set default max width items to column names
     max_width_item = dict(header.items())

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -8,8 +8,10 @@ from code42cli.cmds.search.extraction import create_handlers
 key = "events"
 header = {"property": "Property"}
 
+
 class TestQuery:
     """"""
+
     pass
 
 
@@ -18,7 +20,7 @@ def search(*args, **kwargs):
 
 
 def test_create_handlers_creates_handlers_that_pass_events_to_output_format(
-    mocker, sdk, 
+    mocker, sdk,
 ):
     class TestExtractor(BaseExtractor):
         def __init__(self, handlers, timestamp_filter):
@@ -31,8 +33,13 @@ def test_create_handlers_creates_handlers_that_pass_events_to_output_format(
     output_format = mocker.MagicMock()
     cursor_store = mocker.MagicMock(sepc=BaseCursorStore)
     handlers = create_handlers(
-        sdk, TestExtractor, cursor_store, "chk-name", False, output_format, 
-        output_header=header
+        sdk,
+        TestExtractor,
+        cursor_store,
+        "chk-name",
+        False,
+        output_format,
+        output_header=header,
     )
     http_response = mocker.MagicMock(spec=Response)
     events = [{"property": "bar"}]
@@ -56,8 +63,13 @@ def test_include_all_creates_dynamic_header_from_events_to_output_format(
     output_format = mocker.MagicMock()
     cursor_store = mocker.MagicMock(sepc=BaseCursorStore)
     handlers = create_handlers(
-        sdk, TestExtractor, cursor_store, "chk-name", True, output_format,
-        output_header=header
+        sdk,
+        TestExtractor,
+        cursor_store,
+        "chk-name",
+        True,
+        output_format,
+        output_header=header,
     )
     http_response = mocker.MagicMock(spec=Response)
     events = [{"food": "bar"}]

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -1,0 +1,37 @@
+from c42eventextractor.extractors import BaseExtractor
+from py42.response import Py42Response
+from requests import Response
+
+from code42cli.cmds.search.cursor_store import BaseCursorStore
+from code42cli.cmds.search.extraction import create_handlers
+
+key = "events"
+
+
+class TestQuery:
+    """"""
+
+
+def search(*args, **kwargs):
+    pass
+
+
+def test_create_handlers_creates_handlers_that_pass_events_to_output_format(
+    mocker, sdk
+):
+    class TestExtractor(BaseExtractor):
+        def __init__(self, handlers, timestamp_filter):
+            timestamp_filter._term = "test_term"
+            super().__init__(key, search, handlers, timestamp_filter, TestQuery)
+
+    output_format = mocker.MagicMock()
+    cursor_store = mocker.MagicMock(sepc=BaseCursorStore)
+    handlers = create_handlers(
+        sdk, TestExtractor, cursor_store, "chk-name", False, output_format, "header"
+    )
+    http_response = mocker.MagicMock(spec=Response)
+    events = [{"food": "bar"}]
+    http_response.text = '{{"{0}": [{{"food": "bar"}}]}}'.format(key)
+    py42_response = Py42Response(http_response)
+    handlers.handle_response(py42_response)
+    output_format.assert_called_once_with(events, "header")

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -6,10 +6,11 @@ from code42cli.cmds.search.cursor_store import BaseCursorStore
 from code42cli.cmds.search.extraction import create_handlers
 
 key = "events"
-
+header = {"property": "Property"}
 
 class TestQuery:
     """"""
+    pass
 
 
 def search(*args, **kwargs):
@@ -17,21 +18,50 @@ def search(*args, **kwargs):
 
 
 def test_create_handlers_creates_handlers_that_pass_events_to_output_format(
-    mocker, sdk
+    mocker, sdk, 
 ):
     class TestExtractor(BaseExtractor):
         def __init__(self, handlers, timestamp_filter):
             timestamp_filter._term = "test_term"
             super().__init__(key, search, handlers, timestamp_filter, TestQuery)
 
+        def _get_timestamp_from_item(self, item):
+            pass
+
     output_format = mocker.MagicMock()
     cursor_store = mocker.MagicMock(sepc=BaseCursorStore)
     handlers = create_handlers(
-        sdk, TestExtractor, cursor_store, "chk-name", False, output_format, "header"
+        sdk, TestExtractor, cursor_store, "chk-name", False, output_format, 
+        output_header=header
+    )
+    http_response = mocker.MagicMock(spec=Response)
+    events = [{"property": "bar"}]
+    http_response.text = '{{"{0}": [{{"property": "bar"}}]}}'.format(key)
+    py42_response = Py42Response(http_response)
+    handlers.handle_response(py42_response)
+    output_format.assert_called_once_with(events, header)
+
+
+def test_include_all_creates_dynamic_header_from_events_to_output_format(
+    mocker, sdk,
+):
+    class TestExtractor(BaseExtractor):
+        def __init__(self, handlers, timestamp_filter):
+            timestamp_filter._term = "test_term"
+            super().__init__(key, search, handlers, timestamp_filter, TestQuery)
+
+        def _get_timestamp_from_item(self, item):
+            pass
+
+    output_format = mocker.MagicMock()
+    cursor_store = mocker.MagicMock(sepc=BaseCursorStore)
+    handlers = create_handlers(
+        sdk, TestExtractor, cursor_store, "chk-name", True, output_format,
+        output_header=header
     )
     http_response = mocker.MagicMock(spec=Response)
     events = [{"food": "bar"}]
     http_response.text = '{{"{0}": [{{"food": "bar"}}]}}'.format(key)
     py42_response = Py42Response(http_response)
     handlers.handle_response(py42_response)
-    output_format.assert_called_once_with(events, "header")
+    output_format.assert_called_once_with(events, {"food": "Food"})

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -115,6 +115,16 @@ d12d54f0-5160-47a8-a48f-7d5fa5b051c5,outside td,HIGH,FED_CLOUD_SHARE_PERMISSIONS
 8b393324-c34c-44ac-9f79-4313601dd859,Test different filters,MEDIUM,FED_ENDPOINT_EXFILTRATION,Alerting,True
 5eabed1d-a406-4dfc-af81-f7485ee09b19,Test Alerts using CLI,HIGH,FED_ENDPOINT_EXFILTRATION,Alerting,True"""
 
+DYNAMIC_CSV_OUTPUT = "\r\n".join(
+    [
+        "observerRuleId,name,severity,type,ruleSource,isEnabled",
+        "d12d54f0-5160-47a8-a48f-7d5fa5b051c5,outside td,HIGH,FED_CLOUD_SHARE_PERMISSIONS,Alerting,True",
+        "8b393324-c34c-44ac-9f79-4313601dd859,Test different filters,MEDIUM,FED_ENDPOINT_EXFILTRATION,Alerting,True",
+        "5eabed1d-a406-4dfc-af81-f7485ee09b19,Test Alerts using CLI,HIGH,FED_ENDPOINT_EXFILTRATION,Alerting,True",
+        "",
+    ]
+)
+
 
 TEST_NESTED_DATA = {
     "test": "TEST",
@@ -182,6 +192,11 @@ def test_output_format_returns_to_dynamic_csv_function_when_csv_option_is_passed
     assert id(extraction_output_format_function) == id(to_dynamic_csv)
 
 
+def test_output_format_returns_to_table_function_when_table_option_is_passed():
+    extraction_output_format_function = extraction_output_format(None, None, "TABLE")
+    assert id(extraction_output_format_function) == id(to_table)
+
+
 def test_extraction_output_format_returns_to_formatted_json_function_when_json__option_is_passed():
     format_function = extraction_output_format(None, None, "JSON")
     assert id(format_function) == id(to_formatted_json)
@@ -202,3 +217,8 @@ def test_get_format_header_returns_all_keys_only_which_are_not_nested():
         "tenantId": "Tenantid",
         "id": "Id",
     }
+
+
+def test_to_dynamic_csv():
+    formatted_output = to_dynamic_csv(TEST_DATA, TEST_HEADER)
+    assert formatted_output == DYNAMIC_CSV_OUTPUT

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -6,6 +6,7 @@ from code42cli.output_formats import get_format_header
 from code42cli.output_formats import output_format
 from code42cli.output_formats import to_csv
 from code42cli.output_formats import to_dynamic_csv
+from code42cli.output_formats import to_event_table
 from code42cli.output_formats import to_formatted_json
 from code42cli.output_formats import to_json
 from code42cli.output_formats import to_table
@@ -194,12 +195,12 @@ def test_extraction_output_format_returns_to_json_function_when_raw_json_format_
 
 def test_extraction_output_format_returns_to_table_function_when_table_format_option_is_passed():
     format_function = extraction_output_format(None, None, "TABLE")
-    assert id(format_function) == id(to_table)
+    assert id(format_function) == id(to_event_table)
 
 
 def test_extraction_output_format_returns_to_table_function_when_no_format_option_is_passed():
     format_function = extraction_output_format(None, None, None)
-    assert id(format_function) == id(to_table)
+    assert id(format_function) == id(to_event_table)
 
 
 def test_get_format_header_returns_all_keys_when_include_all_is_false():

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -1,8 +1,11 @@
 import json
 from collections import OrderedDict
 
+from code42cli.output_formats import extraction_output_format
+from code42cli.output_formats import get_format_header
 from code42cli.output_formats import output_format
 from code42cli.output_formats import to_csv
+from code42cli.output_formats import to_dynamic_csv
 from code42cli.output_formats import to_formatted_json
 from code42cli.output_formats import to_json
 from code42cli.output_formats import to_table
@@ -113,6 +116,21 @@ d12d54f0-5160-47a8-a48f-7d5fa5b051c5,outside td,HIGH,FED_CLOUD_SHARE_PERMISSIONS
 5eabed1d-a406-4dfc-af81-f7485ee09b19,Test Alerts using CLI,HIGH,FED_ENDPOINT_EXFILTRATION,Alerting,True"""
 
 
+TEST_NESTED_DATA = {
+    "test": "TEST",
+    "name": "outside td",
+    "description": "",
+    "severity": "HIGH",
+    "isSystem": False,
+    "isEnabled": True,
+    "ruleSource": ["Alerting"],
+    "tenantId": "1d71796f-af5b-4231-9d8e-df6434da4663",
+    "observerRuleId": {"test": ["d12d54f0-5160-47a8-a48f-7d5fa5b051c5"]},
+    "type": ["FED_CLOUD_SHARE_PERMISSIONS"],
+    "id": "5157f1df-cb3e-4755-92a2-0f42c7841020",
+}
+
+
 def test_to_csv_formats_data_to_csv_format():
     formatted_output = to_csv(TEST_DATA, TEST_HEADER)
     assert formatted_output == CSV_OUTPUT
@@ -157,3 +175,58 @@ def test_output_format_returns_to_csv_function_when_csv_format_option_is_passed(
 def test_output_format_returns_to_table_function_when_no_format_option_is_passed():
     format_function = output_format(None, None, None)
     assert id(format_function) == id(to_table)
+
+
+def test_output_format_returns_to_dynamic_csv_function_when_csv_option_is_passed():
+    extraction_output_format_function = extraction_output_format(None, None, "CSV")
+    assert id(extraction_output_format_function) == id(to_dynamic_csv)
+
+
+def test_extraction_output_format_returns_to_formatted_json_function_when_json__option_is_passed():
+    format_function = extraction_output_format(None, None, "JSON")
+    assert id(format_function) == id(to_formatted_json)
+
+
+def test_extraction_output_format_returns_to_json_function_when_raw_json_format_option_is_passed():
+    format_function = extraction_output_format(None, None, "RAW-JSON")
+    assert id(format_function) == id(to_json)
+
+
+def test_extraction_output_format_returns_to_table_function_when_table_format_option_is_passed():
+    format_function = extraction_output_format(None, None, "TABLE")
+    assert id(format_function) == id(to_table)
+
+
+def test_extraction_output_format_returns_to_table_function_when_no_format_option_is_passed():
+    format_function = extraction_output_format(None, None, None)
+    assert id(format_function) == id(to_table)
+
+
+def test_get_format_header_returns_all_keys_when_include_all_is_false():
+    header = get_format_header(False, TEST_NESTED_DATA)
+    assert header == {
+        "test": "Test",
+        "name": "Name",
+        "description": "Description",
+        "severity": "Severity",
+        "tenantId": "Tenantid",
+        "id": "Id",
+    }
+
+
+def test_get_format_header_returns_only_root_level_keys_when_include_all_is_true():
+    header = get_format_header(True, TEST_NESTED_DATA)
+    print(header)
+    assert header == {
+        "test": "Test",
+        "name": "Name",
+        "description": "Description",
+        "severity": "Severity",
+        "isSystem": "Issystem",
+        "isEnabled": "Isenabled",
+        "ruleSource": "Rulesource",
+        "tenantId": "Tenantid",
+        "observerRuleId": "Observerruleid",
+        "type": "Type",
+        "id": "Id",
+    }

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -126,7 +126,7 @@ def test_to_table_formats_data_to_table_format():
 
 def test_to_json():
     formatted_output = to_json(TEST_DATA, TEST_HEADER)
-    assert formatted_output == json.dumps(FILTERED_OUTPUT)
+    assert formatted_output == json.dumps(TEST_DATA)
 
 
 def test_to_formatted_json():

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -192,7 +192,7 @@ def test_extraction_output_format_returns_to_json_function_when_raw_json_format_
     assert id(format_function) == id(to_json)
 
 
-def test_get_format_header_returns_all_keys_when_include_all_is_false():
+def test_get_format_header_returns_all_keys_only_which_are_not_nested():
     header = get_dynamic_header(TEST_NESTED_DATA)
     assert header == {
         "test": "Test",
@@ -200,22 +200,5 @@ def test_get_format_header_returns_all_keys_when_include_all_is_false():
         "description": "Description",
         "severity": "Severity",
         "tenantId": "Tenantid",
-        "id": "Id",
-    }
-
-
-def test_get_format_header_returns_only_root_level_keys_when_include_all_is_true():
-    header = get_dynamic_header(TEST_NESTED_DATA)
-    assert header == {
-        "test": "Test",
-        "name": "Name",
-        "description": "Description",
-        "severity": "Severity",
-        "isSystem": "Issystem",
-        "isEnabled": "Isenabled",
-        "ruleSource": "Rulesource",
-        "tenantId": "Tenantid",
-        "observerRuleId": "Observerruleid",
-        "type": "Type",
         "id": "Id",
     }

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -6,7 +6,6 @@ from code42cli.output_formats import get_format_header
 from code42cli.output_formats import output_format
 from code42cli.output_formats import to_csv
 from code42cli.output_formats import to_dynamic_csv
-from code42cli.output_formats import to_event_table
 from code42cli.output_formats import to_formatted_json
 from code42cli.output_formats import to_json
 from code42cli.output_formats import to_table
@@ -191,16 +190,6 @@ def test_extraction_output_format_returns_to_formatted_json_function_when_json__
 def test_extraction_output_format_returns_to_json_function_when_raw_json_format_option_is_passed():
     format_function = extraction_output_format(None, None, "RAW-JSON")
     assert id(format_function) == id(to_json)
-
-
-def test_extraction_output_format_returns_to_table_function_when_table_format_option_is_passed():
-    format_function = extraction_output_format(None, None, "TABLE")
-    assert id(format_function) == id(to_event_table)
-
-
-def test_extraction_output_format_returns_to_table_function_when_no_format_option_is_passed():
-    format_function = extraction_output_format(None, None, None)
-    assert id(format_function) == id(to_event_table)
 
 
 def test_get_format_header_returns_all_keys_when_include_all_is_false():

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -2,7 +2,7 @@ import json
 from collections import OrderedDict
 
 from code42cli.output_formats import extraction_output_format
-from code42cli.output_formats import get_format_header
+from code42cli.output_formats import get_dynamic_header
 from code42cli.output_formats import output_format
 from code42cli.output_formats import to_csv
 from code42cli.output_formats import to_dynamic_csv
@@ -193,7 +193,7 @@ def test_extraction_output_format_returns_to_json_function_when_raw_json_format_
 
 
 def test_get_format_header_returns_all_keys_when_include_all_is_false():
-    header = get_format_header(False, TEST_NESTED_DATA)
+    header = get_dynamic_header(TEST_NESTED_DATA)
     assert header == {
         "test": "Test",
         "name": "Name",
@@ -205,8 +205,7 @@ def test_get_format_header_returns_all_keys_when_include_all_is_false():
 
 
 def test_get_format_header_returns_only_root_level_keys_when_include_all_is_true():
-    header = get_format_header(True, TEST_NESTED_DATA)
-    print(header)
+    header = get_dynamic_header(TEST_NESTED_DATA)
     assert header == {
         "test": "Test",
         "name": "Name",


### PR DESCRIPTION
**Description of Change**

Added formatting options to extraction/search commands.
`code42 alerts search` 
`code42 security-data search`
`code42 security-data search --saved-search`


**Test Guidelines:** 

```
$ code42 security-data search -b 2020-07-10
$ code42 security-data search -b 2020-07-10 --include-all 
$ code42 security-data search -b 2020-07-10 --include-all -f json
$ code42 security-data search -b 2020-07-10 --include-all -f raw-json
$ code42 security-data search -b 2020-07-10 --include-all -f csv
$ code42 security-data search -b 2020-07-10 --include-all -f table
$ code42 security-data search -b 2020-07-10 -f table
$ code42 security-data search -b 2020-07-10 -f csv
$ code42 security-data search -b 2020-07-10 -f raw-json
$ code42 security-data search -b 2020-07-10 -f json
```

Similarly added same argument options for `alerts` and `saved-search` commands
```
$ code42 security-data search --saved-search a083f08d-8f33-4cbd-81c4-8d1820b61185
$ code42 alerts search -b 2020-07-10
```

**PR Checklist**

Did you remember to do the below?

- [x]   Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes