### PR TITLE
auto console w sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 - New command `code42 users remove-role` to remove a user role from a single user.
 
+- New command `code42 console` that opens an IPython console with a pre-initialized py42 sdk.
+
 ## 1.6.1 - 2021-05-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 - New command `code42 users remove-role` to remove a user role from a single user.
 
-- New command `code42 console` that opens an IPython console with a pre-initialized py42 sdk.
+- New command `code42 shell` that opens an IPython console with a pre-initialized py42 sdk.
 
 ## 1.6.1 - 2021-05-27
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         "c42eventextractor==0.4.1",
         "keyring==18.0.1",
         "keyrings.alt==3.2.0",
-        "ipython>=7.24.1",
+        "ipython>=7.16.1",
         "pandas>=1.1.3",
         "py42>=1.14.2",
     ],

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         "c42eventextractor==0.4.1",
         "keyring==18.0.1",
         "keyrings.alt==3.2.0",
+        "ipython>=7.24.1",
         "pandas>=1.1.3",
         "py42>=1.14.2",
     ],

--- a/src/code42cli/__init__.py
+++ b/src/code42cli/__init__.py
@@ -1,2 +1,15 @@
+from py42.__version__ import __version__ as py42version
+
+from code42cli.__version__ import __version__ as cliversion
+
+
 PRODUCT_NAME = "code42cli"
 MAIN_COMMAND = "code42"
+BANNER = f"""\b
+ dP""b8  dP"Yb  8888b. 888888  dP88  oP"Yb.
+dP   `" dP   Yb 8I  Yb 88__   dP 88  "' dP'
+Yb      Yb   dP 8I  dY 88""  d888888   dP'
+ YboodP  YbodP  8888Y" 888888    88  .d8888
+
+code42cli version {cliversion}, by Code42 Software.
+powered by py42 version {py42version}."""

--- a/src/code42cli/cmds/console.py
+++ b/src/code42cli/cmds/console.py
@@ -1,0 +1,12 @@
+import click
+import IPython
+
+from code42cli import BANNER
+from code42cli.options import sdk_options
+
+
+@click.command()
+@sdk_options()
+def console(state):
+    """Open an IPython shell with py42 initialized as `sdk`."""
+    IPython.embed(colors="Neutral", banner1=BANNER, user_ns={"sdk": state.sdk})

--- a/src/code42cli/cmds/shell.py
+++ b/src/code42cli/cmds/shell.py
@@ -7,6 +7,6 @@ from code42cli.options import sdk_options
 
 @click.command()
 @sdk_options()
-def console(state):
+def shell(state):
     """Open an IPython shell with py42 initialized as `sdk`."""
     IPython.embed(colors="Neutral", banner1=BANNER, user_ns={"sdk": state.sdk})

--- a/src/code42cli/main.py
+++ b/src/code42cli/main.py
@@ -13,13 +13,13 @@ from code42cli.cmds.alert_rules import alert_rules
 from code42cli.cmds.alerts import alerts
 from code42cli.cmds.auditlogs import audit_logs
 from code42cli.cmds.cases import cases
-from code42cli.cmds.console import console
 from code42cli.cmds.departing_employee import departing_employee
 from code42cli.cmds.devices import devices
 from code42cli.cmds.high_risk_employee import high_risk_employee
 from code42cli.cmds.legal_hold import legal_hold
 from code42cli.cmds.profile import profile
 from code42cli.cmds.securitydata import security_data
+from code42cli.cmds.shell import shell
 from code42cli.cmds.users import users
 from code42cli.options import sdk_options
 
@@ -64,13 +64,13 @@ def cli(state, python):
 
 cli.add_command(alerts)
 cli.add_command(alert_rules)
-cli.add_command(security_data)
+cli.add_command(audit_logs)
+cli.add_command(cases)
 cli.add_command(departing_employee)
+cli.add_command(devices)
 cli.add_command(high_risk_employee)
 cli.add_command(legal_hold)
 cli.add_command(profile)
-cli.add_command(devices)
+cli.add_command(security_data)
+cli.add_command(shell)
 cli.add_command(users)
-cli.add_command(audit_logs)
-cli.add_command(cases)
-cli.add_command(console)

--- a/src/code42cli/main.py
+++ b/src/code42cli/main.py
@@ -4,16 +4,16 @@ import sys
 import click
 from click_plugins import with_plugins
 from pkg_resources import iter_entry_points
-from py42.__version__ import __version__ as py42version
 from py42.settings import set_user_agent_suffix
 
+from code42cli import BANNER
 from code42cli import PRODUCT_NAME
-from code42cli.__version__ import __version__ as cliversion
 from code42cli.click_ext.groups import ExceptionHandlingGroup
 from code42cli.cmds.alert_rules import alert_rules
 from code42cli.cmds.alerts import alerts
 from code42cli.cmds.auditlogs import audit_logs
 from code42cli.cmds.cases import cases
+from code42cli.cmds.console import console
 from code42cli.cmds.departing_employee import departing_employee
 from code42cli.cmds.devices import devices
 from code42cli.cmds.high_risk_employee import high_risk_employee
@@ -22,15 +22,6 @@ from code42cli.cmds.profile import profile
 from code42cli.cmds.securitydata import security_data
 from code42cli.cmds.users import users
 from code42cli.options import sdk_options
-
-BANNER = f"""\b
- dP""b8  dP"Yb  8888b. 888888  dP88  oP"Yb.
-dP   `" dP   Yb 8I  Yb 88__   dP 88  "' dP'
-Yb      Yb   dP 8I  dY 88""  d888888   dP'
- YboodP  YbodP  8888Y" 888888    88  .d8888
-
-code42cli version {cliversion}, by Code42 Software.
-powered by py42 version {py42version}."""
 
 
 # Handle KeyboardInterrupts by just exiting instead of printing out a stack
@@ -82,3 +73,4 @@ cli.add_command(devices)
 cli.add_command(users)
 cli.add_command(audit_logs)
 cli.add_command(cases)
+cli.add_command(console)


### PR DESCRIPTION
Adds a new command that automatically opens a shell with a pre-initialized py42 SDK.

```
code42 console
```

```python
 dP""b8  dP"Yb  8888b. 888888  dP88  oP"Yb.
dP   `" dP   Yb 8I  Yb 88__   dP 88  "' dP'
Yb      Yb   dP 8I  dY 88""  d888888   dP'
 YboodP  YbodP  8888Y" 888888    88  .d8888

code42cli version 1.6.1, by Code42 Software.
powered by py42 version 1.14.2.
In [1]: sdk.users.get_current()
Out[1]: <Py42Response [status=200, data={'active': True, 'blocked': False, 'creationDate': '2019-09-30T21:03:08.587Z', 'email': 'juliya.smith...rs@code42.com', ...}]>
```

This is useful for running more complex commands using py42, observing responses from py42, and would save time for QA individual testing py42 - they can instead call



with a code42cli profile already setup and in-use... Then, they can start using the `sdk`.