### PR TITLE
Integration tests- Fix exit status code of command execution 

### DIFF
--- a/integration/__init__.py
+++ b/integration/__init__.py
@@ -27,8 +27,10 @@ def run_command(command):
             output = process.before
             response = encode_response(output).splitlines()
     except pexpect.TIMEOUT:
-        return 1, response
-    return 0, response
+        process.close()
+        return process.exitstatus, response
+    process.close()
+    return process.exitstatus, response
 
 
 __all__ = [run_command]

--- a/integration/test_auditlogs.py
+++ b/integration/test_auditlogs.py
@@ -1,13 +1,15 @@
 from datetime import datetime
 from datetime import timedelta
 
+import pytest
 from integration import run_command
 
-BASE_COMMAND = "code42 auditlogs search -b"
+BASE_COMMAND = "code42 audit-logs search -b"
+begin_date = datetime.utcnow() - timedelta(days=-10)
+begin_date_str = begin_date.strftime("%Y-%m-%d %H:%M:%S")
 
 
-def test_auditlogs_search():
-    begin_date = datetime.utcnow() - timedelta(days=-10)
-    begin_date_str = begin_date.strftime("%Y-%m-%d %H:%M:%S")
-    return_code, response = run_command(BASE_COMMAND + begin_date_str)
+@pytest.mark.parametrize("command", [("{} '{}'".format(BASE_COMMAND, begin_date_str))])
+def test_auditlogs_search(command):
+    return_code, response = run_command(command)
     assert return_code == 0


### PR DESCRIPTION
Read command exit status using `process` module instead of returning hard-coded values.

**Testing Procedure**

`python integration.py [username] [password]`

Did you remember to do the below?

- [ NA]   Add unit tests to verify this change
- [ NA]   Add an entry to CHANGELOG.md describing this change
- [ NA]  Add docstrings for any new public parameters / methods / classes