### PR TITLE
move added feature to Added section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,13 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 # Unreleased
 
-- The `devices` command is added. Included are:
-    - `devices deactivate` to deactivate a single computer
-    - `devices show` to retrieve detailed information about a computer
-    - `devices list` to retrieve info about many devices, including device settings
-    - `devices bulk deactivate` to deactivate a list of devices
-
 # Added
+
+- The `devices` command is added. Included are:
+    - `devices deactivate` to deactivate a single computer.
+    - `devices show` to retrieve detailed information about a computer.
+    - `devices list` to retrieve info about many devices, including device settings.
+    - `devices bulk deactivate` to deactivate a list of devices.
 
 - `code42 departing-employee list` command.
 


### PR DESCRIPTION
* Puts the devices command underneath the header `Added`. It previously was under the upper-level `Unreleased` header.