### PR TITLE
Faster test run

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,12 @@ This will also test that the documentation build passes and run the style checks
 $ tox -e py
 ```
 
+If you want to run the integration tests in your current python environment, you can do:
+
+```bash
+pytest -m "integration"
+```
+
 ### Writing tests
 
 Put actual before expected values in assert statements. Pytest assumes this order.

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ commands =
     # -l: show locals in tracebacks
     # --tb=short: short traceback print mode
     # --strict: marks not registered in configuration file raise errors
-    pytest --cov=code42cli --cov-report xml -v -rsxX -l --tb=short --strict -m --ignore=integration
+    pytest --cov=code42cli --cov-report xml -v -rsxX -l --tb=short --strict --ignore=integration
 
 [testenv:docs]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ commands =
     # -l: show locals in tracebacks
     # --tb=short: short traceback print mode
     # --strict: marks not registered in configuration file raise errors
-    pytest --cov=code42cli --cov-report xml -v -rsxX -l --tb=short --strict -m "not integration"
+    pytest --cov=code42cli --cov-report xml -v -rsxX -l --tb=short --strict -m --ignore=integration
 
 [testenv:docs]
 deps =


### PR DESCRIPTION
Make the tox unit tests command faster
Adds section in contributing for how to run integration tests:

```pytest -m "integration"```

