### PR TITLE
Bugfix: allow disable ssl on profile cmds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 - Issue where `profile` commands that required connecting to an authority failed to respect the `--disable-ssl-errors` flag when set.
 
+### Added
+
+- `--enable-ssl-errors` option to `profile update` command, making it possible to re-enable ssl verification on a profile that had it disabled.
+
 ## 1.6.0 - 2021-05-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+## Unreleased
+
+### Fixed
+
+- Issue where `profile` commands that required connecting to an authority failed to respect the `--disable-ssl-errors` flag when set.
+
 ## 1.6.0 - 2021-05-20
 
 ### Added

--- a/src/code42cli/cmds/profile.py
+++ b/src/code42cli/cmds/profile.py
@@ -6,12 +6,12 @@ from click import secho
 from py42.exceptions import Py42MFARequiredError
 
 import code42cli.profile as cliprofile
+from code42cli.click_ext.options import incompatible_with
 from code42cli.errors import Code42CLIError
 from code42cli.options import yes_option
 from code42cli.profile import CREATE_PROFILE_HELP
 from code42cli.sdk_client import create_sdk
 from code42cli.util import does_user_agree
-from code42cli.click_ext.options import incompatible_with
 
 
 @click.group()

--- a/src/code42cli/cmds/profile.py
+++ b/src/code42cli/cmds/profile.py
@@ -9,7 +9,7 @@ import code42cli.profile as cliprofile
 from code42cli.errors import Code42CLIError
 from code42cli.options import yes_option
 from code42cli.profile import CREATE_PROFILE_HELP
-from code42cli.sdk_client import validate_connection
+from code42cli.sdk_client import create_sdk
 from code42cli.util import does_user_agree
 
 
@@ -193,7 +193,7 @@ def _prompt_for_allow_password_set(profile_name):
 def _set_pw(profile_name, password):
     c42profile = cliprofile.get_profile(profile_name)
     try:
-        validate_connection(c42profile.authority_url, c42profile.username, password)
+        create_sdk(c42profile, is_debug_mode=False, password=password)
     except Py42MFARequiredError:
         echo(
             "Multi-factor account detected. `--totp <token>` option will be required for all code42 invocations."

--- a/src/code42cli/options.py
+++ b/src/code42cli/options.py
@@ -60,7 +60,7 @@ class CLIState:
     @property
     def sdk(self):
         if self._sdk is None:
-            self._sdk = create_sdk(self.profile, self.debug, self.totp)
+            self._sdk = create_sdk(self.profile, self.debug, totp=self.totp)
         return self._sdk
 
     def set_assume_yes(self, param):

--- a/src/code42cli/sdk_client.py
+++ b/src/code42cli/sdk_client.py
@@ -33,29 +33,29 @@ def create_sdk(profile, is_debug_mode, password=None, totp=None):
         )
         py42.settings.verify_ssl_certs = False
     password = password or profile.get_password()
-    return validate_connection(profile.authority_url, profile.username, password, totp)
+    return _validate_connection(profile.authority_url, profile.username, password, totp)
 
 
-def validate_connection(authority_url, username, password, totp=None):
+def _validate_connection(authority_url, username, password, totp=None):
     try:
         return py42.sdk.from_local_account(authority_url, username, password, totp=totp)
     except SSLError as err:
-        logger.log_error(str(err))
+        logger.log_error(err)
         raise LoggedCLIError(
             f"Problem connecting to {authority_url}, SSL certificate verification failed.\nUpdate profile with --disable-ssl-errors to bypass certificate checks (not recommended!)."
         )
     except ConnectionError as err:
-        logger.log_error(str(err))
+        logger.log_error(err)
         raise LoggedCLIError(f"Problem connecting to {authority_url}.")
     except Py42MFARequiredError:
         totp = prompt("Multi-factor authentication required. Enter TOTP", type=int)
-        return validate_connection(authority_url, username, password, totp)
+        return _validate_connection(authority_url, username, password, totp)
     except Py42UnauthorizedError as err:
-        logger.log_error(str(err))
+        logger.log_error(err)
         if "INVALID_TIME_BASED_ONE_TIME_PASSWORD" in err.response.text:
             raise Code42CLIError(f"Invalid TOTP token for user {username}.")
         else:
             raise Code42CLIError(f"Invalid credentials for user {username}.")
     except Exception as err:
-        logger.log_error(str(err))
+        logger.log_error(err)
         raise LoggedCLIError("Unknown problem validating connection.")

