### PR TITLE
add hidden yes_option to `profile create` cmd

### DIFF
--- a/src/code42cli/cmds/profile.py
+++ b/src/code42cli/cmds/profile.py
@@ -70,6 +70,7 @@ def show(profile_name):
 @server_option
 @username_option
 @password_option
+@yes_option(hidden=True)
 @disable_ssl_option
 def create(name, server, username, password, disable_ssl_errors):
     """Create profile settings. The first profile created will be the default."""
@@ -128,7 +129,7 @@ def use(profile_name):
 
 
 @profile.command()
-@yes_option
+@yes_option()
 @profile_name_arg(required=True)
 def delete(profile_name):
     """Deletes a profile and its stored password (if any)."""
@@ -143,7 +144,7 @@ def delete(profile_name):
 
 
 @profile.command()
-@yes_option
+@yes_option()
 def delete_all():
     """Deletes all profiles and saved passwords (if any)."""
     existing_profiles = cliprofile.get_all_profiles()

--- a/src/code42cli/options.py
+++ b/src/code42cli/options.py
@@ -14,14 +14,17 @@ from code42cli.profile import get_profile
 from code42cli.sdk_client import create_sdk
 
 
-yes_option = click.option(
-    "-y",
-    "--assume-yes",
-    is_flag=True,
-    expose_value=False,
-    callback=lambda ctx, param, value: ctx.obj.set_assume_yes(value),
-    help='Assume "yes" as the answer to all prompts and run non-interactively.',
-)
+def yes_option(hidden=False):
+    return click.option(
+        "-y",
+        "--assume-yes",
+        is_flag=True,
+        expose_value=False,
+        callback=lambda ctx, param, value: ctx.obj.set_assume_yes(value),
+        help='Assume "yes" as the answer to all prompts and run non-interactively.',
+        hidden=hidden,
+    )
+
 
 format_option = click.option(
     "-f",


### PR DESCRIPTION
This change allows us to create a temp profile in integration tests with a single command without having to worry about prompts if the keyring backend isn't available, we can just for accept the flat file backend with `-y`.

I made the flag hidden since it's a bit of an edge case just for our testing environment and doesn't necessarily need to be exposed to end-users. 