### PR TITLE
Only use pager for large amounts when echoing dfs

### DIFF
--- a/src/code42cli/output_formats.py
+++ b/src/code42cli/output_formats.py
@@ -113,7 +113,7 @@ class DataFrameOutputFormatter:
 
     def echo_formatted_dataframe(self, output, *args, **kwargs):
         str_output = self._format_output(output, *args, **kwargs)
-        if len(output) < 10:
+        if len(output) <= 10:
             click.echo(str_output)
         else:
             click.echo_via_pager(str_output)

--- a/src/code42cli/output_formats.py
+++ b/src/code42cli/output_formats.py
@@ -116,7 +116,7 @@ class DataFrameOutputFormatter:
         if len(output) < 10:
             click.echo(str_output)
         else:
-            click.echo_via_pager(output)
+            click.echo_via_pager(str_output)
 
 
 def to_csv(output):

--- a/src/code42cli/output_formats.py
+++ b/src/code42cli/output_formats.py
@@ -112,7 +112,11 @@ class DataFrameOutputFormatter:
         return self._format_func(output, *args, **self._output_args)
 
     def echo_formatted_dataframe(self, output, *args, **kwargs):
-        click.echo_via_pager(self._format_output(output, *args, **kwargs))
+        str_output = self._format_output(output, *args, **kwargs)
+        if len(output) < 10:
+            click.echo(str_output)
+        else:
+            click.echo_via_pager(output)
 
 
 def to_csv(output):

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -245,3 +245,5 @@ class TestDataFrameOutputFormatter:
         formatter = output_formats_module.DataFrameOutputFormatter(None)
         formatter.echo_formatted_dataframe(TEST_DATAFRAME)
         mock_dataframe_to_string.assert_called_once_with(TEST_DATAFRAME, index=False)
+
+    def test_echo_formatted_dataframe_when_output_has_less_than_1

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -245,5 +245,3 @@ class TestDataFrameOutputFormatter:
         formatter = output_formats_module.DataFrameOutputFormatter(None)
         formatter.echo_formatted_dataframe(TEST_DATAFRAME)
         mock_dataframe_to_string.assert_called_once_with(TEST_DATAFRAME, index=False)
-
-    def test_echo_formatted_dataframe_when_output_has_less_than_1


### PR DESCRIPTION
This preserves behavior of not using the pager for small amounts of records.