### PR TITLE
Disallow TLS specific args for non-TLS

### DIFF
--- a/src/code42cli/cmds/search/__init__.py
+++ b/src/code42cli/cmds/search/__init__.py
@@ -46,5 +46,5 @@ def _handle_incompatible_args(protocol, ignore_cert_validation, certs):
     )
     if arg is not None:
         raise Code42CLIError(
-            f"'{arg}' must be used with '--protocol {ServerProtocol.TLS_TCP}'."
+            f"'{arg}' can only be used with '--protocol {ServerProtocol.TLS_TCP}'."
         )

--- a/src/code42cli/cmds/search/__init__.py
+++ b/src/code42cli/cmds/search/__init__.py
@@ -43,6 +43,6 @@ def _handle_incompatible_args(protocol, ignore_cert_validation, certs):
     elif certs is not None:
         arg = "--certs"
     if arg is not None:
-        raise Code42CLIError(
-            f"'{arg}' can only be used with '--protocol {ServerProtocol.TLS_TCP}'."
+        raise click.BadOptionUsage(
+            arg, f"'{arg}' can only be used with '--protocol {ServerProtocol.TLS_TCP}'."
         )

--- a/src/code42cli/cmds/search/__init__.py
+++ b/src/code42cli/cmds/search/__init__.py
@@ -2,6 +2,7 @@ import click
 
 from code42cli.errors import Code42CLIError
 from code42cli.logger import get_logger_for_server
+from code42cli.logger.enums import ServerProtocol
 from code42cli.output_formats import OutputFormat
 
 
@@ -21,6 +22,8 @@ class SendToCommand(click.Command):
         protocol = ctx.params.get("protocol")
         output_format = ctx.params.get("format", OutputFormat.RAW)
         ignore_cert_validation = ctx.params.get("ignore_cert_validation")
+        _handle_incompatible_args(protocol, ignore_cert_validation, certs)
+
         if ignore_cert_validation:
             certs = "ignore"
 
@@ -28,3 +31,17 @@ class SendToCommand(click.Command):
             hostname, protocol, output_format, certs
         )
         return super().invoke(ctx)
+
+
+def _handle_incompatible_args(protocol, ignore_cert_validation, certs):
+    if protocol != ServerProtocol.TLS_TCP:
+        arg = None
+        if ignore_cert_validation is not None:
+            arg = "--ignore-cert-validation"
+        elif certs is not None:
+            arg = "--certs"
+
+        if arg is not None:
+            raise Code42CLIError(
+                f"'{arg}' must be used with '--protocol {ServerProtocol.TLS_TCP}'."
+            )

--- a/src/code42cli/cmds/search/__init__.py
+++ b/src/code42cli/cmds/search/__init__.py
@@ -34,14 +34,17 @@ class SendToCommand(click.Command):
 
 
 def _handle_incompatible_args(protocol, ignore_cert_validation, certs):
-    if protocol != ServerProtocol.TLS_TCP:
-        arg = None
-        if ignore_cert_validation is not None:
-            arg = "--ignore-cert-validation"
-        elif certs is not None:
-            arg = "--certs"
+    if protocol == ServerProtocol.TLS_TCP:
+        return
 
-        if arg is not None:
-            raise Code42CLIError(
-                f"'{arg}' must be used with '--protocol {ServerProtocol.TLS_TCP}'."
-            )
+    arg = (
+        "--ignore-cert-validation"
+        if ignore_cert_validation is not None
+        else "--certs"
+        if certs is not None
+        else None
+    )
+    if arg is not None:
+        raise Code42CLIError(
+            f"'{arg}' must be used with '--protocol {ServerProtocol.TLS_TCP}'."
+        )

--- a/src/code42cli/cmds/search/__init__.py
+++ b/src/code42cli/cmds/search/__init__.py
@@ -37,13 +37,11 @@ def _handle_incompatible_args(protocol, ignore_cert_validation, certs):
     if protocol == ServerProtocol.TLS_TCP:
         return
 
