### PR TITLE
Raise exception instead of echo in alert-rules add when rule-id is invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
     - `cases file-events add` sets an event id that is already added to the case.
     - `cases file-events remove` is performed on an already closed case.
 
+### Fixes
+
+- Fixes issue where `code42 alert-rules bulk add` would show as successful when adding users to a non-existent alert rule.
+
 ### Added
 
 - New choice `TLS-TCP` for `--protocol` option used by `send-to` commands:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,9 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
     - `cases file-events add` sets an event id that is already added to the case.
     - `cases file-events remove` is performed on an already closed case.
 
-### Fixes
+### Fixed
 
-- Fixes issue where `code42 alert-rules bulk add` would show as successful when adding users to a non-existent alert rule.
+- Issue where `code42 alert-rules bulk add` would show as successful when adding users to a non-existent alert rule.
 
 ### Added
 

--- a/src/code42cli/cmds/alert_rules.py
+++ b/src/code42cli/cmds/alert_rules.py
@@ -183,7 +183,7 @@ def _handle_rules_results(rules, rule_id=None):
     if not rules:
         id_msg = "with RuleId {} ".format(rule_id) if rule_id else ""
         msg = "No alert rules {}found.".format(id_msg)
-        echo(msg)
+        raise Code42CLIError(msg)
     return rules
 
 

--- a/tests/cmds/test_alert_rules.py
+++ b/tests/cmds/test_alert_rules.py
@@ -169,7 +169,7 @@ def test_add_user_when_rule_not_found_prints_expected_output(mocker, runner, cli
         ["alert-rules", "add-user", "--rule-id", TEST_RULE_ID, "-u", TEST_USERNAME],
         obj=cli_state,
     )
-    assert "No alert rules with RuleId rule-id found." in result.output
+    assert "Error: No alert rules with RuleId rule-id found." in result.output
 
 
 def test_remove_user_removes_user_list_from_alert_rules(runner, cli_state):


### PR DESCRIPTION
**Description**

- Raise exception when rule-id is invalid, make error message adhere to format

**Issues Resolved**
INTEG-1470

Did you remember to do the below?

- [x] Add unit tests to verify this change

- [x] Add an entry to CHANGELOG.md describing this change

- [n/a] Add docstrings for any new public parameters / methods / classes