--- a/src/code42cli/sdk_client.py
+++ b/src/code42cli/sdk_client.py
@@ -7,6 +7,7 @@ from click import secho
 from py42.exceptions import Py42MFARequiredError
 from py42.exceptions import Py42UnauthorizedError
 from requests.exceptions import ConnectionError
+from requests.exceptions import SSLError
 
 from code42cli.errors import Code42CLIError
 from code42cli.errors import LoggedCLIError
@@ -17,7 +18,7 @@ py42.settings.items_per_page = 500
 logger = get_main_cli_logger()
 
 
-def create_sdk(profile, is_debug_mode, totp=None):
+def create_sdk(profile, is_debug_mode, password=None, totp=None):
     if is_debug_mode:
         py42.settings.debug.level = debug.DEBUG
     if profile.ignore_ssl_errors == "True":
@@ -31,13 +32,18 @@ def create_sdk(profile, is_debug_mode, totp=None):
             requests.packages.urllib3.exceptions.InsecureRequestWarning
         )
         py42.settings.verify_ssl_certs = False
-    password = profile.get_password()
+    password = password or profile.get_password()
     return validate_connection(profile.authority_url, profile.username, password, totp)
 
 
 def validate_connection(authority_url, username, password, totp=None):
     try:
         return py42.sdk.from_local_account(authority_url, username, password, totp=totp)
+    except SSLError as err:
+        logger.log_error(str(err))
+        raise LoggedCLIError(
+            f"Problem connecting to {authority_url}, SSL certificate verification failed.\nUpdate profile with --disable-ssl-errors to bypass certificate checks (not recommended!)."
+        )
     except ConnectionError as err:
         logger.log_error(str(err))
         raise LoggedCLIError(f"Problem connecting to {authority_url}.")

--- a/tests/cmds/test_profile.py
+++ b/tests/cmds/test_profile.py
@@ -5,7 +5,6 @@ from requests import Response
 from requests.exceptions import HTTPError
 
 from ..conftest import create_mock_profile
-from code42cli import PRODUCT_NAME
 from code42cli.errors import Code42CLIError
 from code42cli.errors import LoggedCLIError
 from code42cli.main import cli
@@ -13,32 +12,32 @@ from code42cli.main import cli
 
 @pytest.fixture
 def user_agreement(mocker):
-    mock = mocker.patch("{}.cmds.profile.does_user_agree".format(PRODUCT_NAME))
+    mock = mocker.patch("code42cli.cmds.profile.does_user_agree")
     mock.return_value = True
     return mocker
 
 
 @pytest.fixture
 def user_disagreement(mocker):
-    mock = mocker.patch("{}.cmds.profile.does_user_agree".format(PRODUCT_NAME))
+    mock = mocker.patch("code42cli.cmds.profile.does_user_agree")
     mock.return_value = False
     return mocker
 
 
 @pytest.fixture
 def mock_cliprofile_namespace(mocker):
-    return mocker.patch("{}.cmds.profile.cliprofile".format(PRODUCT_NAME))
+    return mocker.patch("code42cli.cmds.profile.cliprofile")
 
 
 @pytest.fixture(autouse=True)
 def mock_getpass(mocker):
-    mock = mocker.patch("{}.cmds.profile.getpass".format(PRODUCT_NAME))
+    mock = mocker.patch("code42cli.cmds.profile.getpass")
     mock.return_value = "newpassword"
 
 
 @pytest.fixture
 def mock_verify(mocker):
-    return mocker.patch("{}.cmds.profile.create_sdk".format(PRODUCT_NAME))
+    return mocker.patch("code42cli.cmds.profile.create_sdk")
 
 
 @pytest.fixture

--- a/tests/cmds/test_profile.py
+++ b/tests/cmds/test_profile.py
@@ -1,5 +1,6 @@
 import pytest
 from py42.exceptions import Py42MFARequiredError
+from py42.sdk import SDKClient
 from requests import Response
 from requests.exceptions import HTTPError
 
@@ -37,12 +38,13 @@ def mock_getpass(mocker):
 
 @pytest.fixture
 def mock_verify(mocker):
-    return mocker.patch("{}.cmds.profile.validate_connection".format(PRODUCT_NAME))
+    return mocker.patch("{}.cmds.profile.create_sdk".format(PRODUCT_NAME))
 
 
 @pytest.fixture
-def valid_connection(mock_verify):
-    mock_verify.return_value = True
+def valid_connection(mocker, mock_verify):
+    mock_sdk = mocker.MagicMock(spec=SDKClient)
+    mock_verify.return_value = mock_sdk
     return mock_verify
 
 

