### PR TITLE
Changed 'bulk add-user' to 'bulk add' in userguide

### DIFF
--- a/docs/userguides/legalhold.md
+++ b/docs/userguides/legalhold.md
@@ -31,9 +31,9 @@ To get the ID for a matter, enter `code42 legal-hold list`.
 You can add one or more custodians to a legal hold matter using the Code42 CLI.
 
 ### Add multiple custodians
-Once you have entered the matter ID and user information in the CSV file, use the `bulk add-user` command with the CSV file path to add multiple custodians at once. For example:
+Once you have entered the matter ID and user information in the CSV file, use the `bulk add` command with the CSV file path to add multiple custodians at once. For example:
 
-`code42 legal-hold bulk add-user /Users/admin/add_users_to_legal_hold.csv`
+`code42 legal-hold bulk add /Users/admin/add_users_to_legal_hold.csv`
 
 ### Add a single custodian
 


### PR DESCRIPTION
The "`add-user`" subcommand does not appear to exist under the `legal-hold bulk` command. I've changed these references to "`code42 legal-hold bulk add`"  instead to fit the command that actually worked in user testing and appears in our auto-generated command docs. 

My apologies on not naming the branch according to CONTRIBUTING.md — I didn't see that before creating it and making the changes. 
I'm also not sure where the Pull Request Template is?