### PR TITLE
feature/205-profile-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+## Unreleased
+
+### Changed
+
+- Command options for `profile update`:
+    - `-n` `--name` is not required, and if omitted with use default profile.
+    - `-s` `--server` and `-u` `--username` are not required and can be updated independently now.
+    - Example: `code42 profile update -s 1.2.3.4:1234`
+
 ## 1.3.0 - 2021-02-11
 
 ### Fixed

--- a/src/code42cli/cmds/profile.py
+++ b/src/code42cli/cmds/profile.py
@@ -25,15 +25,15 @@ def profile_name_arg(required=False):
 name_option = click.option(
     "-n",
     "--name",
-    required=True,
+    required=False,
     help="The name of the Code42 CLI profile to use when executing this command.",
 )
 server_option = click.option(
-    "-s", "--server", required=True, help="The URL you use to sign into Code42.",
+    "-s", "--server", required=False, help="The URL you use to sign into Code42.",
 )
 
 username_option = click.option(
-    "-u", "--username", required=True, help="The username of the Code42 API user.",
+    "-u", "--username", required=False, help="The username of the Code42 API user.",
 )
 
 password_option = click.option(

--- a/src/code42cli/cmds/profile.py
+++ b/src/code42cli/cmds/profile.py
@@ -22,19 +22,32 @@ def profile_name_arg(required=False):
     return click.argument("profile_name", required=required)
 
 
-name_option = click.option(
-    "-n",
-    "--name",
-    required=False,
-    help="The name of the Code42 CLI profile to use when executing this command.",
-)
-server_option = click.option(
-    "-s", "--server", required=False, help="The URL you use to sign into Code42.",
-)
+def name_option(required=False):
+    return click.option(
+        "-n",
+        "--name",
+        required=required,
+        help="The name of the Code42 CLI profile to use when executing this command.",
+    )
 
-username_option = click.option(
-    "-u", "--username", required=False, help="The username of the Code42 API user.",
-)
+
+def server_option(required=False):
+    return click.option(
+        "-s",
+        "--server",
+        required=required,
+        help="The URL you use to sign into Code42.",
+    )
+
+
+def username_option(required=False):
+    return click.option(
+        "-u",
+        "--username",
+        required=required,
+        help="The username of the Code42 API user.",
+    )
+
 
 password_option = click.option(
     "--password",
@@ -66,9 +79,9 @@ def show(profile_name):
 
 
 @profile.command()
-@name_option
-@server_option
-@username_option
+@name_option(required=True)
+@server_option(required=True)
+@username_option(required=True)
 @password_option
 @yes_option(hidden=True)
 @disable_ssl_option
@@ -83,9 +96,9 @@ def create(name, server, username, password, disable_ssl_errors):
 
 
 @profile.command()
-@name_option
-@server_option
-@username_option
+@name_option()
+@server_option()
+@username_option()
 @password_option
 @disable_ssl_option
 def update(name, server, username, password, disable_ssl_errors):

--- a/src/code42cli/profile.py
+++ b/src/code42cli/profile.py
@@ -102,8 +102,6 @@ def switch_default_profile(profile_name):
 def create_profile(name, server, username, ignore_ssl_errors):
     if profile_exists(name):
         raise Code42CLIError("A profile named '{}' already exists.".format(name))
-    if None in {name, server, username}:
-        raise Code42CLIError("You must provide a profile name, server, and username.")
     config_accessor.create_profile(name, server, username, ignore_ssl_errors)
 
 

--- a/src/code42cli/profile.py
+++ b/src/code42cli/profile.py
@@ -102,7 +102,8 @@ def switch_default_profile(profile_name):
 def create_profile(name, server, username, ignore_ssl_errors):
     if profile_exists(name):
         raise Code42CLIError("A profile named '{}' already exists.".format(name))
-
+    if None in {name, server, username}:
+        raise Code42CLIError("You must provide a profile name, server, and username.")
     config_accessor.create_profile(name, server, username, ignore_ssl_errors)
 
 

--- a/tests/cmds/test_profile.py
+++ b/tests/cmds/test_profile.py
@@ -254,6 +254,34 @@ def test_update_profile_updates_existing_profile(
     )
 
 
+def test_update_profile_updates_default_profile(
+    runner, mock_cliprofile_namespace, user_agreement, valid_connection, profile
+):
+    name = "foo"
+    profile.name = name
+    mock_cliprofile_namespace.get_profile.return_value = profile
+    runner.invoke(
+        cli, ["profile", "update", "-s", "bar", "-u", "baz", "--disable-ssl-errors",],
+    )
+    mock_cliprofile_namespace.update_profile.assert_called_once_with(
+        name, "bar", "baz", True
+    )
+
+
+def test_update_profile_updates_name_alone(
+    runner, mock_cliprofile_namespace, user_agreement, valid_connection, profile
+):
+    name = "foo"
+    profile.name = name
+    mock_cliprofile_namespace.get_profile.return_value = profile
+    runner.invoke(
+        cli, ["profile", "update", "-u", "baz", "--disable-ssl-errors",],
+    )
+    mock_cliprofile_namespace.update_profile.assert_called_once_with(
+        name, None, "baz", True
+    )
+
+
 def test_update_profile_if_user_does_not_agree_does_not_save_password(
     runner, mock_cliprofile_namespace, user_disagreement, invalid_connection, profile
 ):

--- a/tests/cmds/test_profile.py
+++ b/tests/cmds/test_profile.py
@@ -261,7 +261,7 @@ def test_update_profile_updates_default_profile(
     profile.name = name
     mock_cliprofile_namespace.get_profile.return_value = profile
     runner.invoke(
-        cli, ["profile", "update", "-s", "bar", "-u", "baz", "--disable-ssl-errors",],
+        cli, ["profile", "update", "-s", "bar", "-u", "baz", "--disable-ssl-errors"],
     )
     mock_cliprofile_namespace.update_profile.assert_called_once_with(
         name, "bar", "baz", True
@@ -275,7 +275,7 @@ def test_update_profile_updates_name_alone(
     profile.name = name
     mock_cliprofile_namespace.get_profile.return_value = profile
     runner.invoke(
-        cli, ["profile", "update", "-u", "baz", "--disable-ssl-errors",],
+        cli, ["profile", "update", "-u", "baz", "--disable-ssl-errors"],
     )
     mock_cliprofile_namespace.update_profile.assert_called_once_with(
         name, None, "baz", True


### PR DESCRIPTION
This PR aims to resolve issue #205 

Args `--name --server --username` are no longer `required=True`. In order to prevent this from allowing users to create profiles with missing information a catch was added to create_profile.