### PR TITLE
Added help text for hostname

### DIFF
--- a/src/code42cli/cmds/alerts.py
+++ b/src/code42cli/cmds/alerts.py
@@ -274,7 +274,10 @@ def send_to(
     or_query,
     **kwargs
 ):
-    """Send alerts to the given server address."""
+    """Send alerts to the given server address.
+
+    HOSTNAME format: address:port where port is optional and defaults to 514.
+    """
     logger = get_logger_for_server(hostname, protocol, format)
     cursor = _get_alert_cursor_store(cli_state.profile.name) if use_checkpoint else None
     handlers = ext.create_send_to_handlers(

--- a/src/code42cli/cmds/auditlogs.py
+++ b/src/code42cli/cmds/auditlogs.py
@@ -177,7 +177,10 @@ def send_to(
     affected_username,
     use_checkpoint,
 ):
-    """Send audit logs to the given server address in JSON format."""
+    """Send audit logs to the given server address in JSON format.
+
+    HOSTNAME format: address:port where port is optional and defaults to 514.
+    """
     logger = get_logger_for_server(hostname, protocol, "RAW-JSON")
     cursor = _get_audit_log_cursor_store(state.profile.name)
     if use_checkpoint:

--- a/src/code42cli/cmds/securitydata.py
+++ b/src/code42cli/cmds/securitydata.py
@@ -337,7 +337,10 @@ def send_to(
     or_query,
     **kwargs,
 ):
-    """Send events to the given server address."""
+    """Send events to the given server address.
+
+    HOSTNAME format: address:port where port is optional and defaults to 514.
+    """
     logger = get_logger_for_server(hostname, protocol, format)
     cursor = (
         _get_file_event_cursor_store(state.profile.name) if use_checkpoint else None


### PR DESCRIPTION
Improve help text for `send-to`  command

Added help text for `hostname` argument to highlight the default port being used for data transfer.