### PR TITLE
Bugfix/Win-Newlines-and-use-pager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+## Unreleased
+
+### Fixed
+
+- Bug where some CSV outputs on Windows would have an extra newline between the rows.
+
+### Changed
+
+- `code42 alert-rules list` now uses outputs via pager when the results are greater than 10.
+
+- `code42 cases list` now uses outputs via pager when the results are greater than 10.
+
 ## 1.4.1 - 2021-04-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 - Bug where some CSV outputs on Windows would have an extra newline between the rows.
 
+- Issue where outputting or sending an alert or file-event with a timestamp without
+  decimals would error.
+
 ### Changed
 
 - `code42 alert-rules list` now outputs via a pager when more than 10 rules.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ### Changed
 
-- `code42 alert-rules list` now uses outputs via pager when the results are greater than 10.
+- `code42 alert-rules list` now outputs via a pager when more than 10 rules.
 
-- `code42 cases list` now uses outputs via pager when the results are greater than 10.
+- `code42 cases list` now outputs via a pager when more than 10 cases.
 
 ## 1.4.1 - 2021-04-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,9 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ### Changed
 
-- `code42 alert-rules list` now outputs via a pager when more than 10 rules.
+- `code42 alert-rules list` now outputs via a pager when results contain more than 10 rules.
 
-- `code42 cases list` now outputs via a pager when more than 10 cases.
+- `code42 cases list` now outputs via a pager when results contain more than 10 cases.
 
 ## 1.4.1 - 2021-04-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,6 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
     - `--end` filters based on an end timestamp.
     - `--event-type` filters based on a list of event types.
 
-## 1.4.1 - 2021-04-15
-
 ### Fixed
 
 - Arguments/options that read data from files now attempt to autodetect file encodings.

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "click>=7.1.1",
         "click_plugins>=1.1.1",
         "colorama>=0.4.3",
-        "c42eventextractor==0.4.0",
+        "c42eventextractor==0.4.1",
         "keyring==18.0.1",
         "keyrings.alt==3.2.0",
         "pandas>=1.1.3",

--- a/src/code42cli/cmds/alert_rules.py
+++ b/src/code42cli/cmds/alert_rules.py
@@ -80,7 +80,7 @@ def remove_user(state, rule_id, username):
 @alert_rules.command("list")
 @format_option
 @sdk_options()
-def list_alert_rules(state, format=None):
+def list_alert_rules(state, format):
     """Fetch existing alert rules."""
     formatter = OutputFormatter(format, _HEADER_KEYS_MAP)
     selected_rules = _get_all_rules_metadata(state.sdk)

--- a/src/code42cli/cmds/alert_rules.py
+++ b/src/code42cli/cmds/alert_rules.py
@@ -86,10 +86,7 @@ def list_alert_rules(state, format):
     selected_rules = _get_all_rules_metadata(state.sdk)
 
     if selected_rules:
-        if len(selected_rules) > 10:
-            click.echo_via_pager(formatter.get_formatted_output(selected_rules))
-        else:
-            formatter.echo_formatted_list(selected_rules)
+        formatter.echo_formatted_list(selected_rules)
 
 
 @alert_rules.command()

--- a/src/code42cli/cmds/alert_rules.py
+++ b/src/code42cli/cmds/alert_rules.py
@@ -84,7 +84,10 @@ def list_alert_rules(state, format):
     """Fetch existing alert rules."""
     formatter = OutputFormatter(format, _HEADER_KEYS_MAP)
     selected_rules = _get_all_rules_metadata(state.sdk)
-    if selected_rules:
+
+    if len(selected_rules) > 10:
+        click.echo_via_pager(formatter.get_formatted_output(selected_rules))
+    else:
         formatter.echo_formatted_list(selected_rules)
 
 

--- a/src/code42cli/cmds/alert_rules.py
+++ b/src/code42cli/cmds/alert_rules.py
@@ -85,10 +85,11 @@ def list_alert_rules(state, format):
     formatter = OutputFormatter(format, _HEADER_KEYS_MAP)
     selected_rules = _get_all_rules_metadata(state.sdk)
 