--- a/tests/cmds/test_profile.py
+++ b/tests/cmds/test_profile.py
@@ -394,10 +394,20 @@ def test_update_profile_when_given_zero_args_prints_error_message(
     result = runner.invoke(cli, ["profile", "update"])
     expected = (
         "Must provide at least one of `--username`, `--server`, `--password`, "
-        "or `--disable-ssl-errors` when updating a profile."
+        "or `--disable-ssl-errors/--enable-ssl-errors` when updating a profile."
     )
     assert "Profile 'foo' has been updated" not in result.output
     assert expected in result.output
+
+
+def test_update_profile_with_enable_ssl_errors_sets_disable_ssl_to_false(
+    runner, mock_cliprofile_namespace, profile
+):
+    mock_cliprofile_namespace.get_profile.return_value = profile
+    runner.invoke(cli, ["profile", "update", "--enable-ssl-errors"])
+    mock_cliprofile_namespace.update_profile.assert_called_once_with(
+        profile.name, None, None, False
+    )
 
 
 def test_delete_profile_warns_if_deleting_default(runner, mock_cliprofile_namespace):

--- a/tests/test_sdk_client.py
+++ b/tests/test_sdk_client.py
@@ -16,7 +16,6 @@ from code42cli.errors import LoggedCLIError
 from code42cli.main import cli
 from code42cli.options import CLIState
 from code42cli.sdk_client import create_sdk
-from code42cli.sdk_client import validate_connection
 
 
 @pytest.fixture
@@ -27,6 +26,17 @@ def sdk_logger(mocker):
 @pytest.fixture
 def mock_sdk_factory(mocker):
     return mocker.patch("py42.sdk.from_local_account")
+
+
+@pytest.fixture
+def mock_profile_with_password():
+    profile = create_mock_profile()
+
+    def mock_get_password():
+        return "Test Password"
+
+    profile.get_password = mock_get_password
+    return profile
 
 
 @pytest.fixture
@@ -54,78 +64,63 @@ def test_create_sdk_when_profile_has_ssl_errors_disabled_sets_py42_setting_and_p
 
 
 def test_create_sdk_when_py42_exception_occurs_raises_and_logs_cli_error(
-    sdk_logger, mock_sdk_factory, requests_exception
+    sdk_logger, mock_sdk_factory, requests_exception, mock_profile_with_password
 ):
 
     mock_sdk_factory.side_effect = Py42UnauthorizedError(requests_exception)
-    profile = create_mock_profile()
 
-    def mock_get_password():
-        return "Test Password"
-
-    profile.get_password = mock_get_password
     with pytest.raises(Code42CLIError) as err:
-        create_sdk(profile, False)
+        create_sdk(mock_profile_with_password, False)
 
     assert "Invalid credentials for user" in err.value.message
     assert sdk_logger.log_error.call_count == 1
-    assert "Failure in HTTP call" in sdk_logger.log_error.call_args[0][0]
+    assert "Failure in HTTP call" in str(sdk_logger.log_error.call_args[0][0])
 
 
 def test_create_sdk_when_connection_exception_occurs_raises_and_logs_cli_error(
-    sdk_logger, mock_sdk_factory
+    sdk_logger, mock_sdk_factory, mock_profile_with_password
 ):
     mock_sdk_factory.side_effect = ConnectionError("connection message")
-    profile = create_mock_profile()
 
-    def mock_get_password():
-        return "Test Password"
-
-    profile.get_password = mock_get_password
     with pytest.raises(LoggedCLIError) as err:
-        create_sdk(profile, False)
+        create_sdk(mock_profile_with_password, False)
 
     assert "Problem connecting to" in err.value.message
     assert sdk_logger.log_error.call_count == 1
-    assert "connection message" in sdk_logger.log_error.call_args[0][0]
+    assert "connection message" in str(sdk_logger.log_error.call_args[0][0])
 
 
 def test_create_sdk_when_unknown_exception_occurs_raises_and_logs_cli_error(
-    sdk_logger, mock_sdk_factory
+    sdk_logger, mock_sdk_factory, mock_profile_with_password
 ):
     mock_sdk_factory.side_effect = Exception("test message")
-    profile = create_mock_profile()
 
-    def mock_get_password():
-        return "Test Password"
-
-    profile.get_password = mock_get_password
     with pytest.raises(LoggedCLIError) as err:
-        create_sdk(profile, False)
+        create_sdk(mock_profile_with_password, False)
 
     assert "Unknown problem validating" in err.value.message
     assert sdk_logger.log_error.call_count == 1
-    assert "test message" in sdk_logger.log_error.call_args[0][0]
+    assert "test message" in str(sdk_logger.log_error.call_args[0][0])
 
 
-def test_create_sdk_when_told_to_debug_turns_on_debug(mock_sdk_factory):
-    profile = create_mock_profile()
-
-    def mock_get_password():
-        return "Test Password"
-
-    profile.get_password = mock_get_password
-    create_sdk(profile, True)
+def test_create_sdk_when_told_to_debug_turns_on_debug(
+    mock_sdk_factory, mock_profile_with_password
+):
+    create_sdk(mock_profile_with_password, True)
     assert py42.settings.debug.level == debug.DEBUG
 
 
-def test_validate_connection_uses_given_credentials(mock_sdk_factory):
-    assert validate_connection("Authority", "Test", "Password", None)
-    mock_sdk_factory.assert_called_once_with("Authority", "Test", "Password", totp=None)
+def test_create_sdk_uses_given_credentials(
+    mock_sdk_factory, mock_profile_with_password
+):
+    create_sdk(mock_profile_with_password, False)
+    mock_sdk_factory.assert_called_once_with(
+        "example.com", "foo", "Test Password", totp=None
+    )
 
 
 def test_validate_connection_when_mfa_required_exception_raised_prompts_for_totp(
-    mocker, monkeypatch, mock_sdk_factory, capsys
+    mocker, monkeypatch, mock_sdk_factory, capsys, mock_profile_with_password
 ):
     monkeypatch.setattr("sys.stdin", StringIO("101010"))
     response = mocker.MagicMock(spec=Response)
@@ -133,20 +128,20 @@ def test_validate_connection_when_mfa_required_exception_raised_prompts_for_totp
         Py42MFARequiredError(HTTPError(response=response)),
         None,
     ]
