### PR TITLE
remove formatting options from `audit-logs send-to`

### DIFF
--- a/src/code42cli/cmds/auditlogs.py
+++ b/src/code42cli/cmds/auditlogs.py
@@ -14,7 +14,6 @@ from code42cli.options import begin_option
 from code42cli.options import end_option
 from code42cli.options import format_option
 from code42cli.options import sdk_options
-from code42cli.options import send_to_format_options
 from code42cli.options import server_options
 from code42cli.output_formats import OutputFormatter
 from code42cli.util import hash_event
@@ -167,13 +166,11 @@ def search(
 @filter_options
 @checkpoint_option
 @server_options
-@send_to_format_options
 @sdk_options()
 def send_to(
     state,
     hostname,
     protocol,
-    format,
     begin,
     end,
     event_type,
@@ -184,8 +181,8 @@ def send_to(
     affected_username,
     use_checkpoint,
 ):
-    """Send audit logs to the given server address."""
-    logger = get_logger_for_server(hostname, protocol, format)
+    """Send audit logs to the given server address in JSON format."""
+    logger = get_logger_for_server(hostname, protocol, "JSON")
     cursor = _get_audit_log_cursor_store(state.profile.name)
     if use_checkpoint:
         checkpoint_name = use_checkpoint

--- a/src/code42cli/cmds/auditlogs.py
+++ b/src/code42cli/cmds/auditlogs.py
@@ -182,7 +182,7 @@ def send_to(
     use_checkpoint,
 ):
     """Send audit logs to the given server address in JSON format."""
-    logger = get_logger_for_server(hostname, protocol, "JSON")
+    logger = get_logger_for_server(hostname, protocol, "RAW-JSON")
     cursor = _get_audit_log_cursor_store(state.profile.name)
     if use_checkpoint:
         checkpoint_name = use_checkpoint


### PR DESCRIPTION
Because CEF format doesn't make sense, and the difference between JSON and RAW-JSON for `send-to` only really applies to file events. I've removed the `--format` option completely from `audit-logs send-to`.