### PR TITLE
Feature/select profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+## Unreleased
+
+### Added
+
+- `code42 profile select` command that allows you to select a default profile
+    from a list of all your profiles.
+
 ## 1.4.0 - 2021-03-09
 
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "keyrings.alt==3.2.0",
         "pandas>=1.1.3",
         "py42>=1.11.1",
+        "PyInquirer>=1.0.3",
     ],
     extras_require={
         "dev": [

--- a/src/code42cli/cmds/profile.py
+++ b/src/code42cli/cmds/profile.py
@@ -10,6 +10,7 @@ from code42cli.options import yes_option
 from code42cli.profile import CREATE_PROFILE_HELP
 from code42cli.sdk_client import validate_connection
 from code42cli.util import does_user_agree
+from code42cli.util import get_user_selected_item
 
 
 @click.group()
@@ -147,7 +148,7 @@ def _list():
 def use(profile_name):
     """Set a profile as the default."""
     cliprofile.switch_default_profile(profile_name)
-    echo("{} has been set as the default profile.".format(profile_name))
+    _print_default_profile_set(profile_name)
 
 
 @profile.command()
@@ -183,6 +184,17 @@ def delete_all():
         echo("\nNo profiles exist. Nothing to delete.")
 
 
+@profile.command()
+def select():
+    existing_profiles = cliprofile.get_all_profiles()
+    profile_names = [p.name for p in existing_profiles]
+    selected_profile_name = get_user_selected_item(
+        "Please select a profile", profile_names
+    )
+    cliprofile.switch_default_profile(selected_profile_name)
+    _print_default_profile_set(selected_profile_name)
+
+
 def _prompt_for_allow_password_set(profile_name):
     if does_user_agree("Would you like to set a password? (y/n): "):
         password = getpass()
@@ -198,3 +210,7 @@ def _set_pw(profile_name, password):
         raise
     cliprofile.set_password(password, c42profile.name)
     return c42profile.name
+
+
+def _print_default_profile_set(profile_name):
+    echo("{} has been set as the default profile.".format(profile_name))

--- a/src/code42cli/util.py
+++ b/src/code42cli/util.py
@@ -12,6 +12,7 @@ from signal import signal
 from click import echo
 from click import get_current_context
 from click import style
+from PyInquirer import prompt
 
 _PADDING_SIZE = 3
 
@@ -173,3 +174,14 @@ def hash_event(event):
     if isinstance(event, dict):
         event = json.dumps(event, sort_keys=True)
     return md5(event.encode()).hexdigest()
+
+
+def get_user_selected_item(message, choices):
+    """Prompts the user for which item they would like to pick from a list."""
+    question = {
+        "type": "list",
+        "name": "choice",
+        "message": message,
+        "choices": choices,
+    }
+    return prompt(question)["choice"]

--- a/tests/cmds/test_profile.py
+++ b/tests/cmds/test_profile.py
@@ -505,3 +505,27 @@ def test_use_profile(runner, mock_cliprofile_namespace, profile):
     assert (
         "{} has been set as the default profile.".format(profile.name) in result.output
     )
+
+
+def test_select_profile_sets_selected_profile_as_default(
+    mocker, runner, mock_cliprofile_namespace, profile
+):
+    mock_profile_selector = mocker.patch(
+        f"{PRODUCT_NAME}.cmds.profile.get_user_selected_item"
+    )
+    mock_profile_selector.return_value = "test_profile"
+    runner.invoke(cli, ["profile", "select"])
+    mock_cliprofile_namespace.switch_default_profile.assert_called_once_with(
+        "test_profile"
+    )
+
+
+def test_select_profile_outputs_expected_text(
+    mocker, runner, mock_cliprofile_namespace, profile
+):
+    mock_profile_selector = mocker.patch(
+        f"{PRODUCT_NAME}.cmds.profile.get_user_selected_item"
+    )
+    mock_profile_selector.return_value = "test_profile"
+    result = runner.invoke(cli, ["profile", "select"])
+    assert f"test_profile has been set as the default profile." in result.output


### PR DESCRIPTION
Allows you to select a profile rather than having to first list all your profiles and then select the one you want (in the case where you forgot the name).

`code42 profile select`

vs

`code42 profile list` + `code42 profile use`

__________

This was a fun thing I made because I kept forgetting exact names of my profiles and I wanted to switch from Core Int to Console to Mock Servers etc.

Since it is rather simple and I use it myself, I figured I'd add a couple tests and open PR.

However, this _does_ take on a dependency of `PyInquirer` (which we could potentially use elsewhere).. If we are not comfortable doing that, I can keep this to myself..  I would completely understand.
