### PR TITLE
org and split up tests

### DIFF
--- a/src/code42cli/cmds/cases.py
+++ b/src/code42cli/cmds/cases.py
@@ -17,6 +17,9 @@ from code42cli.output_formats import OutputFormatter
 
 
 case_number_arg = click.argument("case-number", type=int)
+case_number_option = click.option(
+    "--case-number", type=int, help="The number assigned to the case.", required=True
+)
 name_option = click.option("--name", help="Name of the case.",)
 assignee_option = click.option("--assignee", help="User UID of the assignee.")
 description_option = click.option("--description", help="Description of the case.")
@@ -225,7 +228,7 @@ def file_events_list(state, case_number, format):
 
 
 @file_events.command()
-@case_number_arg
+@case_number_option
 @file_event_id_option
 @sdk_options()
 def add(state, case_number, event_id):
@@ -237,7 +240,7 @@ def add(state, case_number, event_id):
 
 
 @file_events.command()
-@case_number_arg
+@case_number_option
 @file_event_id_option
 @sdk_options()
 def remove(state, case_number, event_id):

--- a/tests/cmds/test_cases.py
+++ b/tests/cmds/test_cases.py
@@ -30,13 +30,12 @@ ALL_CASES = """{
   "totalCount": 31
 }"""
 CASE_DETAILS = '{"number": 3, "name": "test@test.test"}'
-CASES_COMMAND = "cases"
-CASES_FILE_EVENTS_COMMAND = "cases file-events"
 MISSING_ARGUMENT_ERROR = "Missing argument '{}'."
 MISSING_NAME = MISSING_ARGUMENT_ERROR.format("NAME")
-MISSING_CASE_NUMBER = MISSING_ARGUMENT_ERROR.format("CASE_NUMBER")
+MISSING_CASE_NUMBER_ARG = MISSING_ARGUMENT_ERROR.format("CASE_NUMBER")
 MISSING_OPTION_ERROR = "Missing option '--{}'."
 MISSING_EVENT_ID = MISSING_OPTION_ERROR.format("event-id")
+MISSING_CASE_NUMBER_OPTION = MISSING_OPTION_ERROR.format("case-number")
 
 
 @pytest.fixture