-    arg = (
-        "--ignore-cert-validation"
-        if ignore_cert_validation is not None
-        else "--certs"
-        if certs is not None
-        else None
-    )
+    arg = None
+    if ignore_cert_validation is not None:
+        arg = "--ignore-cert-validation"
+    elif certs is not None:
+        arg = "--certs"
     if arg is not None:
         raise Code42CLIError(
             f"'{arg}' can only be used with '--protocol {ServerProtocol.TLS_TCP}'."

--- a/src/code42cli/cmds/search/options.py
+++ b/src/code42cli/cmds/search/options.py
@@ -162,6 +162,7 @@ def server_options(f):
         help="Set to skip CA certificate validation. "
         "Incompatible with the 'certs' option.",
         is_flag=True,
+        default=None,
         cls=incompatible_with(["certs"]),
     )
     f = hostname_arg(f)

--- a/tests/cmds/test_alerts.py
+++ b/tests/cmds/test_alerts.py
@@ -808,7 +808,7 @@ def test_send_to_when_given_ignore_cert_validation_with_non_tls_protocol_fails_e
         obj=cli_state,
     )
     assert (
-        "'--ignore-cert-validation' must be used with '--protocol TLS-TCP'"
+        "'--ignore-cert-validation' can only be used with '--protocol TLS-TCP'"
         in res.output
     )
 
@@ -832,7 +832,7 @@ def test_send_to_when_given_certs_with_non_tls_protocol_fails_expectedly(
         ],
         obj=cli_state,
     )
-    assert "'--certs' must be used with '--protocol TLS-TCP'" in res.output
+    assert "'--certs' can only be used with '--protocol TLS-TCP'" in res.output
 
 
 def test_get_alert_details_batches_results_according_to_batch_size(sdk):

--- a/tests/cmds/test_alerts.py
+++ b/tests/cmds/test_alerts.py
@@ -789,6 +789,52 @@ def test_send_to_when_given_ignore_cert_validation_uses_certs_equal_to_ignore_st
     )
 
 
+@pytest.mark.parametrize("protocol", (ServerProtocol.UDP, ServerProtocol.TCP))
+def test_send_to_when_given_ignore_cert_validation_with_non_tls_protocol_fails_expectedly(
+    cli_state, runner, protocol
+):
+    res = runner.invoke(
+        cli,
+        [
+            "alerts",
+            "send-to",
+            "0.0.0.0",
+            "--begin",
+            "1d",
+            "--protocol",
+            protocol,
+            "--ignore-cert-validation",
+        ],
+        obj=cli_state,
+    )
+    assert (
+        "'--ignore-cert-validation' must be used with '--protocol TLS-TCP'"
+        in res.output
+    )
+
+
+@pytest.mark.parametrize("protocol", (ServerProtocol.UDP, ServerProtocol.TCP))
+def test_send_to_when_given_certs_with_non_tls_protocol_fails_expectedly(
+    cli_state, runner, protocol
+):
+    res = runner.invoke(
+        cli,
+        [
+            "alerts",
+            "send-to",
+            "0.0.0.0",
+            "--begin",
+            "1d",
+            "--protocol",
+            protocol,
+            "--certs",
+            "certs.pem",
+        ],
+        obj=cli_state,
+    )
+    assert "'--certs' must be used with '--protocol TLS-TCP'" in res.output
+
+
 def test_get_alert_details_batches_results_according_to_batch_size(sdk):
     extraction._ALERT_DETAIL_BATCH_SIZE = 2
     sdk.alerts.get_details.side_effect = ALERT_DETAIL_RESULT

--- a/tests/cmds/test_auditlogs.py
+++ b/tests/cmds/test_auditlogs.py
@@ -311,6 +311,52 @@ def test_send_to_emits_events_in_chronological_order(
     )
 
 