-    if len(selected_rules) > 10:
-        click.echo_via_pager(formatter.get_formatted_output(selected_rules))
-    else:
-        formatter.echo_formatted_list(selected_rules)
+    if selected_rules:
+        if len(selected_rules) > 10:
+            click.echo_via_pager(formatter.get_formatted_output(selected_rules))
+        else:
+            formatter.echo_formatted_list(selected_rules)
 
 
 @alert_rules.command()

--- a/src/code42cli/cmds/auditlogs.py
+++ b/src/code42cli/cmds/auditlogs.py
@@ -155,10 +155,7 @@ def search(
     if not events:
         click.echo("No results found.")
         return
-    elif len(events) > 10:
-        click.echo_via_pager(formatter.get_formatted_output(events))
-    else:
-        formatter.echo_formatted_list(events)
+    formatter.echo_formatted_list(events)
 
 
 @audit_logs.command(cls=SendToCommand)

--- a/src/code42cli/cmds/cases.py
+++ b/src/code42cli/cmds/cases.py
@@ -151,10 +151,7 @@ def _list(
     formatter = OutputFormatter(format, _get_cases_header())
     cases = [case for page in pages for case in page["cases"]]
     if cases:
-        if len(cases) > 10:
-            click.echo_via_pager(formatter.get_formatted_output(cases))
-        else:
-            formatter.echo_formatted_list(cases)
+        formatter.echo_formatted_list(cases)
     else:
         click.echo("No cases found.")
 

--- a/src/code42cli/cmds/cases.py
+++ b/src/code42cli/cmds/cases.py
@@ -151,7 +151,10 @@ def _list(
     formatter = OutputFormatter(format, _get_cases_header())
     cases = [case for page in pages for case in page["cases"]]
     if cases:
-        formatter.echo_formatted_list(cases)
+        if len(cases) > 10:
+            click.echo_via_pager(formatter.get_formatted_output(cases))
+        else:
+            formatter.echo_formatted_list(cases)
     else:
         click.echo("No cases found.")
 

--- a/src/code42cli/cmds/detectionlists/__init__.py
+++ b/src/code42cli/cmds/detectionlists/__init__.py
@@ -34,11 +34,7 @@ def list_employees(employee_generator, output_format, additional_header_items=No
             employee_list.append(employee)
     if employee_list:
         formatter = OutputFormatter(output_format, header)
-        if len(employee_list) > 10:
-            output = formatter.get_formatted_output(employee_list)
-            click.echo_via_pager(output)
-        else:
-            formatter.echo_formatted_list(employee_list)
+        formatter.echo_formatted_list(employee_list)
     else:
         click.echo("No users found.")
 

--- a/src/code42cli/cmds/devices.py
+++ b/src/code42cli/cmds/devices.py
@@ -21,7 +21,7 @@ from code42cli.errors import Code42CLIError
 from code42cli.file_readers import read_csv_arg
 from code42cli.options import format_option
 from code42cli.options import sdk_options
-from code42cli.output_formats import DataFrameOutputFormatter
+from code42cli.output_formats import DataFrameOutputFormatter, OutputFormat
 from code42cli.output_formats import OutputFormatter
 
 
@@ -154,11 +154,11 @@ def _change_device_name(sdk, guid, name):
 @devices.command()
 @device_guid_argument
 @sdk_options()
-def show(state, device_guid, format=None):
+def show(state, device_guid):
     """Print individual device details. Requires device GUID."""
 
-    formatter = OutputFormatter(format, _device_info_keys_map())
-    backup_set_formatter = OutputFormatter(format, _backup_set_keys_map())
+    formatter = OutputFormatter(OutputFormat.TABLE, _device_info_keys_map())
+    backup_set_formatter = OutputFormatter(OutputFormat.TABLE, _backup_set_keys_map())
     device_info = _get_device_info(state.sdk, device_guid)
     formatter.echo_formatted_list([device_info])
     backup_usage = device_info.get("backupUsage")

--- a/src/code42cli/cmds/devices.py
+++ b/src/code42cli/cmds/devices.py
@@ -21,7 +21,8 @@ from code42cli.errors import Code42CLIError
 from code42cli.file_readers import read_csv_arg
 from code42cli.options import format_option
 from code42cli.options import sdk_options
-from code42cli.output_formats import DataFrameOutputFormatter, OutputFormat
+from code42cli.output_formats import DataFrameOutputFormatter
+from code42cli.output_formats import OutputFormat
 from code42cli.output_formats import OutputFormatter
 
 

--- a/src/code42cli/cmds/legal_hold.py
+++ b/src/code42cli/cmds/legal_hold.py
@@ -165,11 +165,7 @@ def search_events(state, matter_id, event_type, begin, end, format):
     events = _get_all_events(state.sdk, matter_id, begin, end)
     if event_type:
         events = [event for event in events if event["eventType"] == event_type]
-    if len(events) > 10:
-        output = formatter.get_formatted_output(events)
-        click.echo_via_pager(output)
-    else:
-        formatter.echo_formatted_list(events)
+    formatter.echo_formatted_list(events)
 
 
 @legal_hold.group(cls=OrderedGroup)

--- a/src/code42cli/cmds/search/extraction.py
+++ b/src/code42cli/cmds/search/extraction.py
@@ -101,11 +101,7 @@ def create_handlers(
         events = _get_events(sdk, handlers, extractor._key, response)
         total_events = len(events)
         handlers.TOTAL_EVENTS += total_events
-
-        if total_events > 10 or force_pager:
-            click.echo_via_pager(formatter.get_formatted_output(events))
-        else:
-            formatter.echo_formatted_list(events)
+        formatter.echo_formatted_list(events, force_pager=force_pager)
 
         # To make sure the extractor records correct timestamp event when `CTRL-C` is pressed.
         if total_events:

--- a/src/code42cli/output_formats.py
+++ b/src/code42cli/output_formats.py
@@ -12,6 +12,7 @@ from code42cli.util import format_to_table
 
 CEF_DEFAULT_PRODUCT_NAME = "Advanced Exfiltration Detection"
 CEF_DEFAULT_SEVERITY_LEVEL = "5"
+OUTPUT_VIA_PAGER_THRESHOLD = 10
 
 
 class JsonOutputFormat:
@@ -68,7 +69,7 @@ class OutputFormatter:
 
     def echo_formatted_list(self, output_list, force_pager=False):
         formatted_output = self.get_formatted_output(output_list)
-        if len(output_list) > 10 or force_pager:
+        if len(output_list) > OUTPUT_VIA_PAGER_THRESHOLD or force_pager:
             click.echo_via_pager(formatted_output)
         else:
             for output in formatted_output:
@@ -127,7 +128,7 @@ class DataFrameOutputFormatter:
 
     def echo_formatted_dataframe(self, df, **kwargs):
         str_output = self.get_formatted_output(df, **kwargs)
-        if len(df) <= 10:
+        if len(df) <= OUTPUT_VIA_PAGER_THRESHOLD:
             click.echo(str_output)
         else:
             click.echo_via_pager(str_output)

--- a/src/code42cli/output_formats.py
+++ b/src/code42cli/output_formats.py
@@ -135,7 +135,7 @@ def to_csv(output):
 
     if not output:
         return
-    string_io = io.StringIO(newline="")
+    string_io = io.StringIO(newline=None)
     fieldnames = list({k for d in output for k in d.keys()})
     writer = csv.DictWriter(string_io, fieldnames=fieldnames)
     writer.writeheader()

--- a/src/code42cli/output_formats.py
+++ b/src/code42cli/output_formats.py
@@ -135,7 +135,7 @@ def to_csv(output):
 
     if not output:
         return
-    string_io = io.StringIO()
+    string_io = io.StringIO(newline="")
     fieldnames = list({k for d in output for k in d.keys()})
     writer = csv.DictWriter(string_io, fieldnames=fieldnames)
     writer.writeheader()

--- a/src/code42cli/output_formats.py
+++ b/src/code42cli/output_formats.py
@@ -66,12 +66,15 @@ class OutputFormatter:
             for item in output:
                 yield self._format_output(item)
 
-    def echo_formatted_list(self, output_list):
+    def echo_formatted_list(self, output_list, force_pager=False):
         formatted_output = self.get_formatted_output(output_list)
-        for output in formatted_output:
-            click.echo(output, nl=False)
-        if self.output_format in [OutputFormat.TABLE]:
-            click.echo()
+        if len(output_list) > 10 or force_pager:
+            click.echo_via_pager(formatted_output)
+        else:
+            for output in formatted_output:
+                click.echo(output, nl=False)
+            if self.output_format in [OutputFormat.TABLE]:
+                click.echo()
 
     @property
     def _requires_list_output(self):

--- a/tests/cmds/search/test_extraction.py
+++ b/tests/cmds/search/test_extraction.py
@@ -64,7 +64,7 @@ def test_create_handlers_creates_handlers_that_pass_events_to_output_formatter(
     http_response.text = '{{"{0}": [{{"property": "bar"}}]}}'.format(key)
     py42_response = Py42Response(http_response)
     handlers.handle_response(py42_response)
-    formatter.echo_formatted_list.assert_called_once_with(events)
+    formatter.echo_formatted_list.assert_called_once_with(events, force_pager=False)
 
 
 def test_send_to_handlers_creates_handlers_that_pass_events_to_logger(

--- a/tests/cmds/test_departing_employee.py
+++ b/tests/cmds/test_departing_employee.py
@@ -192,7 +192,7 @@ def test_add_departing_employee_when_user_does_not_exist_exits(
 
 
 def test_add_departing_employee_when_user_already_exits_with_correct_message(
-    mocker, runner, cli_state_with_user, user_already_added_error
+    runner, cli_state_with_user, user_already_added_error
 ):
     def add_user(user):
         raise user_already_added_error
@@ -224,7 +224,7 @@ def test_remove_departing_employee_when_user_does_not_exist_exits(
     assert "User '{}' does not exist.".format(TEST_EMPLOYEE) in result.output
 
 
-def test_add_bulk_users_calls_expected_py42_methods(runner, mocker, cli_state):
+def test_add_bulk_users_calls_expected_py42_methods(runner, cli_state):
     de_add_user = thread_safe_side_effect()
     add_user_cloud_alias = thread_safe_side_effect()
     update_user_notes = thread_safe_side_effect()

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -821,11 +821,14 @@ class TestDataFrameOutputFormatter:
             "      string2          43            "
         )
 
-    def test_echo_formatted_dataframe_uses_pager_when_gt_10_rows(self, mocker):
+    def test_echo_formatted_dataframe_uses_pager_when_len_rows_gt_threshold_const(
+        self, mocker
+    ):
         mock_echo = mocker.patch("click.echo")
         mock_pager = mocker.patch("click.echo_via_pager")
         formatter = DataFrameOutputFormatter(OutputFormat.TABLE)
-        big_df = DataFrame([{"column": val} for val in range(11)])
+        rows_len = output_formats_module.OUTPUT_VIA_PAGER_THRESHOLD + 1
+        big_df = DataFrame([{"column": val} for val in range(rows_len)])
         small_df = DataFrame([{"column": val} for val in range(5)])
         formatter.echo_formatted_dataframe(big_df)
         formatter.echo_formatted_dataframe(small_df)


### PR DESCRIPTION
* Fixes Windows bug where CSV outputs would have extra newlines between the output

^ Verify via `code42 high-risk-employee list -f csv >> test.csv` and then open the file (on Windows and Mac)

* Uses pager when outputting > 10 alert rules

^ Verify via `code42 alert-rules list`. Notice you can page.

* Uses pager when outputting > 10 case

^ Verify via `code42 cases list`. Notice you can page.


also updates the extractor to fix that weird timestamp bug
