### PR TITLE
Show correct profile name when resetting default

### DIFF
--- a/src/code42cli/cmds/profile.py
+++ b/src/code42cli/cmds/profile.py
@@ -102,8 +102,8 @@ def reset_pw(profile_name):
     Change the stored password for a profile. Only affects what's stored in the local profile,
     does not make any changes to the Code42 user account."""
     password = getpass()
-    _set_pw(profile_name, password)
-    echo("Password updated for profile '{}'".format(profile_name))
+    profile_name_saved = _set_pw(profile_name, password)
+    echo("Password updated for profile '{}'.".format(profile_name_saved))
 
 
 @profile.command("list")
@@ -171,3 +171,4 @@ def _set_pw(profile_name, password):
         secho("Password not stored!", bold=True)
         raise
     cliprofile.set_password(password, c42profile.name)
+    return c42profile.name

--- a/tests/cmds/test_profile.py
+++ b/tests/cmds/test_profile.py
@@ -390,7 +390,7 @@ def test_delete_all_deletes_all_existing_profiles(
     mock_cliprofile_namespace.delete_profile.assert_any_call("test2")
 
 
-def test_prompt_for_password_reset_if_credentials_valid_password_saved(
+def test_reset_password_reset_if_credentials_valid_password_saved(
     runner, mocker, user_agreement, mock_verify, mock_cliprofile_namespace
 ):
     mock_verify.return_value = True
@@ -401,7 +401,7 @@ def test_prompt_for_password_reset_if_credentials_valid_password_saved(
     )
 
 
-def test_prompt_for_password_reset_if_credentials_invalid_password_not_saved(
+def test_reset_password_reset_if_credentials_invalid_password_not_saved(
     runner, user_agreement, mock_verify, mock_cliprofile_namespace
 ):
     mock_verify.side_effect = Code42CLIError("Invalid credentials for user")

--- a/tests/cmds/test_profile.py
+++ b/tests/cmds/test_profile.py
@@ -415,11 +415,15 @@ def test_reset_pw_uses_default_profile_when_not_given_one(
 ):
     mock_verify.return_value = True
     mock_cliprofile_namespace.profile_exists.return_value = False
+    mock_profile = create_mock_profile("one")
+    mock_cliprofile_namespace.get_profile.return_value = mock_profile
     res = runner.invoke(cli, ["profile", "reset-pw"])
     mock_cliprofile_namespace.set_password.assert_called_once_with(
         "newpassword", mocker.ANY
     )
-    assert "Password updated for profile ''." in res.output
+    assert "Password updated for profile 'one'." in res.output
+
+
 def test_list_profiles(runner, mock_cliprofile_namespace):
     profiles = [
         create_mock_profile("one"),

--- a/tests/cmds/test_profile.py
+++ b/tests/cmds/test_profile.py
@@ -390,7 +390,7 @@ def test_delete_all_deletes_all_existing_profiles(
     mock_cliprofile_namespace.delete_profile.assert_any_call("test2")
 
 
-def test_reset_password_reset_if_credentials_valid_password_saved(
+def test_reset_pw_if_credentials_valid_password_saved(
     runner, mocker, user_agreement, mock_verify, mock_cliprofile_namespace
 ):
     mock_verify.return_value = True
@@ -401,7 +401,7 @@ def test_reset_password_reset_if_credentials_valid_password_saved(
     )
 
 
-def test_reset_password_reset_if_credentials_invalid_password_not_saved(
+def test_reset_pw_if_credentials_invalid_password_not_saved(
     runner, user_agreement, mock_verify, mock_cliprofile_namespace
 ):
     mock_verify.side_effect = Code42CLIError("Invalid credentials for user")
@@ -410,6 +410,16 @@ def test_reset_password_reset_if_credentials_invalid_password_not_saved(
     assert not mock_cliprofile_namespace.set_password.call_count
 
 
+def test_reset_pw_uses_default_profile_when_not_given_one(
+    runner, mocker, user_agreement, mock_verify, mock_cliprofile_namespace
+):
+    mock_verify.return_value = True
+    mock_cliprofile_namespace.profile_exists.return_value = False
+    res = runner.invoke(cli, ["profile", "reset-pw"])
+    mock_cliprofile_namespace.set_password.assert_called_once_with(
+        "newpassword", mocker.ANY
+    )
+    assert "Password updated for profile ''." in res.output
 def test_list_profiles(runner, mock_cliprofile_namespace):
     profiles = [
         create_mock_profile("one"),


### PR DESCRIPTION
When not providing a profile name, it would say `Password updated for profile 'None'.`
This fixes that.