### PR TITLE
prefix error

### DIFF
--- a/src/code42cli/cmds/search/extraction.py
+++ b/src/code42cli/cmds/search/extraction.py
@@ -58,7 +58,12 @@ def _set_handlers(cursor_store, checkpoint_name):
         else:
             message = exception
         logger.log_error(message)
-        secho(str(message), err=True, fg="red")
+
+        message = str(message)
+        if not message.lower().startswith("error:"):
+            message = f"Error: {message}"
+
+        secho(message, err=True, fg="red")
 
     handlers.handle_error = handle_error
     if cursor_store:

--- a/tests/cmds/test_auditlogs.py
+++ b/tests/cmds/test_auditlogs.py
@@ -61,9 +61,6 @@ TEST_EVENTS_WITH_DIFFERENT_TIMESTAMPS = [
         "timestamp": TEST_AUDIT_LOG_TIMESTAMP_3,
     },
 ]
-TEST_CHECKPOINT_EVENT_HASHLIST = [
-    hash_event(event) for event in TEST_EVENTS_WITH_SAME_TIMESTAMP
-]
 search_and_send_to_test = get_mark_for_search_and_send_to("audit-logs")
 
 

--- a/tests/cmds/test_securitydata.py
+++ b/tests/cmds/test_securitydata.py
@@ -773,13 +773,10 @@ def test_search_and_send_to_when_extraction_handles_error_expected_message_logge
 ):
     errors.ERRORED = False
     exception_msg = "Test Exception"
-
-    def file_search_error(x):
-        raise Exception(exception_msg)
-
-    cli_state.sdk.securitydata.search_file_events.side_effect = file_search_error
+    cli_state.sdk.securitydata.search_file_events.side_effect = Exception(exception_msg)
     with caplog.at_level(logging.ERROR):
         result = runner.invoke(cli, [*command, "--begin", "1d"], obj=cli_state)
+        assert "Error:" in result.output
         assert exception_msg in result.output
         assert exception_msg in caplog.text
         assert errors.ERRORED


### PR DESCRIPTION
Nikunj pointed out that `Error:` (the prefix) only showed up for `audit-logs` when the connection was interrupted during `send-to`. This make it appear on `alerts` and `security-data` as well, for a consistent experience.