### PR TITLE
JSON output format and other fixes

### DIFF
--- a/src/code42cli/cmds/cases.py
+++ b/src/code42cli/cmds/cases.py
@@ -20,10 +20,14 @@ case_number_option = click.option(
     "--case-number", type=int, help="The number assigned to the case.", required=True
 )
 name_option = click.option("--name", help="The name of the case.",)
-assignee_option = click.option("--assignee", help="The UID of the user assigned to the case.")
+assignee_option = click.option(
+    "--assignee", help="The UID of the user to assign to the case."
+)
 description_option = click.option("--description", help="The description of the case.")
 findings_option = click.option("--findings", help="Any findings for the case.")
-subject_option = click.option("--subject", help="The user UID of the subject of the case.")
+subject_option = click.option(
+    "--subject", help="The user UID of the subject of the case."
+)
 status_option = click.option(
     "--status",
     help="Status of the case. `OPEN` or `CLOSED`.",
@@ -32,7 +36,6 @@ status_option = click.option(
 file_event_id_option = click.option(
     "--event-id", required=True, help="The file event ID associated to the case."
 )
-
 CASES_KEYWORD = "cases"
 BEGIN_DATE_DICT = set_begin_default_dict(CASES_KEYWORD)
 END_DATE_DICT = set_end_default_dict(CASES_KEYWORD)

--- a/src/code42cli/cmds/cases.py
+++ b/src/code42cli/cmds/cases.py
@@ -112,10 +112,10 @@ def update(state, case_number, name, subject, assignee, description, findings, s
 
 @cases.command("list")
 @click.option(
-    "--name", help="Filter by name of a case, supports partial name matches.",
+    "--name", help="Filter by name of a case. Supports partial name matches.",
 )
-@click.option("--subject", help="Filter by user UID of the subject of a case.")
-@click.option("--assignee", help="Filter by user UID of assignee.")
+@click.option("--subject", help="Filter by the user UID of the subject of a case.")
+@click.option("--assignee", help="Filter by the user UID of an assignee.")
 @click.option("--begin-create-time", **BEGIN_DATE_DICT)
 @click.option("--end-create-time", **END_DATE_DICT)
 @click.option("--begin-update-time", **BEGIN_DATE_DICT)

--- a/src/code42cli/cmds/cases.py
+++ b/src/code42cli/cmds/cases.py
@@ -189,7 +189,9 @@ def show(state, case_number, format, include_file_events):
 @cases.command()
 @case_number_arg
 @click.option(
-    "--path", help="File path. Defaults to the current directory.", default="."
+    "--path",
+    help="The file path where to save the PDF. Defaults to the current directory.",
+    default=".",
 )
 @sdk_options()
 def export(state, case_number, path):

--- a/src/code42cli/cmds/cases.py
+++ b/src/code42cli/cmds/cases.py
@@ -34,7 +34,7 @@ status_option = click.option(
     type=click.Choice(CaseStatus.choices()),
 )
 file_event_id_option = click.option(
-    "--event-id", required=True, help="The file event ID associated to the case."
+    "--event-id", required=True, help="The file event ID associated with the case."
 )
 CASES_KEYWORD = "cases"
 BEGIN_DATE_DICT = set_begin_default_dict(CASES_KEYWORD)

--- a/src/code42cli/cmds/cases.py
+++ b/src/code42cli/cmds/cases.py
@@ -19,18 +19,18 @@ case_number_arg = click.argument("case-number", type=int)
 case_number_option = click.option(
     "--case-number", type=int, help="The number assigned to the case.", required=True
 )
-name_option = click.option("--name", help="Name of the case.",)
-assignee_option = click.option("--assignee", help="User UID of the assignee.")
-description_option = click.option("--description", help="Description of the case.")
-findings_option = click.option("--findings", help="Findings on the case.")
-subject_option = click.option("--subject", help="User UID of a subject of the case.")
+name_option = click.option("--name", help="The name of the case.",)
+assignee_option = click.option("--assignee", help="The UID of the user assigned to the case.")
+description_option = click.option("--description", help="The description of the case.")
+findings_option = click.option("--findings", help="Any findings for the case.")
+subject_option = click.option("--subject", help="The user UID of the subject of the case.")
 status_option = click.option(
     "--status",
     help="Status of the case. `OPEN` or `CLOSED`.",
     type=click.Choice(CaseStatus.choices()),
 )
 file_event_id_option = click.option(
-    "--event-id", required=True, help="File event id associated to the case."
+    "--event-id", required=True, help="The file event ID associated to the case."
 )
 
 CASES_KEYWORD = "cases"

--- a/src/code42cli/cmds/cases.py
+++ b/src/code42cli/cmds/cases.py
@@ -191,7 +191,7 @@ def show(state, case_number, format, include_file_events):
 @click.option(
     "--path",
     help="The file path where to save the PDF. Defaults to the current directory.",
-    default=".",
+    default=os.getcwd(),
 )
 @sdk_options()
 def export(state, case_number, path):

--- a/src/code42cli/cmds/cases.py
+++ b/src/code42cli/cmds/cases.py
@@ -1,6 +1,5 @@
 import json
 import os
-from pprint import pformat
 
 import click
 from py42.clients.cases import CaseStatus
@@ -162,7 +161,7 @@ def _get_file_events(sdk, case_number):
 def _display_file_events(events):
     if events:
         click.echo("\nFile Events:\n")
-        click.echo(pformat(events))
+        click.echo(json.dumps(events, indent=4))
     else:
         click.echo("\nNo events found.")
 

--- a/src/code42cli/cmds/devices.py
+++ b/src/code42cli/cmds/devices.py
@@ -485,7 +485,7 @@ bulk.add_command(devices_generate_template)
 @bulk.command(name="deactivate")
 @read_csv_arg(headers=_bulk_device_activation_headers)
 @change_device_name_option(
-    "Prepend 'deactivated_<current_date>' to the name of any deactivated devices."
+    "Prepend 'deactivated_<current_date>' to the name of any successfully deactivated devices."
 )
 @purge_date_option
 @format_option

--- a/src/code42cli/cmds/devices.py
+++ b/src/code42cli/cmds/devices.py
@@ -43,6 +43,7 @@ def change_device_name_option(help_msg):
         help=help_msg,
     )
 
+
 DATE_FORMAT = "%Y-%m-%d"
 purge_date_option = click.option(
     "--purge-date",
@@ -56,7 +57,9 @@ purge_date_option = click.option(
 
 @devices.command()
 @device_guid_argument
-@change_device_name_option("Prepend 'deactivated_<current_date>' to the name of the deactivated device.")
+@change_device_name_option(
+    "Prepend 'deactivated_<current_date>' to the device if deactivation is successful."
+)
 @purge_date_option
 @sdk_options()
 def deactivate(state, device_guid, change_device_name, purge_date):
@@ -481,7 +484,9 @@ bulk.add_command(devices_generate_template)
 
 @bulk.command(name="deactivate")
 @read_csv_arg(headers=_bulk_device_activation_headers)
-@change_device_name_option("Prepend 'deactivated_<current_date>' to the name of any deactivated devices.")
+@change_device_name_option(
+    "Prepend 'deactivated_<current_date>' to the name of any deactivated devices."
+)
 @purge_date_option
 @format_option
 @sdk_options()

--- a/src/code42cli/cmds/devices.py
+++ b/src/code42cli/cmds/devices.py
@@ -33,13 +33,15 @@ device_guid_argument = click.argument(
     "device-guid", type=str, callback=lambda ctx, param, arg: _verify_guid_type(arg),
 )
 
-change_device_name_option = click.option(
-    "--change-device-name",
-    required=False,
-    is_flag=True,
-    default=False,
-    help="Prepend 'deactivated_<current_date>' to the name of any deactivated devices.",
-)
+
+def change_device_name_option(help_msg):
+    return click.option(
+        "--change-device-name",
+        required=False,
+        is_flag=True,
+        default=False,
+        help=help_msg,
+    )
 
 DATE_FORMAT = "%Y-%m-%d"
 purge_date_option = click.option(
@@ -54,7 +56,7 @@ purge_date_option = click.option(
 
 @devices.command()
 @device_guid_argument
-@change_device_name_option
+@change_device_name_option("Prepend 'deactivated_<current_date>' to the name of the deactivated device.")
 @purge_date_option
 @sdk_options()
 def deactivate(state, device_guid, change_device_name, purge_date):
@@ -479,7 +481,7 @@ bulk.add_command(devices_generate_template)
 
 @bulk.command(name="deactivate")
 @read_csv_arg(headers=_bulk_device_activation_headers)
-@change_device_name_option
+@change_device_name_option("Prepend 'deactivated_<current_date>' to the name of any deactivated devices.")
 @purge_date_option
 @format_option
 @sdk_options()

--- a/src/code42cli/cmds/devices.py
+++ b/src/code42cli/cmds/devices.py
@@ -58,7 +58,7 @@ purge_date_option = click.option(
 @devices.command()
 @device_guid_argument
 @change_device_name_option(
-    "Prepend 'deactivated_<current_date>' to the device if deactivation is successful."
+    "Prepend 'deactivated_<current_date>' to the name of the device if deactivation is successful."
 )
 @purge_date_option
 @sdk_options()

--- a/tests/cmds/test_cases.py
+++ b/tests/cmds/test_cases.py
@@ -1,4 +1,5 @@
 import json
+import os
 from unittest import mock
 from unittest.mock import mock_open
 
@@ -227,7 +228,8 @@ def test_export_calls_export_summary_with_expected_params(runner, cli_state, moc
             cli, ["cases", "export", "1"], obj=cli_state,
         )
         cli_state.sdk.cases.export_summary.assert_called_once_with(1)
-        mf.assert_called_once_with("./1_case_summary.pdf", "wb")
+        expected = os.path.join(os.getcwd(), "1_case_summary.pdf")
+        mf.assert_called_once_with(expected, "wb")
 
 
 def test_export_when_missing_case_number_prints_error(runner, cli_state):


### PR DESCRIPTION
* Use `json.dumps()` rather than `pprint` to follow suit with other `show` commands' output format.
* Impove doc strings language
* Change default param from `"."` to `os.getwd()`