### PR TITLE
List users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ## Unreleased
 
-- `code42 users list` command
+### Added
+
+- New command `code42 users list` with options:
     - `--org-uid` filters on org membership.
     - `--role-name` filters on users having a particular role.
     - `--active` and `--inactive` filter on user status.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ## Unreleased
 
+- `code42 users list` command
+    - `--org-uid` filters on org membership.
+    - `--role-name` filters on users having a particular role.
+    - `--active` and `--inactive` filter on user status.
+
 ### Fixed
 
 - Bug where some CSV outputs on Windows would have an extra newline between the rows.

--- a/src/code42cli/cmds/users.py
+++ b/src/code42cli/cmds/users.py
@@ -1,40 +1,38 @@
 import click
+from pandas import DataFrame
 
-from code42cli.options import format_option
-from code42cli.options import sdk_options
-from code42cli.output_formats import DataFrameOutputFormatter
 from code42cli.click_ext.groups import OrderedGroup
 from code42cli.click_ext.options import incompatible_with
 from code42cli.errors import Code42CLIError
+from code42cli.options import format_option
+from code42cli.options import sdk_options
+from code42cli.output_formats import DataFrameOutputFormatter
 from code42cli.output_formats import OutputFormatter
-from pandas import DataFrame
 
 
 @click.group(cls=OrderedGroup)
 @sdk_options(hidden=True)
 def users(state):
