### PR TITLE
fix bug in alert search table output when --include-all is passed. 

### DIFF
--- a/src/code42cli/util.py
+++ b/src/code42cli/util.py
@@ -57,14 +57,14 @@ def find_format_width(record, header, include_header=True):
         if not header:
             header = _get_default_header(record)
         rows.append(header)
-
     max_width_item = dict(header.items())  # Copy
     for record_row in record:
         row = OrderedDict()
         for header_key in header.keys():
-            row[header_key] = record_row[header_key]
+            item = record_row.get(header_key)
+            row[header_key] = item
             max_width_item[header_key] = max(
-                max_width_item[header_key], str(record_row[header_key]), key=len
+                max_width_item[header_key], str(item), key=len
             )
         rows.append(row)
     column_size = {key: len(value) for key, value in max_width_item.items()}


### PR DESCRIPTION
some rows might not contain all keys, so use .get() on the row. 