### PR TITLE
pin click version to fix failing tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,14 +31,14 @@ setup(
     zip_safe=False,
     python_requires=">3, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4",
     install_requires=[
-        "click>=7.1.1",
+        "click>=7.1.1, <8",
         "click_plugins>=1.1.1",
         "colorama>=0.4.3",
         "c42eventextractor==0.4.1",
         "keyring==18.0.1",
         "keyrings.alt==3.2.0",
         "pandas>=1.1.3",
-        "py42>=1.11.1",
+        "py42>=1.13.0",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
Click 8.0 was released ~14hrs ago and is causing unit tests to fail due to some breaking changes it made. We should eventually try to update to the latest and greatest and make the appropriate corresponding changes but for now let's just get everything to pass again.