### PR TITLE
Bugfix/attempt to autodetect file encodings when reading files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+## Unreleased
+
+### Fixed
+
+- Arguments/options that read data from files now attempt to autodetect file encodings. Resolving a bug where CSVs written 
+  on Windows with Powershell would fail to be read properly. 
+
 ## 1.4.0 - 2021-03-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ### Fixed
 
-- Arguments/options that read data from files now attempt to autodetect file encodings. Resolving a bug where CSVs written 
-  on Windows with Powershell would fail to be read properly. 
+- Arguments/options that read data from files now attempt to autodetect file encodings. Resolving a bug where CSVs written
+  on Windows with Powershell would fail to be read properly.
 
 ## 1.4.0 - 2021-03-09
 

--- a/src/code42cli/click_ext/types.py
+++ b/src/code42cli/click_ext/types.py
@@ -17,7 +17,7 @@ class AutoDecodedFile(click.File):
             with open(value, "rb") as file:
                 self.encoding = chardet.detect(file.read())["encoding"]
             if self.encoding is None:
-                CliLogger.log_error(f"Failed to detect encoding of file: {value}")
+                CliLogger().log_error(f"Failed to detect encoding of file: {value}")
         finally:
             return super().convert(value, param, ctx)
 

--- a/src/code42cli/click_ext/types.py
+++ b/src/code42cli/click_ext/types.py
@@ -25,7 +25,7 @@ class AutoDecodedFile(click.File):
         return super().convert(value, param, ctx)
 
 
-class FileOrString(click.File):
+class FileOrString(AutoDecodedFile):
     """Declares a parameter to be a file (if the argument begins with `@`), otherwise accepts it as
     a string.
     """

--- a/src/code42cli/click_ext/types.py
+++ b/src/code42cli/click_ext/types.py
@@ -3,8 +3,20 @@ from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
 
+import chardet
 import click
 from click.exceptions import BadParameter
+
+
+class AutoDecodedFile(click.File):
+    """Attempts to autodetect file's encoding prior to normal click.File processing."""
+
+    def convert(self, value, param, ctx):
+        try:
+            with open(value, "rb") as file:
+                self.encoding = chardet.detect(file.read())["encoding"]
+        finally:
+            return super().convert(value, param, ctx)
 
 
 class FileOrString(click.File):

--- a/src/code42cli/click_ext/types.py
+++ b/src/code42cli/click_ext/types.py
@@ -6,6 +6,7 @@ from datetime import timezone
 import chardet
 import click
 from click.exceptions import BadParameter
+
 from code42cli.logger import CliLogger
 
 
@@ -18,8 +19,10 @@ class AutoDecodedFile(click.File):
                 self.encoding = chardet.detect(file.read())["encoding"]
             if self.encoding is None:
                 CliLogger().log_error(f"Failed to detect encoding of file: {value}")
-        finally:
-            return super().convert(value, param, ctx)
+        except Exception:
+            pass  # we'll let click.File do it's own exception handling for the filepath
+
+        return super().convert(value, param, ctx)
 
 
 class FileOrString(click.File):

--- a/src/code42cli/click_ext/types.py
+++ b/src/code42cli/click_ext/types.py
@@ -6,6 +6,7 @@ from datetime import timezone
 import chardet
 import click
 from click.exceptions import BadParameter
+from code42cli.logger import CliLogger
 
 
 class AutoDecodedFile(click.File):
@@ -15,6 +16,8 @@ class AutoDecodedFile(click.File):
         try:
             with open(value, "rb") as file:
                 self.encoding = chardet.detect(file.read())["encoding"]
+            if self.encoding is None:
+                CliLogger.log_error(f"Failed to detect encoding of file: {value}")
         finally:
             return super().convert(value, param, ctx)
 

--- a/src/code42cli/file_readers.py
+++ b/src/code42cli/file_readers.py
@@ -2,6 +2,7 @@ import csv
 
 import click
 
+from code42cli.click_ext.types import AutoDecodedFile
 from code42cli.errors import Code42CLIError
 
 
@@ -13,7 +14,7 @@ def read_csv_arg(headers):
     return click.argument(
         "csv_rows",
         metavar="CSV_FILE",
-        type=click.File("r"),
+        type=AutoDecodedFile("r"),
         callback=lambda ctx, param, arg: read_csv(arg, headers=headers),
     )
 

--- a/src/code42cli/file_readers.py
+++ b/src/code42cli/file_readers.py
@@ -66,7 +66,7 @@ def read_flat_file(file):
 
 read_flat_file_arg = click.argument(
     "file_rows",
-    type=click.File("r"),
+    type=AutoDecodedFile("r"),
     metavar="FILE",
     callback=lambda ctx, param, arg: read_flat_file(arg),
 )

--- a/tests/test_file_readers.py
+++ b/tests/test_file_readers.py
@@ -66,7 +66,7 @@ def test_read_csv_when_some_but_not_all_required_headers_present_raises(runner):
 
 
 @pytest.mark.parametrize(
-    "encoding", ["utf8", "utf16", "latin_1"],
+    "encoding", ["ascii", "utf8", "utf16", "latin_1"],
 )
 def test_read_csv_reads_various_encodings_automatically(runner, encoding):
     with runner.isolated_filesystem():


### PR DESCRIPTION
This arose from Pro Services attempting to deactivate devices running the commands on Windows:

```
code42 devices list --<some-filter-options> -f CSV > devices.csv
code42 devices bulk deactivate devices.csv
``

Powershell apparently writes the `> devices.csv` file as UTF-16 encoded, so the `csv_reader` function erroring saying the headers were wrong even though they appeared fine in a text editor. 

This change adds a new click type extension to wrap `click.File` with the `chardet` lib's `detect()` method (`chardet` is already a dependency of requests, so we're not adding anything new). 