### PR TITLE
Remove extra space from raw json for syslog purposes

### DIFF
--- a/src/code42cli/output_formats.py
+++ b/src/code42cli/output_formats.py
@@ -90,7 +90,7 @@ def to_table(output, header):
 
 def to_json(output):
     """Output is a single record"""
-    return "{}\n".format(json.dumps(output))
+    return "{}".format(json.dumps(output))
 
 
 def to_formatted_json(output):

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -136,7 +136,7 @@ def test_to_table_when_not_given_header_creates_header_dynamically():
 
 def test_to_json():
     formatted_output = output_formats_module.to_json(TEST_DATA)
-    assert formatted_output == "{}\n".format(json.dumps(TEST_DATA))
+    assert formatted_output == json.dumps(TEST_DATA)
 
 
 def test_to_formatted_json():


### PR DESCRIPTION
Remove extra space from raw json for syslog purposes