### PR TITLE
Feature/2fa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+## Unreleased
+
+### Added
+
+- Support for users that require multi-factor authentication.
+
 ## 1.4.2 - 2021-04-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 ### Added
 
 - Support for users that require multi-factor authentication.
-  
+
 - New command `code42 alerts show` that displays information about a single alert.
 
 - New command `code42 alerts update` that can update an alert's state or note.

--- a/docs/userguides/gettingstarted.md
+++ b/docs/userguides/gettingstarted.md
@@ -72,9 +72,15 @@ python3 -m pip install code42cli --upgrade
 .. important:: The Code42 CLI currently only supports token-based authentication.
 ```
 
-Create a user in Code42 to authenticate (basic authentication) and access data via the CLI. The CLI returns data based on the roles assigned to this user. To ensure that the user's rights are not too permissive, create a user with the lowest level of privilege necessary. See our [Role assignment use cases](https://support.code42.com/Administrator/Cloud/Monitoring_and_managing/Role_assignment_use_cases) for information on recommended roles. We recommend you test to confirm that the user can access the right data.
+Create a user in Code42 to authenticate (basic authentication) and access data via the CLI. The CLI returns data based 
+on the roles assigned to this user. To ensure that the user's rights are not too permissive, create a user with the lowest 
+level of privilege necessary. See our [Role assignment use cases](https://support.code42.com/Administrator/Cloud/Monitoring_and_managing/Role_assignment_use_cases) 
+for information on recommended roles. We recommend you test to confirm that the user can access the right data.
 
 If you choose not to store your password in the CLI, you must enter it for each command that requires a connection.
+
+The Code42 CLI supports local accounts with MFA (multi-factor authentication) enabled. The Time-based One-Time 
+Password (TOTP) must be provided at every invocation of the CLI, either via the `--totp` option, or when prompted.
 
 The Code42 CLI currently does **not** support SSO login providers or any other identity providers such as Active
 Directory or Okta.

--- a/docs/userguides/gettingstarted.md
+++ b/docs/userguides/gettingstarted.md
@@ -72,14 +72,14 @@ python3 -m pip install code42cli --upgrade
 .. important:: The Code42 CLI currently only supports token-based authentication.
 ```
 
