### PR TITLE
handle windows log error from ssl connection

### DIFF
--- a/src/code42cli/logger/handlers.py
+++ b/src/code42cli/logger/handlers.py
@@ -85,7 +85,7 @@ class NoPrioritySysLogHandler(SysLogHandler):
         them nowhere.
         """
         t, _, _ = sys.exc_info()
-        if t == BrokenPipeError:
+        if ConnectionError in t.__bases__:
             raise SyslogServerNetworkConnectionError()
         super().handleError(record)
 

--- a/src/code42cli/logger/handlers.py
+++ b/src/code42cli/logger/handlers.py
@@ -14,7 +14,7 @@ class SyslogServerNetworkConnectionError(Exception):
         super().__init__(
             "The network connection broke while sending results. "
             "This might happen if your connection requires TLS and you are attempting "
-            "unencrypted TCP communication"
+            "unencrypted TCP communication."
         )
 
 

--- a/src/code42cli/logger/handlers.py
+++ b/src/code42cli/logger/handlers.py
@@ -85,7 +85,7 @@ class NoPrioritySysLogHandler(SysLogHandler):
         them nowhere.
         """
         t, _, _ = sys.exc_info()
-        if ConnectionError in t.__bases__:
+        if issubclass(t, ConnectionError):
             raise SyslogServerNetworkConnectionError()
         super().handleError(record)
 

--- a/src/code42cli/logger/handlers.py
+++ b/src/code42cli/logger/handlers.py
@@ -11,7 +11,11 @@ class SyslogServerNetworkConnectionError(Exception):
     """An error raised when the connection is disrupted during logging."""
 
     def __init__(self):
-        super().__init__("Network connection broken while sending results.")
+        super().__init__(
+            "The network connection broke while sending results. "
+            "This might happen if your connection requires TLS and you are attempting "
+            "unencrypted TCP communication"
+        )
 
 
 class NoPrioritySysLogHandler(SysLogHandler):

--- a/tests/logger/test_handlers.py
+++ b/tests/logger/test_handlers.py
@@ -48,11 +48,20 @@ def socket_mocks(mocker):
     return mocks
 
 
+def system_exception_info(mocker):
+    return mocker.patch("code42cli.logger.handlers.sys.exc_info")
+
+
 @pytest.fixture()
-def broken_pipe_error(mocker):
-    mock_exc_info = mocker.patch("code42cli.logger.handlers.sys.exc_info")
-    mock_exc_info.return_value = (BrokenPipeError, None, None)
-    return mock_exc_info
+def broken_pipe_error(system_exception_info):
+    system_exception_info.return_value = (BrokenPipeError, None, None)
+    return system_exception_info
+
+
+@pytest.fixture()
+def connection_reset_error(system_exception_info):
+    system_exception_info.return_value = (ConnectionResetError, None, None)
+    return system_exception_info
 
 
 def _get_normal_socket_initializer_mocks(mocker, new_socket):
@@ -204,8 +213,17 @@ class TestNoPrioritySysLogHandler:
             expected_message, (_TEST_HOST, _TEST_PORT)
         )
 
-    def test_handle_error_raises_expected_error(
+    def test_handle_error_when_broken_pipe_error_occurs_raises_expected_error(
         self, mock_file_event_log_record, broken_pipe_error
+    ):
+        handler = NoPrioritySysLogHandler(
+            _TEST_HOST, _TEST_PORT, ServerProtocol.UDP, None
+        )
+        with pytest.raises(SyslogServerNetworkConnectionError):
+            handler.handleError(mock_file_event_log_record)
+
+    def test_handle_error_when_connection_reset_error_occurs_raises_expected_error(
+        self, mock_file_event_log_record, connection_reset_error
     ):
         handler = NoPrioritySysLogHandler(
             _TEST_HOST, _TEST_PORT, ServerProtocol.UDP, None

--- a/tests/logger/test_handlers.py
+++ b/tests/logger/test_handlers.py
@@ -48,6 +48,7 @@ def socket_mocks(mocker):
     return mocks
 
 
+@pytest.fixture()
 def system_exception_info(mocker):
     return mocker.patch("code42cli.logger.handlers.sys.exc_info")
 


### PR DESCRIPTION
Fixes issue where Windows would not raise an error when sending TCP to a TLS server.
The fix works by catching a common base class between the operating systems instead of the BrokenPipError that we saw originally.
On WIndows, I observed the error was ConnectionResetError.
Both BrokenPipeError and ConnectionResetError share the base class ConnectionError.

Questions:

Are there any concerns catching the other errors that inherit the base class? Subclasses are BrokenPipeError, ConnectionAbortedError, ConnectionRefusedError and ConnectionResetError.

Is there a more preferred way to check the base classes?