@@ -83,6 +82,13 @@ def test_create_with_optional_fields_calls_create_with_expected_params(
     cli_state.sdk.cases.create.assert_called_once_with(
         "TEST_CASE", assignee="a", description="d", findings="n", subject="s"
     )
+
+
+def test_create_when_missing_name_prints_error(runner, cli_state):
+    command = ["cases", "create", "--description", "d"]
+    result = runner.invoke(cli, command, obj=cli_state)
+    assert result.exit_code == 2
+    assert MISSING_NAME in result.output
 
 
 def test_update_with_optional_fields_calls_update_with_expected_params(
@@ -135,11 +141,31 @@ def test_update_calls_update_with_expected_params(runner, cli_state):
     )
 
 
+def test_update_when_missing_case_number_prints_error(runner, cli_state):
+    command = ["cases", "update", "--description", "d"]
+    result = runner.invoke(cli, command, obj=cli_state)
+    assert result.exit_code == 2
+    assert MISSING_CASE_NUMBER_ARG in result.output
+
+
 def test_list_calls_get_all_with_expected_params(runner, cli_state):
     runner.invoke(
         cli, ["cases", "list"], obj=cli_state,
     )
     assert cli_state.sdk.cases.get_all.call_count == 1
+
+
+def test_list_prints_expected_data(runner, cli_state, py42_response):
+    py42_response.data = json.loads(ALL_CASES)
+
+    def gen():
+        yield py42_response.data
+
+    cli_state.sdk.cases.get_all.return_value = gen()
+    result = runner.invoke(cli, ["cases", "list"], obj=cli_state,)
+    assert "test@test.test" in result.output
+    assert "2021-01-24T11:00:04.217878Z" in result.output
+    assert "942897" in result.output
 
 
 def test_show_calls_get_case_with_expected_params(runner, cli_state):
@@ -158,39 +184,7 @@ def test_show_with_include_file_events_calls_file_events_get_all_with_expected_p
     cli_state.sdk.cases.file_events.get_all.assert_called_once_with(1)
 
 
-def test_export_calls_export_summary_with_expected_params(runner, cli_state, mocker):
-    with mock.patch("builtins.open", mock_open()) as mf:
-        runner.invoke(
-            cli, ["cases", "export", "1"], obj=cli_state,
-        )
-        cli_state.sdk.cases.export_summary.assert_called_once_with(1)
-        mf.assert_called_once_with("./1_case_summary.pdf", "wb")
-
-
-def test_file_events_add_calls_add_event_with_expected_params(runner, cli_state):
-    runner.invoke(
-        cli, ["cases", "file-events", "add", "1", "--event-id", "1"], obj=cli_state,
-    )
-    cli_state.sdk.cases.file_events.add.assert_called_once_with(1, "1")
-
-
-def test_file_events_remove_calls_delete_event_with_expected_params(runner, cli_state):
-    runner.invoke(
-        cli, ["cases", "file-events", "remove", "1", "--event-id", "1"], obj=cli_state,
-    )
-    cli_state.sdk.cases.file_events.delete.assert_called_once_with(1, "1")
-
-
-def test_file_events_list_calls_get_all_with_expected_params(runner, cli_state):
-    runner.invoke(
-        cli, ["cases", "file-events", "list", "1"], obj=cli_state,
-    )
-    cli_state.sdk.cases.file_events.get_all.assert_called_once_with(1)
-
-
-def test_show_when_py42_raises_exception_returns_error_message(
-    runner, cli_state, error
-):
+def test_show_when_py42_raises_exception_prints_error_message(runner, cli_state, error):
     cli_state.sdk.cases.file_events.get_all.side_effect = Py42NotFoundError(error)
     result = runner.invoke(
         cli, ["cases", "show", "1", "--include-file-events"], obj=cli_state,
@@ -199,49 +193,14 @@ def test_show_when_py42_raises_exception_returns_error_message(
     assert "Invalid case-number 1." in result.output
 
 
-def test_file_events_add_when_py42_raises_exception_returns_error_message(
-    runner, cli_state, error
-):
-    cli_state.sdk.cases.file_events.add.side_effect = Py42BadRequestError(error)
-    result = runner.invoke(
-        cli, ["cases", "file-events", "add", "1", "--event-id", "1"], obj=cli_state,
-    )
-    cli_state.sdk.cases.file_events.add.assert_called_once_with(1, "1")
-    assert "Invalid case-number or event-id." in result.output
-
-
-def test_file_events_remove_when_py42_raises_exception_returns_error_message(
-    runner, cli_state, error
-):
-    cli_state.sdk.cases.file_events.delete.side_effect = Py42NotFoundError(error)
-    result = runner.invoke(
-        cli, ["cases", "file-events", "remove", "1", "--event-id", "1"], obj=cli_state,
-    )
-    cli_state.sdk.cases.file_events.delete.assert_called_once_with(1, "1")
-    assert "Invalid case-number or event-id." in result.output
-
-
-def test_show_returns_expected_data(runner, cli_state, py42_response):
+def test_show_prints_expected_data(runner, cli_state, py42_response):
     py42_response.data = json.loads(CASE_DETAILS)
     cli_state.sdk.cases.get.return_value = py42_response
     result = runner.invoke(cli, ["cases", "show", "1"], obj=cli_state,)
     assert "test@test.test" in result.output
 
 
-def test_list_returns_expected_data(runner, cli_state, py42_response):
-    py42_response.data = json.loads(ALL_CASES)
-
-    def gen():
-        yield py42_response.data
-
-    cli_state.sdk.cases.get_all.return_value = gen()
-    result = runner.invoke(cli, ["cases", "list"], obj=cli_state,)
-    assert "test@test.test" in result.output
-    assert "2021-01-24T11:00:04.217878Z" in result.output
-    assert "942897" in result.output
-
-
-def test_show_returns_expected_data_with_include_file_events_option(
+def test_show_prints_expected_data_with_include_file_events_option(
     runner, cli_state, py42_response
 ):
     py42_response.text = ALL_EVENTS
@@ -255,7 +214,109 @@ def test_show_returns_expected_data_with_include_file_events_option(
     )
 
 
-def test_events_list_returns_expected_data(runner, cli_state):
+def test_show_case_when_missing_case_number_prints_error(runner, cli_state):
+    command = ["cases", "show"]
+    result = runner.invoke(cli, command, obj=cli_state)
+    assert result.exit_code == 2
+    assert MISSING_CASE_NUMBER_ARG in result.output
+
+
+def test_export_calls_export_summary_with_expected_params(runner, cli_state, mocker):
+    with mock.patch("builtins.open", mock_open()) as mf:
+        runner.invoke(
+            cli, ["cases", "export", "1"], obj=cli_state,
+        )
+        cli_state.sdk.cases.export_summary.assert_called_once_with(1)
+        mf.assert_called_once_with("./1_case_summary.pdf", "wb")
+
+
+def test_export_when_missing_case_number_prints_error(runner, cli_state):
+    command = ["cases", "export"]
+    result = runner.invoke(cli, command, obj=cli_state)
+    assert result.exit_code == 2
+    assert MISSING_CASE_NUMBER_ARG in result.output
+
+
+def test_file_events_add_calls_add_event_with_expected_params(runner, cli_state):
+    runner.invoke(
+        cli,
+        ["cases", "file-events", "add", "--case-number", "1", "--event-id", "1"],
+        obj=cli_state,
+    )
+    cli_state.sdk.cases.file_events.add.assert_called_once_with(1, "1")
+
+
+def test_file_events_add_when_py42_raises_exception_prints_error_message(
+    runner, cli_state, error
+):
+    cli_state.sdk.cases.file_events.add.side_effect = Py42BadRequestError(error)
+    result = runner.invoke(
+        cli,
+        ["cases", "file-events", "add", "--case-number", "1", "--event-id", "1"],
+        obj=cli_state,
+    )
+    cli_state.sdk.cases.file_events.add.assert_called_once_with(1, "1")
+    assert "Invalid case-number or event-id." in result.output
+
+
+def test_file_events_add_when_missing_event_id_prints_error(runner, cli_state):
+    command = ["cases", "file-events", "remove", "--case-number", "4"]
+    result = runner.invoke(cli, command, obj=cli_state)
+    assert result.exit_code == 2
+    assert MISSING_EVENT_ID in result.output
+
+
+def test_file_events_add_when_missing_case_number_prints_error(runner, cli_state):
+    command = ["cases", "file-events", "add"]
+    result = runner.invoke(cli, command, obj=cli_state)
+    assert result.exit_code == 2
+    assert MISSING_CASE_NUMBER_OPTION in result.output
+
+
+def test_file_events_remove_calls_delete_event_with_expected_params(runner, cli_state):
+    runner.invoke(
+        cli,
+        ["cases", "file-events", "remove", "--case-number", "1", "--event-id", "1"],
+        obj=cli_state,
+    )
+    cli_state.sdk.cases.file_events.delete.assert_called_once_with(1, "1")
+
+
+def test_file_events_remove_when_py42_raises_exception_prints_error_message(
+    runner, cli_state, error
+):
+    cli_state.sdk.cases.file_events.delete.side_effect = Py42NotFoundError(error)
+    result = runner.invoke(
+        cli,
+        ["cases", "file-events", "remove", "--case-number", "1", "--event-id", "1"],
+        obj=cli_state,
+    )
+    cli_state.sdk.cases.file_events.delete.assert_called_once_with(1, "1")
+    assert "Invalid case-number or event-id." in result.output
+
+
+def test_file_events_remove_when_missing_event_id_prints_error(runner, cli_state):
+    command = ["cases", "file-events", "remove", "--case-number", "4"]
+    result = runner.invoke(cli, command, obj=cli_state)
+    assert result.exit_code == 2
+    assert MISSING_EVENT_ID in result.output
+
+
+def test_file_events_remove_when_missing_case_number_prints_error(runner, cli_state):
+    command = ["cases", "file-events", "add"]
+    result = runner.invoke(cli, command, obj=cli_state)
+    assert result.exit_code == 2
+    assert MISSING_CASE_NUMBER_OPTION in result.output
+
+
+def test_file_events_list_calls_get_all_with_expected_params(runner, cli_state):
+    runner.invoke(
+        cli, ["cases", "file-events", "list", "1"], obj=cli_state,
+    )
+    cli_state.sdk.cases.file_events.get_all.assert_called_once_with(1)
+
+
+def test_file_events_list_prints_expected_data(runner, cli_state):
     cli_state.sdk.cases.file_events.get_all.return_value = json.loads(ALL_EVENTS)
     result = runner.invoke(cli, ["cases", "file-events", "list", "1"], obj=cli_state,)
     assert (
@@ -265,28 +326,8 @@ def test_events_list_returns_expected_data(runner, cli_state):
     assert "2020-12-23T12:41:38.592Z" in result.output
 
 
-@pytest.mark.parametrize(
-    "command, error_msg",
-    [
-        ("{} create --description d".format(CASES_COMMAND), MISSING_NAME),
-        ("{} update --description d".format(CASES_COMMAND), MISSING_CASE_NUMBER),
-        ("{} show".format(CASES_COMMAND), MISSING_CASE_NUMBER),
-        ("{} export".format(CASES_COMMAND), MISSING_CASE_NUMBER),
-        ("{} add".format(CASES_FILE_EVENTS_COMMAND), MISSING_CASE_NUMBER),
-        ("{} add --event-id 3".format(CASES_FILE_EVENTS_COMMAND), MISSING_CASE_NUMBER),
-        ("{} add 3".format(CASES_FILE_EVENTS_COMMAND), MISSING_EVENT_ID),
-        ("{} remove 3".format(CASES_FILE_EVENTS_COMMAND), MISSING_EVENT_ID),
-        ("{} remove".format(CASES_FILE_EVENTS_COMMAND), MISSING_CASE_NUMBER),
-        (
-            "{} remove --event-id 3".format(CASES_FILE_EVENTS_COMMAND),
-            MISSING_CASE_NUMBER,
-        ),
-        ("{} list".format(CASES_FILE_EVENTS_COMMAND), MISSING_CASE_NUMBER),
-    ],
-)
-def test_cases_command_when_missing_required_parameters_errors(
-    command, error_msg, runner, cli_state
-):
-    result = runner.invoke(cli, command.split(" "), obj=cli_state)
+def test_file_events_list_when_missing_case_number_prints_error(runner, cli_state):
+    command = ["cases", "file-events", "list"]
+    result = runner.invoke(cli, command, obj=cli_state)
     assert result.exit_code == 2
-    assert error_msg in "".join(result.output)
+    assert MISSING_CASE_NUMBER_ARG in result.output


### PR DESCRIPTION
* makes case number an option rather than an arg for the commands `code42 cases file-events add` and `code42 cases file-events remove` per the rule where if we have multiple required args, we use options instead so that arg order cannot be confused.

When fixing the tests after this change, I found it really hard to know where all the tests were since they were not organized. Also, there was a large and complex parameterized test that is easier to work with if broken up into separate tests, so this pr also organized and splits up those tests