-Create a user in Code42 to authenticate (basic authentication) and access data via the CLI. The CLI returns data based 
-on the roles assigned to this user. To ensure that the user's rights are not too permissive, create a user with the lowest 
-level of privilege necessary. See our [Role assignment use cases](https://support.code42.com/Administrator/Cloud/Monitoring_and_managing/Role_assignment_use_cases) 
+Create a user in Code42 to authenticate (basic authentication) and access data via the CLI. The CLI returns data based
+on the roles assigned to this user. To ensure that the user's rights are not too permissive, create a user with the lowest
+level of privilege necessary. See our [Role assignment use cases](https://support.code42.com/Administrator/Cloud/Monitoring_and_managing/Role_assignment_use_cases)
 for information on recommended roles. We recommend you test to confirm that the user can access the right data.
 
 If you choose not to store your password in the CLI, you must enter it for each command that requires a connection.
 
-The Code42 CLI supports local accounts with MFA (multi-factor authentication) enabled. The Time-based One-Time 
+The Code42 CLI supports local accounts with MFA (multi-factor authentication) enabled. The Time-based One-Time
 Password (TOTP) must be provided at every invocation of the CLI, either via the `--totp` option, or when prompted.
 
 The Code42 CLI currently does **not** support SSO login providers or any other identity providers such as Active

--- a/docs/userguides/gettingstarted.md
+++ b/docs/userguides/gettingstarted.md
@@ -80,7 +80,7 @@ for information on recommended roles. We recommend you test to confirm that the 
 If you choose not to store your password in the CLI, you must enter it for each command that requires a connection.
 
 The Code42 CLI supports local accounts with MFA (multi-factor authentication) enabled. The Time-based One-Time
-Password (TOTP) must be provided at every invocation of the CLI, either via the `--totp` option, or when prompted.
+Password (TOTP) must be provided at every invocation of the CLI, either via the `--totp` option or when prompted.
 
 The Code42 CLI currently does **not** support SSO login providers or any other identity providers such as Active
 Directory or Okta.

--- a/docs/userguides/profile.md
+++ b/docs/userguides/profile.md
@@ -36,6 +36,6 @@ code42 profile list
 
 ## Profiles with Multi-Factor Authentication
 
-If your Code42 user account requires multi-factor authentication, the token is not required to create your profile, but
+If your Code42 user account requires multi-factor authentication, the token is not required to create your profile but
 will be required for any subsequent CLI commands. The MFA token can either be passed in with the `--totp` option, or if
 not passed you will be prompted to enter it before the command executes.

--- a/docs/userguides/profile.md
+++ b/docs/userguides/profile.md
@@ -33,3 +33,9 @@ To see all your profiles, do:
 ```bash
 code42 profile list
 ```
+
+## Profiles with Multi-Factor Authentication
+
+If your Code42 user account requires multi-factor authentication, the token is not required to create your profile, but 
+will be required for any subsequent CLI commands. The MFA token can either be passed in with the `--totp` option, or if 
+not passed you will be prompted to enter it before the command executes.

--- a/docs/userguides/profile.md
+++ b/docs/userguides/profile.md
@@ -36,6 +36,6 @@ code42 profile list
 
 ## Profiles with Multi-Factor Authentication
 
-If your Code42 user account requires multi-factor authentication, the token is not required to create your profile, but 
-will be required for any subsequent CLI commands. The MFA token can either be passed in with the `--totp` option, or if 
+If your Code42 user account requires multi-factor authentication, the token is not required to create your profile, but
+will be required for any subsequent CLI commands. The MFA token can either be passed in with the `--totp` option, or if
 not passed you will be prompted to enter it before the command executes.

--- a/src/code42cli/click_ext/groups.py
+++ b/src/code42cli/click_ext/groups.py
@@ -72,12 +72,6 @@ class ExceptionHandlingGroup(click.Group):
             self.logger.log_error(err)
             raise Code42CLIError(str(err))
 
-        except Py42MFARequiredError as err:
-            self.logger.log_error(err)
-            raise Code42CLIError(
-                "User requires multi-factor authentication. Use `--totp <token>` option to provide token."
-            )
-
         except Py42ForbiddenError as err:
             self.logger.log_verbose_error(self._original_args, err.response.request)
             raise LoggedCLIError(

--- a/src/code42cli/click_ext/groups.py
+++ b/src/code42cli/click_ext/groups.py
@@ -13,6 +13,7 @@ from py42.exceptions import Py42LegalHoldNotFoundOrPermissionDeniedError
 from py42.exceptions import Py42UpdateClosedCaseError
 from py42.exceptions import Py42UserAlreadyAddedError
 from py42.exceptions import Py42UserNotOnListError
+from py42.exceptions import Py42MFARequiredError
 
 from code42cli.errors import Code42CLIError
 from code42cli.errors import LoggedCLIError
@@ -70,6 +71,12 @@ class ExceptionHandlingGroup(click.Group):
         ) as err:
             self.logger.log_error(err)
             raise Code42CLIError(str(err))
+
+        except Py42MFARequiredError as err:
+            self.logger.log_error(err)
+            raise Code42CLIError(
+                "User requires multi-factor authentication. Use `--totp <token>` option to provide token."
+            )
 
         except Py42ForbiddenError as err:
             self.logger.log_verbose_error(self._original_args, err.response.request)

--- a/src/code42cli/click_ext/groups.py
+++ b/src/code42cli/click_ext/groups.py
@@ -10,7 +10,6 @@ from py42.exceptions import Py42ForbiddenError
 from py42.exceptions import Py42HTTPError
 from py42.exceptions import Py42InvalidRuleOperationError
 from py42.exceptions import Py42LegalHoldNotFoundOrPermissionDeniedError
-from py42.exceptions import Py42MFARequiredError
 from py42.exceptions import Py42UpdateClosedCaseError
 from py42.exceptions import Py42UserAlreadyAddedError
 from py42.exceptions import Py42UserNotOnListError

--- a/src/code42cli/click_ext/groups.py
+++ b/src/code42cli/click_ext/groups.py
@@ -10,10 +10,10 @@ from py42.exceptions import Py42ForbiddenError
 from py42.exceptions import Py42HTTPError
 from py42.exceptions import Py42InvalidRuleOperationError
 from py42.exceptions import Py42LegalHoldNotFoundOrPermissionDeniedError
+from py42.exceptions import Py42MFARequiredError
 from py42.exceptions import Py42UpdateClosedCaseError
 from py42.exceptions import Py42UserAlreadyAddedError
 from py42.exceptions import Py42UserNotOnListError
-from py42.exceptions import Py42MFARequiredError
 
 from code42cli.errors import Code42CLIError
 from code42cli.errors import LoggedCLIError

--- a/src/code42cli/cmds/profile.py
+++ b/src/code42cli/cmds/profile.py
@@ -3,6 +3,7 @@ from getpass import getpass
 import click
 from click import echo
 from click import secho
+from py42.exceptions import Py42MFARequiredError
 
 import code42cli.profile as cliprofile
 from code42cli.errors import Code42CLIError
@@ -10,7 +11,6 @@ from code42cli.options import yes_option
 from code42cli.profile import CREATE_PROFILE_HELP
 from code42cli.sdk_client import validate_connection
 from code42cli.util import does_user_agree
-from py42.exceptions import Py42MFARequiredError
 
 
 @click.group()

--- a/src/code42cli/cmds/profile.py
+++ b/src/code42cli/cmds/profile.py
@@ -193,9 +193,7 @@ def _prompt_for_allow_password_set(profile_name):
 def _set_pw(profile_name, password):
     c42profile = cliprofile.get_profile(profile_name)
     try:
-        validate_connection(
-            c42profile.authority_url, c42profile.username, password, None
-        )
+        validate_connection(c42profile.authority_url, c42profile.username, password)
     except Py42MFARequiredError:
         echo(
             "Multi-factor account detected. `--totp <token>` option will be required for all code42 invocations."

--- a/src/code42cli/cmds/profile.py
+++ b/src/code42cli/cmds/profile.py
@@ -10,6 +10,7 @@ from code42cli.options import yes_option
 from code42cli.profile import CREATE_PROFILE_HELP
 from code42cli.sdk_client import validate_connection
 from code42cli.util import does_user_agree
+from py42.exceptions import Py42MFARequiredError
 
 
 @click.group()
@@ -192,7 +193,13 @@ def _prompt_for_allow_password_set(profile_name):
 def _set_pw(profile_name, password):
     c42profile = cliprofile.get_profile(profile_name)
     try:
-        validate_connection(c42profile.authority_url, c42profile.username, password)
+        validate_connection(
+            c42profile.authority_url, c42profile.username, password, None
+        )
+    except Py42MFARequiredError:
+        echo(
+            "Multi-factor account detected. `--totp <token>` option will be required for all code42 invocations."
+        )
     except Exception:
         secho("Password not stored!", bold=True)
         raise

--- a/src/code42cli/sdk_client.py
+++ b/src/code42cli/sdk_client.py
@@ -4,6 +4,7 @@ import py42.settings.debug as debug
 import requests
 from click import secho
 from py42.exceptions import Py42UnauthorizedError
+from py42.exceptions import Py42MFARequiredError
 from requests.exceptions import ConnectionError
 
 from code42cli.errors import Code42CLIError
@@ -15,7 +16,7 @@ py42.settings.items_per_page = 500
 logger = get_main_cli_logger()
 
 
-def create_sdk(profile, is_debug_mode):
+def create_sdk(profile, is_debug_mode, totp=None):
     if is_debug_mode:
         py42.settings.debug.level = debug.DEBUG
     if profile.ignore_ssl_errors == "True":
@@ -30,18 +31,23 @@ def create_sdk(profile, is_debug_mode):
         )
         py42.settings.verify_ssl_certs = False
     password = profile.get_password()
-    return validate_connection(profile.authority_url, profile.username, password)
+    return validate_connection(profile.authority_url, profile.username, password, totp)
 
 
-def validate_connection(authority_url, username, password):
+def validate_connection(authority_url, username, password, totp):
     try:
-        return py42.sdk.from_local_account(authority_url, username, password)
+        return py42.sdk.from_local_account(authority_url, username, password, totp=totp)
     except ConnectionError as err:
         logger.log_error(str(err))
-        raise LoggedCLIError("Problem connecting to {}".format(authority_url))
+        raise LoggedCLIError(f"Problem connecting to {authority_url}.")
+    except Py42MFARequiredError:
+        raise
     except Py42UnauthorizedError as err:
         logger.log_error(str(err))
-        raise Code42CLIError("Invalid credentials for user {}".format(username))
+        if "INVALID_TIME_BASED_ONE_TIME_PASSWORD" in err.response.text:
+            raise Code42CLIError(f"Invalid TOTP token for user {username}.")
+        else:
+            raise Code42CLIError(f"Invalid credentials for user {username}.")
     except Exception as err:
         logger.log_error(str(err))
         raise LoggedCLIError("Unknown problem validating connection.")

--- a/src/code42cli/sdk_client.py
+++ b/src/code42cli/sdk_client.py
@@ -35,7 +35,7 @@ def create_sdk(profile, is_debug_mode, totp=None):
     return validate_connection(profile.authority_url, profile.username, password, totp)
 
 
-def validate_connection(authority_url, username, password, totp):
+def validate_connection(authority_url, username, password, totp=None):
     try:
         return py42.sdk.from_local_account(authority_url, username, password, totp=totp)
     except ConnectionError as err:

--- a/src/code42cli/sdk_client.py
+++ b/src/code42cli/sdk_client.py
@@ -2,9 +2,10 @@ import py42.sdk
 import py42.settings
 import py42.settings.debug as debug
 import requests
+from click import prompt
 from click import secho
-from py42.exceptions import Py42UnauthorizedError
 from py42.exceptions import Py42MFARequiredError
+from py42.exceptions import Py42UnauthorizedError
 from requests.exceptions import ConnectionError
 
 from code42cli.errors import Code42CLIError
@@ -41,7 +42,8 @@ def validate_connection(authority_url, username, password, totp):
         logger.log_error(str(err))
         raise LoggedCLIError(f"Problem connecting to {authority_url}.")
     except Py42MFARequiredError:
-        raise
+        totp = prompt("Multi-factor authentication required. Enter TOTP", type=int)
+        return validate_connection(authority_url, username, password, totp)
     except Py42UnauthorizedError as err:
         logger.log_error(str(err))
         if "INVALID_TIME_BASED_ONE_TIME_PASSWORD" in err.response.text:

--- a/tests/test_sdk_client.py
+++ b/tests/test_sdk_client.py
@@ -155,7 +155,7 @@ def test_totp_option_when_passed_is_passed_to_sdk_initialization(
     mock_py42 = mocker.patch("code42cli.sdk_client.py42.sdk.from_local_account")
     cli_state = CLIState()
     totp = "1234"
-    profile.authority_url = "test.com"
+    profile.authority_url = "example.com"
     profile.username = "user"
     profile.get_password.return_value = "password"
     cli_state._profile = profile

--- a/tests/test_sdk_client.py
+++ b/tests/test_sdk_client.py
@@ -1,14 +1,20 @@
+from io import StringIO
+
 import py42.sdk
 import py42.settings.debug as debug
 import pytest
+from py42.exceptions import Py42MFARequiredError
 from py42.exceptions import Py42UnauthorizedError
 from requests import Response
 from requests.exceptions import ConnectionError
+from requests.exceptions import HTTPError
 from requests.exceptions import RequestException
 
 from .conftest import create_mock_profile
 from code42cli.errors import Code42CLIError
 from code42cli.errors import LoggedCLIError
+from code42cli.main import cli
+from code42cli.options import CLIState
 from code42cli.sdk_client import create_sdk
 from code42cli.sdk_client import validate_connection
 
@@ -114,5 +120,46 @@ def test_create_sdk_when_told_to_debug_turns_on_debug(mock_sdk_factory):
 
 
 def test_validate_connection_uses_given_credentials(mock_sdk_factory):
-    assert validate_connection("Authority", "Test", "Password")
-    mock_sdk_factory.assert_called_once_with("Authority", "Test", "Password")
+    assert validate_connection("Authority", "Test", "Password", None)
+    mock_sdk_factory.assert_called_once_with("Authority", "Test", "Password", totp=None)
+
+
+def test_validate_connection_when_mfa_required_exception_raised_prompts_for_totp(
+    mocker, monkeypatch, mock_sdk_factory, capsys
+):
+    monkeypatch.setattr("sys.stdin", StringIO("101010"))
+    response = mocker.MagicMock(spec=Response)
+    mock_sdk_factory.side_effect = [
+        Py42MFARequiredError(HTTPError(response=response)),
+        None,
+    ]
+    validate_connection("Authority", "Test", "Password", None)
+    output = capsys.readouterr()
+    assert "Multi-factor authentication required. Enter TOTP:" in output.out
+
+
+def test_validate_connection_when_mfa_token_invalid_raises_expected_cli_error(
+    mocker, mock_sdk_factory
+):
+    response = mocker.MagicMock(spec=Response)
+    response.text = '{"data":null,"error":[{"primaryErrorKey":"INVALID_TIME_BASED_ONE_TIME_PASSWORD","otherErrors":null}],"warnings":null}'
+    mock_sdk_factory.side_effect = Py42UnauthorizedError(HTTPError(response=response))
+    with pytest.raises(Code42CLIError) as err:
+        validate_connection("Authority", "Test", "Password", "1234")
+    assert str(err.value) == "Invalid TOTP token for user Test."
+
+
+def test_totp_option_when_passed_is_passed_to_sdk_initialization(
+    mocker, profile, runner
+):
+    mock_py42 = mocker.patch("code42cli.sdk_client.py42.sdk.from_local_account")
+    cli_state = CLIState()
+    totp = "1234"
+    profile.authority_url = "test.com"
+    profile.username = "user"
+    profile.get_password.return_value = "password"
+    cli_state._profile = profile
+    runner.invoke(cli, ["users", "list", "--totp", totp], obj=cli_state)
+    mock_py42.assert_called_once_with(
+        profile.authority_url, profile.username, "password", totp=totp
+    )


### PR DESCRIPTION
Implements support for MFA accounts.

When a profile for an MFA user is created, the user will see the message:
```
Multi-factor account detected. `--totp <token>` option will be required for all code42 invocations.
```

Then any commands that initialize the sdk will either require the `--totp <token>` option, or if the option isn't provided, the CLI will prompt for the token. 