### PR TITLE
Add pre-test setup and post test cleanup for `send-to` command

### DIFF
--- a/tests/cmds/test_auditlogs.py
+++ b/tests/cmds/test_auditlogs.py
@@ -5,9 +5,6 @@ from logging import Logger
 
 import pytest
 from py42.response import Py42Response
-from tests.integration.util import DockerDaemon
-from tests.integration.util import SyslogServer
-from tests.integration import run_command
 from requests import Response
 
 from code42cli.click_ext.types import MagicDate
@@ -438,32 +435,3 @@ def test_audit_log_parse_timestamp_handles_possible_strings():
     ts1 = _parse_audit_log_timestamp_string_to_timestamp(TIMESTAMP_WITH_MILLISECONDS)
     ts2 = _parse_audit_log_timestamp_string_to_timestamp(TIMESTAMP_WITHOUT_MILLISECONDS)
     assert ts1 == ts2
-
-
-begin_date = datetime.utcnow() - timedelta(days=-10)
-begin_date_str = begin_date.strftime("%Y-%m-%d %H:%M:%S")
-
-@pytest.fixture
-def data_transfer():
-    with DockerDaemon():
-        print("docker daemon started")
-        with SyslogServer():
-            print("syslog server started")
-            yield run_command
-
-
-@pytest.mark.parametrize(
-    "command",
-    [
-        (
-            "code42 audit-logs send-to localhost -p TCP -b '{}'".format(
-                begin_date_str
-            )
-        )
-    ],
-)
-def test_auditlogs_send_to(data_transfer, command):
-    exit_status, response = data_transfer(command)
-    print(exit_status)
-    print(response)
-    assert exit_status == 0

--- a/tests/integration/test_auditlogs.py
+++ b/tests/integration/test_auditlogs.py
@@ -15,7 +15,7 @@ end_date = datetime.utcnow() - timedelta(days=0)
 end_date_str = end_date.strftime("%Y-%m-%d %H:%M:%S")
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def data_transfer():
     with DockerDaemon():
         with SyslogServer():
@@ -25,13 +25,7 @@ def data_transfer():
 @pytest.mark.integration
 @pytest.mark.parametrize(
     "command",
-    [
-        (
-            "code42 audit-logs send-to localhost -p TCP -b '{}'".format(
-                begin_date_str
-            )
-        )
-    ],
+    [("code42 audit-logs send-to localhost -p TCP -b '{}'".format(begin_date_str))],
 )
 def test_auditlogs_send_to(data_transfer, command):
     exit_status, response = data_transfer(command)
@@ -70,6 +64,3 @@ def test_auditlogs_send_to(data_transfer, command):
 def test_auditlogs_search_command_returns_success_return_code(command):
     return_code, response = run_command(command)
     assert return_code == 0
-
-
-

--- a/tests/integration/test_auditlogs.py
+++ b/tests/integration/test_auditlogs.py
@@ -9,22 +9,16 @@ from tests.integration.util import SyslogServer
 
 SEARCH_COMMAND = "code42 audit-logs search"
 BASE_COMMAND = "{} -b".format(SEARCH_COMMAND)
-begin_date = datetime.utcnow() - timedelta(days=-10)
+begin_date = datetime.utcnow() - timedelta(days=2)
 begin_date_str = begin_date.strftime("%Y-%m-%d %H:%M:%S")
-end_date = datetime.utcnow() - timedelta(days=10)
+end_date = datetime.utcnow() - timedelta(days=0)
 end_date_str = end_date.strftime("%Y-%m-%d %H:%M:%S")
 
 
-begin_date = datetime.utcnow() - timedelta(days=-10)
-begin_date_str = begin_date.strftime("%Y-%m-%d %H:%M:%S")
-
-
-@pytest.fixture
+@pytest.fixture(scope='session')
 def data_transfer():
     with DockerDaemon():
-        print("docker daemon started")
         with SyslogServer():
-            print("syslog server started")
             yield run_command
 
 
@@ -41,12 +35,9 @@ def data_transfer():
 )
 def test_auditlogs_send_to(data_transfer, command):
     exit_status, response = data_transfer(command)
