### PR TITLE
Bugfix/windows log ssl error

### DIFF
--- a/src/code42cli/logger/handlers.py
+++ b/src/code42cli/logger/handlers.py
@@ -85,7 +85,7 @@ class NoPrioritySysLogHandler(SysLogHandler):
         them nowhere.
         """
         t, _, _ = sys.exc_info()
-        if t == BrokenPipeError:
+        if ConnectionError in t.__bases__:
             raise SyslogServerNetworkConnectionError()
         super().handleError(record)
 


### PR DESCRIPTION
Fixes issue where Windows would not raise an error when sending TCP to a TLS server.
The fix works by catching a common base class between the operating systems instead of the `BrokenPipError` that we saw originally. 
On WIndows, I observed the error was `ConnectionResetError`.
Both `BrokenPipeError` and `ConnectionResetError` share the base class `ConnectionError`.

Questions:

* Are there any concerns catching the other errors that inherit the base class? Subclasses are `BrokenPipeError`, `ConnectionAbortedError`, `ConnectionRefusedError` and `ConnectionResetError`.

* Is there a more preferred way to check the base classes?