-	"""Manage users within your Code42 environment"""
-	pass
+    """Manage users within your Code42 environment"""
+    pass
+
 
 org_uid_option = click.option(
-	"--org-uid",
-	required=False,
+    "--org-uid",
+    required=False,
     type=str,
     default=None,
-    help="Limit users to only those in the organization you specify. "
+    help="Limit users to only those in the organization you specify. ",
 )
 role_name_option = click.option(
-	"--role-name",
-	required=False,
-	type=str,
-	default=None,
-	help="Limit results to only users having the specified role."
+    "--role-name",
+    required=False,
+    type=str,
+    default=None,
+    help="Limit results to only users having the specified role.",
 )
 active_option = click.option(
-    "--active",
-    is_flag=True,
-    help="Limits results to only active users.",
-    default=None,
+    "--active", is_flag=True, help="Limits results to only active users.", default=None,
 )
 inactive_option = click.option(
     "--inactive",
@@ -43,6 +41,7 @@ inactive_option = click.option(
     cls=incompatible_with("active"),
 )
 
+
 @users.command(name="list")
 @org_uid_option
 @role_name_option
@@ -50,56 +49,37 @@ inactive_option = click.option(
 @inactive_option
 @format_option
 @sdk_options()
-def list_users(
-	state,
-	org_uid,
-	role_name,
-	active,
-	inactive,
-	format
-	):
-	"""List users in your Code42 environment."""
-	if inactive:
-		active = False
-	if role_name:
-		role_id = _get_role_id(state.sdk, role_name)
-	else:
-		role_id = None
-	df = _get_users_dataframe(
-		state.sdk,
-		org_uid,
-		role_id,
-		active
-	)
-	if df.empty:
-		click.echo("No results found.")
-	else:
-		formatter = DataFrameOutputFormatter(format)
-		formatter.echo_formatted_dataframe(df)
-
+def list_users(state, org_uid, role_name, active, inactive, format):
+    """List users in your Code42 environment."""
+    if inactive:
+        active = False
+    if role_name:
+        role_id = _get_role_id(state.sdk, role_name)
+    else:
+        role_id = None
+    df = _get_users_dataframe(state.sdk, org_uid, role_id, active)
+    if df.empty:
+        click.echo("No results found.")
+    else:
+        formatter = DataFrameOutputFormatter(format)
+        formatter.echo_formatted_dataframe(df)
 
 
 def _get_role_id(sdk, role_name):
-	try:
-		roles_dataframe = DataFrame.from_records(
-			sdk.users.get_available_roles().data
-		)
-		return str(roles_dataframe.loc[roles_dataframe['roleName']==role_name, 'roleId'].array[0])
-	except KeyError:
-		raise Code42CLIError("Role with name {} not found.".format(role_name))
+    try:
+        roles_dataframe = DataFrame.from_records(sdk.users.get_available_roles().data)
+        return str(
+            roles_dataframe.loc[
+                roles_dataframe["roleName"] == role_name, "roleId"
+            ].array[0]
+        )
+    except KeyError:
+        raise Code42CLIError("Role with name {} not found.".format(role_name))
 
-def _get_users_dataframe(
-	sdk,
-	org_uid,
-	role_id,
-	active
-):
-	users_generator = sdk.users.get_all(
-			active=active,
-			org_uid=org_uid,
-			role_id=role_id
-		)
-	users_list = []
-	for page in users_generator:
-		users_list.extend(page["users"])
-	return DataFrame.from_records(users_list)
+
+def _get_users_dataframe(sdk, org_uid, role_id, active):
+    users_generator = sdk.users.get_all(active=active, org_uid=org_uid, role_id=role_id)
+    users_list = []
+    for page in users_generator:
+        users_list.extend(page["users"])
+    return DataFrame.from_records(users_list)

--- a/src/code42cli/cmds/users.py
+++ b/src/code42cli/cmds/users.py
@@ -1,0 +1,105 @@
+import click
+
+from code42cli.options import format_option
+from code42cli.options import sdk_options
+from code42cli.output_formats import DataFrameOutputFormatter
+from code42cli.click_ext.groups import OrderedGroup
+from code42cli.click_ext.options import incompatible_with
+from code42cli.errors import Code42CLIError
+from code42cli.output_formats import OutputFormatter
+from pandas import DataFrame
+
+
+@click.group(cls=OrderedGroup)
+@sdk_options(hidden=True)
+def users(state):
+	"""Manage users within your Code42 environment"""
+	pass
+
+org_uid_option = click.option(
+	"--org-uid",
+	required=False,
+    type=str,
+    default=None,
+    help="Limit users to only those in the organization you specify. "
+)
+role_name_option = click.option(
+	"--role-name",
+	required=False,
+	type=str,
+	default=None,
+	help="Limit results to only users having the specified role."
+)
+active_option = click.option(
+    "--active",
+    is_flag=True,
+    help="Limits results to only active users.",
+    default=None,
+)
+inactive_option = click.option(
+    "--inactive",
+    is_flag=True,
+    help="Limits results to only deactivated users.",
+    cls=incompatible_with("active"),
+)
+
+@users.command(name="list")
+@org_uid_option
+@role_name_option
+@active_option
+@inactive_option
+@format_option
+@sdk_options()
+def list_users(
+	state,
+	org_uid,
+	role_name,
+	active,
+	inactive,
+	format
+	):
+	"""List users in your Code42 environment."""
+	if inactive:
+		active = False
+	if role_name:
+		role_id = _get_role_id(state.sdk, role_name)
+	else:
+		role_id = None
+	df = _get_users_dataframe(
+		state.sdk,
+		org_uid,
+		role_id,
+		active
+	)
+	if df.empty:
+		click.echo("No results found.")
+	else:
+		formatter = DataFrameOutputFormatter(format)
+		formatter.echo_formatted_dataframe(df)
+
+
+
+def _get_role_id(sdk, role_name):
+	try:
+		roles_dataframe = DataFrame.from_records(
+			sdk.users.get_available_roles().data
+		)
+		return str(roles_dataframe.loc[roles_dataframe['roleName']==role_name, 'roleId'].array[0])
+	except KeyError:
+		raise Code42CLIError("Role with name {} not found.".format(role_name))
+
+def _get_users_dataframe(
+	sdk,
+	org_uid,
+	role_id,
+	active
+):
+	users_generator = sdk.users.get_all(
+			active=active,
+			org_uid=org_uid,
+			role_id=role_id
+		)
+	users_list = []
+	for page in users_generator:
+		users_list.extend(page["users"])
+	return DataFrame.from_records(users_list)

--- a/src/code42cli/cmds/users.py
+++ b/src/code42cli/cmds/users.py
@@ -7,7 +7,6 @@ from code42cli.errors import Code42CLIError
 from code42cli.options import format_option
 from code42cli.options import sdk_options
 from code42cli.output_formats import DataFrameOutputFormatter
-from code42cli.output_formats import OutputFormatter
 
 
 @click.group(cls=OrderedGroup)

--- a/src/code42cli/main.py
+++ b/src/code42cli/main.py
@@ -16,6 +16,7 @@ from code42cli.cmds.auditlogs import audit_logs
 from code42cli.cmds.cases import cases
 from code42cli.cmds.departing_employee import departing_employee
 from code42cli.cmds.devices import devices
+from code42cli.cmds.users import users
 from code42cli.cmds.high_risk_employee import high_risk_employee
 from code42cli.cmds.legal_hold import legal_hold
 from code42cli.cmds.profile import profile
@@ -80,5 +81,6 @@ cli.add_command(high_risk_employee)
 cli.add_command(legal_hold)
 cli.add_command(profile)
 cli.add_command(devices)
+cli.add_command(users)
 cli.add_command(audit_logs)
 cli.add_command(cases)

--- a/src/code42cli/main.py
+++ b/src/code42cli/main.py
@@ -16,11 +16,11 @@ from code42cli.cmds.auditlogs import audit_logs
 from code42cli.cmds.cases import cases
 from code42cli.cmds.departing_employee import departing_employee
 from code42cli.cmds.devices import devices
-from code42cli.cmds.users import users
 from code42cli.cmds.high_risk_employee import high_risk_employee
 from code42cli.cmds.legal_hold import legal_hold
 from code42cli.cmds.profile import profile
 from code42cli.cmds.securitydata import security_data
+from code42cli.cmds.users import users
 from code42cli.options import sdk_options
 
 BANNER = """\b

--- a/tests/cmds/test_users.py
+++ b/tests/cmds/test_users.py
@@ -1,31 +1,29 @@
-from code42cli.main import cli
+import json
+
+import pytest
 from pandas.core.frame import DataFrame
 from py42.response import Py42Response
 from requests import Response
-import pytest
+
 from code42cli.cmds.users import _get_role_id
 from code42cli.cmds.users import _get_users_dataframe
-import json
+from code42cli.main import cli
 
-TEST_ROLE_RETURN_DATA = {"data":[
-	{
-		"roleName": "Customer Cloud Admin",
-		"roleId": "12"
-	}
-]}
+TEST_ROLE_RETURN_DATA = {"data": [{"roleName": "Customer Cloud Admin", "roleId": "12"}]}
 
 TEST_USERS_RESPONSE = {
-	"users": [
-		{
-			"userId":"1234",
-			"userUid":"997962681513153325",
-			"status": "Active",
-			"username": "test_username@code42.com",
-			"creationDate": "2021-03-12T20:07:40.898Z",
-			"modificationDate": "2021-03-12T20:07:40.938Z"
-		}
-	]
+    "users": [
+        {
+            "userId": "1234",
+            "userUid": "997962681513153325",
+            "status": "Active",
+            "username": "test_username@code42.com",
+            "creationDate": "2021-03-12T20:07:40.898Z",
+            "modificationDate": "2021-03-12T20:07:40.938Z",
+        }
+    ]
 }
+
 
 def _create_py42_response(mocker, text):
     response = mocker.MagicMock(spec=Response)
@@ -34,45 +32,57 @@ def _create_py42_response(mocker, text):
     response.status_code = 200
     return Py42Response(response)
 
+
 def get_all_users_generator():
-	yield TEST_USERS_RESPONSE
+    yield TEST_USERS_RESPONSE
+
 
 @pytest.fixture
 def get_available_roles_response(mocker):
-	return _create_py42_response(mocker, json.dumps(TEST_ROLE_RETURN_DATA))
+    return _create_py42_response(mocker, json.dumps(TEST_ROLE_RETURN_DATA))
+
 
 @pytest.fixture
 def get_all_users_success(cli_state):
-	cli_state.sdk.users.get_all.return_value = get_all_users_generator()
+    cli_state.sdk.users.get_all.return_value = get_all_users_generator()
+
 
 @pytest.fixture
 def get_available_roles_success(cli_state, get_available_roles_response):
-	cli_state.sdk.users.get_available_roles.return_value = get_available_roles_response
+    cli_state.sdk.users.get_available_roles.return_value = get_available_roles_response
+
 
 def test_list_outputs_appropriate_columns(runner, cli_state, get_all_users_success):
-	result = runner.invoke(cli, ["users","list"], obj=cli_state)
-	assert "userId" in result.output
-	assert "userUid" in result.output
-	assert "status" in result.output
-	assert "username" in result.output
-	assert "creationDate" in result.output
-	assert "modificationDate" in result.output
+    result = runner.invoke(cli, ["users", "list"], obj=cli_state)
+    assert "userId" in result.output
+    assert "userUid" in result.output
+    assert "status" in result.output
+    assert "username" in result.output
+    assert "creationDate" in result.output
+    assert "modificationDate" in result.output
 
-def test_get_role_id_returns_appropriate_role_id(cli_state, get_available_roles_success):
-	result = _get_role_id(cli_state.sdk, "Customer Cloud Admin")
-	assert result == "12"
+
+def test_get_role_id_returns_appropriate_role_id(
+    cli_state, get_available_roles_success
+):
+    result = _get_role_id(cli_state.sdk, "Customer Cloud Admin")
+    assert result == "12"
+
 
 def test_get_users_dataframe_returns_dataframe(cli_state, get_all_users_success):
-	result = _get_users_dataframe(cli_state.sdk, org_uid = None, role_id = None, active = None)
-	assert isinstance(result, DataFrame)
+    result = _get_users_dataframe(
+        cli_state.sdk, org_uid=None, role_id=None, active=None
+    )
+    assert isinstance(result, DataFrame)
 
-def test_get_users_dataframe_calls_get_all_users_with_correct_parameters(cli_state, get_all_users_success):
-	org_uid = "TEST_ORG_UID"
-	role_id = "TEST_ROLE_ID"
-	active = "TEST_ACTIVE"
-	_get_users_dataframe(cli_state.sdk, org_uid = org_uid, role_id = role_id, active = active)
-	cli_state.sdk.users.get_all.assert_called_once_with(
-		active=active,
-		org_uid=org_uid,
-		role_id=role_id
-	)
+
+def test_get_users_dataframe_calls_get_all_users_with_correct_parameters(
+    cli_state, get_all_users_success
+):
+    org_uid = "TEST_ORG_UID"
+    role_id = "TEST_ROLE_ID"
+    active = "TEST_ACTIVE"
+    _get_users_dataframe(cli_state.sdk, org_uid=org_uid, role_id=role_id, active=active)
+    cli_state.sdk.users.get_all.assert_called_once_with(
+        active=active, org_uid=org_uid, role_id=role_id
+    )

--- a/tests/cmds/test_users.py
+++ b/tests/cmds/test_users.py
@@ -9,7 +9,9 @@ from code42cli.cmds.users import _get_role_id
 from code42cli.cmds.users import _get_users_dataframe
 from code42cli.main import cli
 
-TEST_ROLE_RETURN_DATA = {"data": [{"roleName": "Customer Cloud Admin", "roleId": "1234543"}]}
+TEST_ROLE_RETURN_DATA = {
+    "data": [{"roleName": "Customer Cloud Admin", "roleId": "1234543"}]
+}
 
 TEST_USERS_RESPONSE = {
     "users": [
@@ -66,9 +68,7 @@ def test_list_users_calls_users_get_all_with_expected_role_id(
     runner, cli_state, get_available_roles_success, get_all_users_success
 ):
     ROLE_NAME = "Customer Cloud Admin"
-    runner.invoke(
-        cli, ["users", "list", "--role-name", ROLE_NAME], obj=cli_state
-    )
+    runner.invoke(cli, ["users", "list", "--role-name", ROLE_NAME], obj=cli_state)
     cli_state.sdk.users.get_all.assert_called_once_with(
         active=None, org_uid=None, role_id="1234543"
     )
@@ -89,12 +89,11 @@ def test_list_users_calls_get_all_users_with_correct_parameters(
 def test_list_users_when_given_inactive_uses_active_equals_false(
     runner, cli_state, get_available_roles_success, get_all_users_success
 ):
-    runner.invoke(
-        cli, ["users", "list", "--inactive"], obj=cli_state
-    )
+    runner.invoke(cli, ["users", "list", "--inactive"], obj=cli_state)
     cli_state.sdk.users.get_all.assert_called_once_with(
         active=False, org_uid=None, role_id=None
     )
+
 
 def test_list_users_when_given_active_and_inactive_raises_error(
     runner, cli_state, get_available_roles_success, get_all_users_success
@@ -108,9 +107,7 @@ def test_list_users_when_given_active_and_inactive_raises_error(
 def test_list_users_when_given_excluding_active_and_inactive_uses_active_equals_none(
     runner, cli_state, get_available_roles_success, get_all_users_success
 ):
-    runner.invoke(
-        cli, ["users", "list"], obj=cli_state
-    )
+    runner.invoke(cli, ["users", "list"], obj=cli_state)
     cli_state.sdk.users.get_all.assert_called_once_with(
         active=None, org_uid=None, role_id=None
     )

--- a/tests/cmds/test_users.py
+++ b/tests/cmds/test_users.py
@@ -1,12 +1,9 @@
 import json
 
 import pytest
-from pandas.core.frame import DataFrame
 from py42.response import Py42Response
 from requests import Response
 
-from code42cli.cmds.users import _get_role_id
-from code42cli.cmds.users import _get_users_dataframe
 from code42cli.main import cli
 
 TEST_ROLE_RETURN_DATA = {

--- a/tests/cmds/test_users.py
+++ b/tests/cmds/test_users.py
@@ -1,0 +1,78 @@
+from code42cli.main import cli
+from pandas.core.frame import DataFrame
+from py42.response import Py42Response
+from requests import Response
+import pytest
+from code42cli.cmds.users import _get_role_id
+from code42cli.cmds.users import _get_users_dataframe
+import json
+
+TEST_ROLE_RETURN_DATA = {"data":[
+	{
+		"roleName": "Customer Cloud Admin",
+		"roleId": "12"
+	}
+]}
+
+TEST_USERS_RESPONSE = {
+	"users": [
+		{
+			"userId":"1234",
+			"userUid":"997962681513153325",
+			"status": "Active",
+			"username": "test_username@code42.com",
+			"creationDate": "2021-03-12T20:07:40.898Z",
+			"modificationDate": "2021-03-12T20:07:40.938Z"
+		}
+	]
+}
+
+def _create_py42_response(mocker, text):
+    response = mocker.MagicMock(spec=Response)
+    response.text = text
+    response._content_consumed = mocker.MagicMock()
+    response.status_code = 200
+    return Py42Response(response)
+
+def get_all_users_generator():
+	yield TEST_USERS_RESPONSE
+
+@pytest.fixture
+def get_available_roles_response(mocker):
+	return _create_py42_response(mocker, json.dumps(TEST_ROLE_RETURN_DATA))
+
+@pytest.fixture
+def get_all_users_success(cli_state):
+	cli_state.sdk.users.get_all.return_value = get_all_users_generator()
+
+@pytest.fixture
+def get_available_roles_success(cli_state, get_available_roles_response):
+	cli_state.sdk.users.get_available_roles.return_value = get_available_roles_response
+
+def test_list_outputs_appropriate_columns(runner, cli_state, get_all_users_success):
+	result = runner.invoke(cli, ["users","list"], obj=cli_state)
+	assert "userId" in result.output
+	assert "userUid" in result.output
+	assert "status" in result.output
+	assert "username" in result.output
+	assert "creationDate" in result.output
+	assert "modificationDate" in result.output
+
+def test_get_role_id_returns_appropriate_role_id(cli_state, get_available_roles_success):
+	result = _get_role_id(cli_state.sdk, "Customer Cloud Admin")
+	assert result == "12"
+
+def test_get_users_dataframe_returns_dataframe(cli_state, get_all_users_success):
+	result = _get_users_dataframe(cli_state.sdk, org_uid = None, role_id = None, active = None)
+	assert isinstance(result, DataFrame)
+
+def test_get_users_dataframe_calls_get_all_users_with_correct_parameters(cli_state, get_all_users_success):
+	org_uid = "TEST_ORG_UID"
+	role_id = "TEST_ROLE_ID"
+	active = "TEST_ACTIVE"
+	_get_users_dataframe(cli_state.sdk, org_uid = org_uid, role_id = role_id, active = active)
+	cli_state.sdk.users.get_all.assert_called_once_with(
+		active=active,
+		org_uid=org_uid,
+		role_id=role_id
+	)

--- a/tests/cmds/test_users.py
+++ b/tests/cmds/test_users.py
@@ -14,7 +14,7 @@ TEST_ROLE_RETURN_DATA = {"data": [{"roleName": "Customer Cloud Admin", "roleId":
 TEST_USERS_RESPONSE = {
     "users": [
         {
-            "userId": "1234",
+            "userId": 1234,
             "userUid": "997962681513153325",
             "status": "Active",
             "username": "test_username@code42.com",
@@ -76,13 +76,13 @@ def test_get_users_dataframe_returns_dataframe(cli_state, get_all_users_success)
     assert isinstance(result, DataFrame)
 
 
-def test_get_users_dataframe_calls_get_all_users_with_correct_parameters(
-    cli_state, get_all_users_success
+def test_list_users_calls_get_all_users_with_correct_parameters(
+    runner, cli_state, get_all_users_success
 ):
     org_uid = "TEST_ORG_UID"
-    role_id = "TEST_ROLE_ID"
-    active = "TEST_ACTIVE"
-    _get_users_dataframe(cli_state.sdk, org_uid=org_uid, role_id=role_id, active=active)
+    runner.invoke(
+        cli, ["users", "list", "--org-uid", org_uid, "--active"], obj=cli_state
+    )
     cli_state.sdk.users.get_all.assert_called_once_with(
-        active=active, org_uid=org_uid, role_id=role_id
+        active=True, org_uid=org_uid, role_id=None
     )


### PR DESCRIPTION
**Description of Change**

This adds a "users list" command and parameters to filter on active status, org Uid, and role name.

This partially addresses #259, but more work will follow in additional PRs.

**Testing Procedure**

```
code42 users list
code42 users list --role-name "Customer Cloud Admin"
code42 users list --org-uid "12345"
code42 users list --inactive
code42 users list --active
```

**PR Checklist**

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes