### PR TITLE
Add date validation for bulk add command in departing employee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 ### Fixed
 
 - Bug where `code42 legal-hold show` would error when terminal was too small.
+- Fixed bug in `departing_employee bulk add` command that allowed invalid dates to be passed without validation.
 
 ### Changed
 

--- a/src/code42cli/cmds/departing_employee.py
+++ b/src/code42cli/cmds/departing_employee.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import click
 from py42.exceptions import Py42BadRequestError
 
@@ -15,6 +17,9 @@ from code42cli.options import OrderedGroup
 from code42cli.options import sdk_options
 
 
+DATE_FORMAT = "%Y-%m-%d"
+
+
 @click.group(cls=OrderedGroup)
 @sdk_options(hidden=True)
 def departing_employee(state):
@@ -27,7 +32,7 @@ def departing_employee(state):
 @click.option(
     "--departure-date",
     help="The date the employee is departing. Format: yyyy-MM-dd.",
-    type=click.DateTime(formats=["%Y-%m-%d"]),
+    type=click.DateTime(formats=[DATE_FORMAT]),
 )
 @cloud_alias_option
 @notes_option
@@ -35,7 +40,7 @@ def departing_employee(state):
 def add(state, username, cloud_alias, departure_date, notes):
     """Add a user to the departing-employee detection list."""
     if departure_date:
-        departure_date = departure_date.strftime("%Y-%m-%d")
+        departure_date = departure_date.strftime(DATE_FORMAT)
     _add_departing_employee(state.sdk, username, cloud_alias, departure_date, notes)
 
 
@@ -70,11 +75,18 @@ bulk.add_command(departing_employee_generate_template)
 )
 @read_csv_arg(headers=DEPARTING_EMPLOYEE_CSV_HEADERS)
 @sdk_options()
-def bulk_add(state, csv_rows):
-    sdk = state.sdk
-
+@click.pass_context
+def bulk_add(ctx, state, csv_rows):
     def handle_row(username, cloud_alias, departure_date, notes):
-        _add_departing_employee(sdk, username, cloud_alias, departure_date, notes)
+        if departure_date:
+            departure_date = datetime.strptime(departure_date, DATE_FORMAT)
+        ctx.invoke(
+            add,
+            username=username,
+            cloud_alias=cloud_alias,
+            departure_date=departure_date,
+            notes=notes,
+        )
 
     run_bulk_process(
         handle_row,

--- a/src/code42cli/cmds/departing_employee.py
+++ b/src/code42cli/cmds/departing_employee.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 import click
 from py42.exceptions import Py42BadRequestError
 
@@ -11,6 +9,7 @@ from code42cli.cmds.detectionlists.options import cloud_alias_option
 from code42cli.cmds.detectionlists.options import notes_option
 from code42cli.cmds.detectionlists.options import username_arg
 from code42cli.cmds.shared import get_user_id
+from code42cli.errors import Code42CLIError
 from code42cli.file_readers import read_csv_arg
 from code42cli.file_readers import read_flat_file_arg
 from code42cli.options import OrderedGroup
@@ -79,7 +78,15 @@ bulk.add_command(departing_employee_generate_template)
 def bulk_add(ctx, state, csv_rows):
     def handle_row(username, cloud_alias, departure_date, notes):
         if departure_date:
-            departure_date = datetime.strptime(departure_date, DATE_FORMAT)
+            try:
+                departure_date = click.DateTime(formats=[DATE_FORMAT]).convert(
+                    departure_date, None, None
+                )
+            except click.exceptions.BadParameter:
+                message = "Invalid date {}, valid date format {}".format(
+                    departure_date, DATE_FORMAT
+                )
+                raise Code42CLIError(message)
         ctx.invoke(
             add,
             username=username,

--- a/tests/cmds/test_departing_employee.py
+++ b/tests/cmds/test_departing_employee.py
@@ -122,6 +122,8 @@ def test_add_bulk_users_calls_expected_py42_methods(runner, mocker, cli_state):
                     "test_user,test_alias,2020-01-01,test_note\n",
                     "test_user_2,test_alias_2,2020-02-01,test_note_2\n",
                     "test_user_3,,,\n",
+                    "test_user_3,,2020-30-02,\n",
+                    "test_user_3,,20-02-2020,\n",
                 ]
             )
         runner.invoke(


### PR DESCRIPTION
**Change Description**

Added `departure_date` validation in `bulk add` subcommand in `departing_employee`  command.

**Test Guidelines**
`code42 departing-employee bulk add <csv-file>`

**PR Checklist**

Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [ n/a] Add docstrings for any new public parameters / methods / classes