+@pytest.mark.parametrize("protocol", (ServerProtocol.UDP, ServerProtocol.TCP))
+def test_send_to_when_given_ignore_cert_validation_with_non_tls_protocol_fails_expectedly(
+    cli_state, runner, protocol
+):
+    res = runner.invoke(
+        cli,
+        [
+            "audit-logs",
+            "send-to",
+            "0.0.0.0",
+            "--begin",
+            "1d",
+            "--protocol",
+            protocol,
+            "--ignore-cert-validation",
+        ],
+        obj=cli_state,
+    )
+    assert (
+        "'--ignore-cert-validation' must be used with '--protocol TLS-TCP'"
+        in res.output
+    )
+
+
+@pytest.mark.parametrize("protocol", (ServerProtocol.UDP, ServerProtocol.TCP))
+def test_send_to_when_given_certs_with_non_tls_protocol_fails_expectedly(
+    cli_state, runner, protocol
+):
+    res = runner.invoke(
+        cli,
+        [
+            "audit-logs",
+            "send-to",
+            "0.0.0.0",
+            "--begin",
+            "1d",
+            "--protocol",
+            protocol,
+            "--certs",
+            "certs.pem",
+        ],
+        obj=cli_state,
+    )
+    assert "'--certs' must be used with '--protocol TLS-TCP'" in res.output
+
+
 @search_and_send_to_test
 def test_search_and_send_to_with_checkpoint_saves_expected_cursor_timestamp(
     cli_state,

--- a/tests/cmds/test_auditlogs.py
+++ b/tests/cmds/test_auditlogs.py
@@ -330,7 +330,7 @@ def test_send_to_when_given_ignore_cert_validation_with_non_tls_protocol_fails_e
         obj=cli_state,
     )
     assert (
-        "'--ignore-cert-validation' must be used with '--protocol TLS-TCP'"
+        "'--ignore-cert-validation' can only be used with '--protocol TLS-TCP'"
         in res.output
     )
 
@@ -354,7 +354,7 @@ def test_send_to_when_given_certs_with_non_tls_protocol_fails_expectedly(
         ],
         obj=cli_state,
     )
-    assert "'--certs' must be used with '--protocol TLS-TCP'" in res.output
+    assert "'--certs' can only be used with '--protocol TLS-TCP'" in res.output
 
 
 @search_and_send_to_test

--- a/tests/cmds/test_securitydata.py
+++ b/tests/cmds/test_securitydata.py
@@ -317,7 +317,7 @@ def test_send_to_when_given_ignore_cert_validation_with_non_tls_protocol_fails_e
         obj=cli_state,
     )
     assert (
-        "'--ignore-cert-validation' must be used with '--protocol TLS-TCP'"
+        "'--ignore-cert-validation' can only be used with '--protocol TLS-TCP'"
         in res.output
     )
 
@@ -341,7 +341,7 @@ def test_send_to_when_given_certs_with_non_tls_protocol_fails_expectedly(
         ],
         obj=cli_state,
     )
-    assert "'--certs' must be used with '--protocol TLS-TCP'" in res.output
+    assert "'--certs' can only be used with '--protocol TLS-TCP'" in res.output
 
 
 @search_and_send_to_test

--- a/tests/cmds/test_securitydata.py
+++ b/tests/cmds/test_securitydata.py
@@ -298,6 +298,52 @@ def test_send_to_with_saved_search_and_incompatible_argument_errors(
     assert "{} can't be used with: --saved-search".format(arg[0]) in result.output
 
 
+@pytest.mark.parametrize("protocol", (ServerProtocol.UDP, ServerProtocol.TCP))
+def test_send_to_when_given_ignore_cert_validation_with_non_tls_protocol_fails_expectedly(
+    cli_state, runner, protocol
+):
+    res = runner.invoke(
+        cli,
+        [
+            "security-data",
+            "send-to",
+            "0.0.0.0",
+            "--begin",
+            "1d",
+            "--protocol",
+            protocol,
+            "--ignore-cert-validation",
+        ],
+        obj=cli_state,
+    )
+    assert (
+        "'--ignore-cert-validation' must be used with '--protocol TLS-TCP'"
+        in res.output
+    )
+
+
+@pytest.mark.parametrize("protocol", (ServerProtocol.UDP, ServerProtocol.TCP))
+def test_send_to_when_given_certs_with_non_tls_protocol_fails_expectedly(
+    cli_state, runner, protocol
+):
+    res = runner.invoke(
+        cli,
+        [
+            "security-data",
+            "send-to",
+            "0.0.0.0",
+            "--begin",
+            "1d",
+            "--protocol",
+            protocol,
+            "--certs",
+            "certs.pem",
+        ],
+        obj=cli_state,
+    )
+    assert "'--certs' must be used with '--protocol TLS-TCP'" in res.output
+
+
 @search_and_send_to_test
 def test_search_and_send_to_when_given_begin_and_end_dates_uses_expected_query(
     runner, cli_state, file_event_extractor, command


### PR DESCRIPTION
* Fixes issue where the user was still allowed to pass in `--certs` and `--ignore-cert-validation` when not using the `TLS-TCP` protocol for `send-to` commands.