### PR TITLE
Handle updating cloud aliases when adding to a list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+## Unreleased
+
+### Changed
+
+- Now, when adding a cloud alias to a detection list user, such as during `departing-employee add`, it will remove the existing cloud alias if one exists.
+
 ## 1.0.0 - 2020-08-31
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 ### Changed
 
 - Now, when adding a cloud alias to a detection list user, such as during `departing-employee add`, it will remove the existing cloud alias if one exists.
+    - Before, it would error and the cloud alias would not get added.
 
 ## 1.0.0 - 2020-08-31
 

--- a/src/code42cli/cmds/detectionlists/__init__.py
+++ b/src/code42cli/cmds/detectionlists/__init__.py
@@ -14,7 +14,7 @@ def update_user(sdk, username, cloud_alias=None, risk_tag=None, notes=None):
     user_id = get_user_id(sdk, username)
     if cloud_alias:
         profile = sdk.detectionlists.get_user_by_id(user_id)
-        cloud_aliases = profile.data.get("cloudUsernames")
+        cloud_aliases = profile.data.get("cloudUsernames") or []
         for alias in cloud_aliases:
             if alias != profile["userName"]:
                 sdk.detectionlists.remove_user_cloud_alias(user_id, alias)

--- a/src/code42cli/cmds/detectionlists/__init__.py
+++ b/src/code42cli/cmds/detectionlists/__init__.py
@@ -12,6 +12,12 @@ def update_user(sdk, username, cloud_alias=None, risk_tag=None, notes=None):
         notes (str or unicode): Notes about the user.
     """
     user_id = get_user_id(sdk, username)
+    _update_cloud_alias(sdk, user_id, cloud_alias)
+    _update_risk_tags(sdk, username, risk_tag)
+    _update_notes(sdk, user_id, notes)
+
+
+def _update_cloud_alias(sdk, user_id, cloud_alias):
     if cloud_alias:
         profile = sdk.detectionlists.get_user_by_id(user_id)
         cloud_aliases = profile.data.get("cloudUsernames") or []
@@ -19,8 +25,14 @@ def update_user(sdk, username, cloud_alias=None, risk_tag=None, notes=None):
             if alias != profile["userName"]:
                 sdk.detectionlists.remove_user_cloud_alias(user_id, alias)
         sdk.detectionlists.add_user_cloud_alias(user_id, cloud_alias)
+
+
+def _update_risk_tags(sdk, username, risk_tag):
     if risk_tag:
         add_risk_tags(sdk, username, risk_tag)
+
+
+def _update_notes(sdk, user_id, notes):
     if notes:
         sdk.detectionlists.update_user_notes(user_id, notes)
 

--- a/src/code42cli/cmds/detectionlists/__init__.py
+++ b/src/code42cli/cmds/detectionlists/__init__.py
@@ -13,6 +13,11 @@ def update_user(sdk, username, cloud_alias=None, risk_tag=None, notes=None):
     """
     user_id = get_user_id(sdk, username)
     if cloud_alias:
+        profile = sdk.detectionlists.get_user_by_id(user_id)
+        cloud_aliases = profile.data.get("cloudUsernames")
+        for alias in cloud_aliases:
+            if alias != profile["userName"]:
+                sdk.detectionlists.remove_user_cloud_alias(user_id, alias)
         sdk.detectionlists.add_user_cloud_alias(user_id, cloud_alias)
     if risk_tag:
         add_risk_tags(sdk, username, risk_tag)

--- a/src/code42cli/cmds/detectionlists/options.py
+++ b/src/code42cli/cmds/detectionlists/options.py
@@ -5,6 +5,7 @@ cloud_alias_option = click.option(
     "--cloud-alias",
     help="If the employee has an email alias other than their Code42 username "
     "that they use for cloud services such as Google Drive, OneDrive, or Box, "
-    "add and monitor the alias.",
+    "add and monitor the alias. WARNING: Adding a cloud alias will override the "
+    "existing user cloud alias if they already have one.",
 )
 notes_option = click.option("--notes", help="Optional notes about the employee.")

--- a/src/code42cli/cmds/detectionlists/options.py
+++ b/src/code42cli/cmds/detectionlists/options.py
@@ -5,7 +5,7 @@ cloud_alias_option = click.option(
     "--cloud-alias",
     help="If the employee has an email alias other than their Code42 username "
     "that they use for cloud services such as Google Drive, OneDrive, or Box, "
-    "add and monitor the alias. WARNING: Adding a cloud alias will override the "
-    "existing user cloud alias if they already have one.",
+    "add and monitor the alias. WARNING: Adding a cloud alias will override any "
+    "existing cloud alias for this user.",
 )
 notes_option = click.option("--notes", help="Optional notes about the employee.")

--- a/tests/cmds/detectionlists/test_init.py
+++ b/tests/cmds/detectionlists/test_init.py
@@ -1,0 +1,58 @@
+import pytest
+from py42.response import Py42Response
+from requests import Response
+
+from code42cli.cmds.detectionlists import update_user
+
+
+MOCK_USER_ID = "USER-ID"
+MOCK_USER_NAME = "test@example.com"
+MOCK_ALIAS = "alias@example"
+MOCK_USER_PROFILE_RESPONSE = """
+{{
+    "type$": "USER_V2",
+    "tenantId": "TENANT-ID",
+    "userId": "{0}",
+    "userName": "{1}",
+    "displayName": "Test",
+    "notes": "Notes",
+    "cloudUsernames": ["{2}", "{1}"],
+    "riskFactors": ["HIGH_IMPACT_EMPLOYEE"]
+}}
+""".format(
+    MOCK_USER_ID, MOCK_USER_NAME, MOCK_ALIAS
+)
+
+
+@pytest.fixture
+def user_response_with_cloud_aliases(mocker):
+    response = mocker.MagicMock(spec=Response)
+    response.text = MOCK_USER_PROFILE_RESPONSE
+    return Py42Response(response)
+
+
+@pytest.fixture
+def mock_user_id(mocker):
+    mock = mocker.patch("code42cli.cmds.detectionlists.get_user_id")
+    mock.return_value = MOCK_USER_ID
+    return mock
+
+
+def test_update_user_when_given_cloud_alias_add_cloud_alias(
+    sdk, user_response_with_cloud_aliases, mock_user_id
+):
+    sdk.detectionlists.get_user_by_id.return_value = user_response_with_cloud_aliases
+    update_user(sdk, MOCK_USER_NAME, cloud_alias="new.alias@exaple.com")
+    sdk.detectionlists.add_user_cloud_alias.assert_called_once_with(
+        MOCK_USER_ID, "new.alias@exaple.com"
+    )
+
+
+def test_update_user_when_given_cloud_alias_first_removes_old_alias(
+    sdk, user_response_with_cloud_aliases, mock_user_id
+):
+    sdk.detectionlists.get_user_by_id.return_value = user_response_with_cloud_aliases
+    update_user(sdk, MOCK_USER_NAME, cloud_alias="new.alias@exaple.com")
+    sdk.detectionlists.remove_user_cloud_alias.assert_called_once_with(
+        MOCK_USER_ID, MOCK_ALIAS
+    )


### PR DESCRIPTION
Currently, when trying to use `--cloud-alias` when adding a Departing Employee or a High Risk Employee, it fails if the employee already has a cloud alias..
This will remove the other cloud aliases before adding the new one