-    print(exit_status)
-    print(response)
     assert exit_status == 0
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize(
     "command",
     [

--- a/tests/integration/util.py
+++ b/tests/integration/util.py
@@ -1,4 +1,7 @@
 import os
+import time
+
+from integration import run_command
 
 
 class cleanup:
@@ -17,7 +20,7 @@ def cleanup_after_validation(filename):
     execution.
 
     The decorated function should return validation function that takes the content of the file
-    as input. e.g `test_alerts.py::test_alert_writes_to_file_and_filters_result_by_severity`
+    as input. e.g
     """
 
     def wrap(test_function):
@@ -30,3 +33,73 @@ def cleanup_after_validation(filename):
         return wrapper
 
     return wrap
+
+
+class DockerDaemon:
+    def __init__(self):
+        self.process_name = None
+
+    def __enter__(self):
+        # Need to change to Unix
+        if not self._check_docker_state():
+            mac_command = "open --background -a Docker"
+            exit_status, _ = run_command(mac_command)
+            if exit_status == 0:
+                self._wait_for_docker_daemon_to_be_up()
+            else:
+                # Fail here, raise exception
+                pass
+        self._set_docker_process_name()
+
+    def _check_docker_state(self):
+        exit_status, _ = run_command("docker info")
+        if exit_status == 0:
+            return True
+        return False
+
+    def _wait_for_docker_daemon_to_be_up(self):
+        while True:
+            if self._check_docker_state():
+                break
+            time.sleep(10)
+
+    def _set_docker_process_name(self):
+        # Need to change to Unix
+        mac_command = (
+            '/bin/bash -c "launchctl list | grep docker | cut -f3 | grep -v helper"'
+        )
+        exit_status, response = run_command(mac_command)
+        print(f"process name is {response[0]}")
+        if exit_status == 0:
+            self.process_name = response[0]
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # Need to change to Unix
+        if self.process_name is not None:
+            stop_command = f"launchctl stop {self.process_name}"
+            exit_status, response = run_command(stop_command)
+            if (
+                exit_status != 0
+            ):  # being explicit here, if exit_status too should be ok.
+                print(f"Failed to stop the docker daemon, error {response}")
+
+
+class SyslogServer:
+    def __enter__(self):
+        # TODO change hard-coded path
+        command = "/bin/bash -c 'docker ps | grep test-server_centossyslog_1'"
+        exit_status, response = run_command(command)
+        print(f"docker ps command response: {response}")
+        if exit_status != 0:
+            command = (
+                "sh /Users/kchaudhary/workspace/test-server/start-syslog-server.sh"
+            )
+            exit_status, response = run_command(command)
+            print(f"shell script response: {response}")
+            if exit_status != 0:
+                # Fail here, raise exception
+                pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        command = "docker stop test-server_centossyslog_1"
+        exit_status, response = run_command(command)

--- a/tests/integration/util.py
+++ b/tests/integration/util.py
@@ -37,12 +37,13 @@ def cleanup_after_validation(filename):
 
 START_DOCKER_DAEMON_COMMAND = "open --background -a Docker"
 DOCKER_INFO_COMMAND = "docker info"
-GET_DOCKER_PROCESS_NAME_COMMAND = '/bin/bash -c "launchctl list | grep docker | cut -f3 | grep -v helper"'
+GET_DOCKER_PROCESS_NAME_COMMAND = (
+    '/bin/bash -c "launchctl list | grep docker | cut -f3 | grep -v helper"'
+)
 STOP_DOCKER_DAEMON_COMMAND = "launchctl stop {}"
 
 
 class DockerDaemon:
-
     def __init__(self):
         self.process_name = None
 
@@ -79,8 +80,10 @@ class DockerDaemon:
     def __exit__(self, exc_type, exc_val, exc_tb):
         # Need to change to Unix
         if self.process_name is not None:
-            exit_status, response = run_command(STOP_DOCKER_DAEMON_COMMAND.format(self.process_name))
-            if exit_status != 0:  
+            exit_status, response = run_command(
+                STOP_DOCKER_DAEMON_COMMAND.format(self.process_name)
+            )
+            if exit_status != 0:
                 print("Failed to stop the docker daemon, error {}".format(response))
 
 
@@ -90,12 +93,14 @@ class SyslogServer:
 
     def __enter__(self):
         if not os.environ[SyslogServer.PATH_ENV]:
-            raise Exception("Set environment variable: {}".format(SyslogServer.PATH_ENV))
+            raise Exception(
+                "Set environment variable: {}".format(SyslogServer.PATH_ENV)
+            )
         exit_status, response = run_command("docker-compose up")
         if exit_status != 0:
             raise Exception("Could not start syslog server.")
-        
+
     def __exit__(self, exc_type, exc_val, exc_tb):
         exit_status, response = run_command("docker-compose down")
-        if exit_status !=0:
+        if exit_status != 0:
             print("Failed to stop syslog server.")

--- a/tests/integration/util.py
+++ b/tests/integration/util.py
@@ -1,7 +1,7 @@
 import os
 import time
 
-from integration import run_command
+from tests.integration import run_command
 
 
 class cleanup:
@@ -36,6 +36,7 @@ def cleanup_after_validation(filename):
 
 
 class DockerDaemon:
+
     def __init__(self):
         self.process_name = None
 
@@ -85,14 +86,20 @@ class DockerDaemon:
 
 
 class SyslogServer:
+
+    SCRIPT_NAME = "start-syslog-server.sh"
+    PATH_ENV = "DOCKER_SCRIPT_PATH"
+
     def __enter__(self):
         # TODO change hard-coded path
+        if not os.environ[SyslogServer.PATH_ENV]:
+            raise Exception("Set environment variable: {}".format(SyslogServer.PATH_ENV))
         command = "/bin/bash -c 'docker ps | grep test-server_centossyslog_1'"
         exit_status, response = run_command(command)
         print(f"docker ps command response: {response}")
         if exit_status != 0:
             command = (
-                "sh /Users/kchaudhary/workspace/test-server/start-syslog-server.sh"
+                "{0}{1}".format(os.environ[SyslogServer.PATH_ENV], SyslogServer.SCRIPT_NAME)
             )
             exit_status, response = run_command(command)
             print(f"shell script response: {response}")
@@ -101,5 +108,5 @@ class SyslogServer:
                 pass
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        command = "docker stop test-server_centossyslog_1"
+        command = "docker-compose down"
         exit_status, response = run_command(command)


### PR DESCRIPTION
**Description**
Added integration tests for `send-to` commands.

Creates a server using `ncat` tool at port 5140 on localhost.
Executes actual command to test.
Closes the server.