### PR TITLE
Query Alerts with Microsecond precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+## Unreleased
+
+### Changed
+
+- `code42 alerts search` now uses microsecond precision when searching by alerts' date observed.
+
 ## 1.7.0 - 2021-06-17
 
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "keyrings.alt==3.2.0",
         "ipython>=7.16.1",
         "pandas>=1.1.3",
-        "py42>=1.15.0",
+        "py42>=1.15.1",
     ],
     extras_require={
         "dev": [

--- a/src/code42cli/date_helper.py
+++ b/src/code42cli/date_helper.py
@@ -48,4 +48,4 @@ def round_datetime_to_day_start(dt):
 
 
 def round_datetime_to_day_end(dt):
-    return dt.replace(hour=23, minute=59, second=59, microsecond=999000)
+    return dt.replace(hour=23, minute=59, second=59, microsecond=999999)

--- a/tests/cmds/test_alerts.py
+++ b/tests/cmds/test_alerts.py
@@ -114,9 +114,9 @@ ADVANCED_QUERY_VALUES = {
     "state_2": "PENDING",
     "state_3": "IN_PROGRESS",
     "actor": "test@example.com",
-    "on_or_after": "2020-01-01T06:00:00.000Z",
+    "on_or_after": "2020-01-01T06:00:00.000000Z",
     "on_or_after_timestamp": 1577858400.0,
-    "on_or_before": "2020-02-01T06:00:00.000Z",
+    "on_or_before": "2020-02-01T06:00:00.000000Z",
     "on_or_before_timestamp": 1580536800.0,
     "rule_id": "xyz123",
 }
@@ -328,7 +328,7 @@ def alert_cursor_without_checkpoint(mocker):
 def begin_option(mocker):
     mock = mocker.patch(f"{PRODUCT_NAME}.cmds.alerts.convert_datetime_to_timestamp")
     mock.return_value = BEGIN_TIMESTAMP
-    mock.expected_timestamp = "2020-01-01T06:00:00.000Z"
+    mock.expected_timestamp = "2020-01-01T06:00:00.000000Z"
     return mock
 
 
@@ -428,9 +428,9 @@ def test_search_and_send_to_when_given_begin_and_end_dates_uses_expected_query(
     )
     filters = alert_extractor.extract.call_args[0][0]
     actual_begin = get_filter_value_from_json(filters, filter_index=0)
-    expected_begin = f"{begin_date}T00:00:00.000Z"
+    expected_begin = f"{begin_date}T00:00:00.000000Z"
     actual_end = get_filter_value_from_json(filters, filter_index=1)
-    expected_end = f"{end_date}T23:59:59.999Z"
+    expected_end = f"{end_date}T23:59:59.999999Z"
     assert actual_begin == expected_begin
     assert actual_end == expected_end
 
@@ -449,9 +449,9 @@ def test_search_when_given_begin_and_end_date_and_times_uses_expected_query(
     )
     filters = alert_extractor.extract.call_args[0][0]
     actual_begin = get_filter_value_from_json(filters, filter_index=0)
-    expected_begin = f"{begin_date}T{time}.000Z"
+    expected_begin = f"{begin_date}T{time}.000000Z"
     actual_end = get_filter_value_from_json(filters, filter_index=1)
-    expected_end = f"{end_date}T{time}.000Z"
+    expected_end = f"{end_date}T{time}.000000Z"
     assert actual_begin == expected_begin
     assert actual_end == expected_end
 
@@ -466,7 +466,7 @@ def test_search_when_given_begin_date_and_time_without_seconds_uses_expected_que
     actual = get_filter_value_from_json(
         alert_extractor.extract.call_args[0][0], filter_index=0
     )
-    expected = f"{date}T{time}:00.000Z"
+    expected = f"{date}T{time}:00.000000Z"
     assert actual == expected
 
 
@@ -485,7 +485,7 @@ def test_search_and_send_to_when_given_end_date_and_time_uses_expected_query(
     actual = get_filter_value_from_json(
         alert_extractor.extract.call_args[0][0], filter_index=1
     )
-    expected = f"{end_date}T{time}:00.000Z"
+    expected = f"{end_date}T{time}:00.000000Z"
     assert actual == expected
 
 
@@ -521,7 +521,7 @@ def test_search_and_send_to_when_given_begin_date_and_not_use_checkpoint_and_cur
     actual_ts = get_filter_value_from_json(
         alert_extractor.extract.call_args[0][0], filter_index=0
     )
-    expected_ts = f"{begin_date}T00:00:00.000Z"
+    expected_ts = f"{begin_date}T00:00:00.000000Z"
     assert actual_ts == expected_ts
     assert filter_term_is_in_call_args(alert_extractor, f.DateObserved._term)
 
@@ -768,7 +768,7 @@ def test_search_and_send_to_with_or_query_flag_produces_expected_query(
                     {
                         "operator": "ON_OR_AFTER",
                         "term": "createdAt",
-                        "value": f"{begin_date}T00:00:00.000Z",
+                        "value": f"{begin_date}T00:00:00.000000Z",
                     }
                 ],
             },

--- a/tests/test_magic_date_type.py
+++ b/tests/test_magic_date_type.py
@@ -117,7 +117,7 @@ class TestMagicDateRoundingToEnd:
         actual = self.convert(end_date_str)
         expected = datetime.strptime(end_date_str, "%Y-%m-%d")
         expected = utc(
-            expected.replace(hour=23, minute=59, second=59, microsecond=999000)
+            expected.replace(hour=23, minute=59, second=59, microsecond=999999)
         )
         assert actual == expected
 
@@ -130,7 +130,7 @@ class TestMagicDateRoundingToEnd:
         actual_date = self.convert("20d")
         expected_date = get_test_date(days_ago=20)
         expected_date = utc(
-            expected_date.replace(hour=23, minute=59, second=59, microsecond=999000)
+            expected_date.replace(hour=23, minute=59, second=59, microsecond=999999)
         )
         assert actual_date == expected_date
 


### PR DESCRIPTION
Requires this pr to merge: https://github.com/code42/py42/pull/336
And a new release of py42.

Use microsecond precision when querying for alerts.