-    validate_connection("Authority", "Test", "Password", None)
+    create_sdk(mock_profile_with_password, False)
     output = capsys.readouterr()
     assert "Multi-factor authentication required. Enter TOTP:" in output.out
 
 
 def test_validate_connection_when_mfa_token_invalid_raises_expected_cli_error(
-    mocker, mock_sdk_factory
+    mocker, mock_sdk_factory, mock_profile_with_password
 ):
     response = mocker.MagicMock(spec=Response)
     response.text = '{"data":null,"error":[{"primaryErrorKey":"INVALID_TIME_BASED_ONE_TIME_PASSWORD","otherErrors":null}],"warnings":null}'
     mock_sdk_factory.side_effect = Py42UnauthorizedError(HTTPError(response=response))
     with pytest.raises(Code42CLIError) as err:
-        validate_connection("Authority", "Test", "Password", "1234")
-    assert str(err.value) == "Invalid TOTP token for user Test."
+        create_sdk(mock_profile_with_password, False, totp="1234")
+    assert str(err.value) == "Invalid TOTP token for user foo."
 
 
 def test_totp_option_when_passed_is_passed_to_sdk_initialization(

--- a/tests/test_sdk_client.py
+++ b/tests/test_sdk_client.py
@@ -119,7 +119,7 @@ def test_create_sdk_uses_given_credentials(
     )
 
 
-def test_validate_connection_when_mfa_required_exception_raised_prompts_for_totp(
+def test_create_sdk_connection_when_mfa_required_exception_raised_prompts_for_totp(
     mocker, monkeypatch, mock_sdk_factory, capsys, mock_profile_with_password
 ):
     monkeypatch.setattr("sys.stdin", StringIO("101010"))
@@ -133,7 +133,7 @@ def test_validate_connection_when_mfa_required_exception_raised_prompts_for_totp
     assert "Multi-factor authentication required. Enter TOTP:" in output.out
 
 
-def test_validate_connection_when_mfa_token_invalid_raises_expected_cli_error(
+def test_create_sdk_connection_when_mfa_token_invalid_raises_expected_cli_error(
     mocker, mock_sdk_factory, mock_profile_with_password
 ):
     response = mocker.MagicMock(spec=Response)


### PR DESCRIPTION
This PR makes `validate_connection()` internal and has the profile commands use `create_sdk()` instead so they can succeed when ssl verification is turned off and they hit a server with a bad cert. 

It also adds the `--enable-ssl-errors` option to `profile update` to allow a user to re-enable verification on a profile that had it disabled (the only way prior to this was to either delete/recreate profile or manually edit the config.cfg