### PR TITLE
Update user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ## Unreleased
 
+### Added
+
+- New command `code42 users update` to update a single user.
+
+- New command `code42 users bulk update` to update users in bulk.
+
 ### Changed
 
 - `code42 alerts search` now uses microsecond precision when searching by alerts' date observed.

--- a/src/code42cli/click_ext/groups.py
+++ b/src/code42cli/click_ext/groups.py
@@ -12,6 +12,7 @@ from py42.exceptions import Py42InvalidRuleOperationError
 from py42.exceptions import Py42LegalHoldNotFoundOrPermissionDeniedError
 from py42.exceptions import Py42UpdateClosedCaseError
 from py42.exceptions import Py42UserAlreadyAddedError
+from py42.exceptions import Py42UsernameMustBeEmailError
 from py42.exceptions import Py42UserNotOnListError
 
 from code42cli.errors import Code42CLIError
@@ -67,6 +68,7 @@ class ExceptionHandlingGroup(click.Group):
             Py42DescriptionLimitExceededError,
             Py42CaseAlreadyHasEventError,
             Py42UpdateClosedCaseError,
+            Py42UsernameMustBeEmailError,
         ) as err:
             self.logger.log_error(err)
             raise Code42CLIError(str(err))

--- a/src/code42cli/cmds/devices.py
+++ b/src/code42cli/cmds/devices.py
@@ -573,7 +573,7 @@ bulk.add_command(devices_generate_template)
 def bulk_deactivate(state, csv_rows, change_device_name, purge_date, format):
     """Deactivate all devices from the provided CSV containing a 'guid' column."""
     sdk = state.sdk
-    csv_rows[0]["deactivated"] = False
+    csv_rows[0]["deactivated"] = "False"
     formatter = OutputFormatter(format, {key: key for key in csv_rows[0].keys()})
     for row in csv_rows:
         row["change_device_name"] = change_device_name

--- a/src/code42cli/cmds/users.py
+++ b/src/code42cli/cmds/users.py
@@ -33,6 +33,9 @@ inactive_option = click.option(
 )
 
 
+user_uid_option = click.option("--user-id", help="The unique identifier of the user to be modified.", required=True)
+
+
 def role_name_option(help):
     return click.option("--role-name", help=help)
 
@@ -84,6 +87,43 @@ def remove_role(state, username, role_name):
     _remove_user_role(state.sdk, role_name, username)
 
 
+@users.command(name="update")
+@user_uid_option
+@click.option("--username", help="The new username for the user.")
+@click.option("--password", help="The new password for the user.")
+@click.option("--email", help="The new email for the user.")
+@click.option("--first-name", help="The new first name for the user.")
+@click.option("--last-name", help="The new last name for the user.")
+@click.option("--notes", help="Notes about this user.")
+@click.option(
+    "--archive-size-quota", help="The total size (in bytes) allowed for this user."
+)
+@sdk_options()
+def update_user(
+    state,
+    user_id,
+    username,
+    email,
+    password,
+    first_name,
+    last_name,
+    notes,
+    archive_size_quota,
+):
+    """Update a user with the specified unique identifier."""
+    _update_user(
+        state.sdk,
+        user_id,
+        username,
+        email,
+        password,
+        first_name,
+        last_name,
+        notes,
+        archive_size_quota,
+    )
+
+
 def _add_user_role(sdk, username, role_name):
     user_id = _get_user_id(sdk, username)
     _get_role_id(sdk, role_name)  # function provides role name validation
@@ -122,3 +162,26 @@ def _get_users_dataframe(sdk, columns, org_uid, role_id, active):
         users_list.extend(page["users"])
 
     return DataFrame.from_records(users_list, columns=columns)
+
+
+def _update_user(
+    sdk,
+    user_uid,
+    username,
+    email,
+    password,
+    first_name,
+    last_name,
+    notes,
+    archive_size_quota_bytes,
+):
+    return sdk.users.update_user(
+        user_uid,
+        username=username,
+        email=email,
+        password=password,
+        first_name=first_name,
+        last_name=last_name,
+        notes=notes,
+        archive_size_quota_bytes=archive_size_quota_bytes,
+    )

--- a/src/code42cli/cmds/users.py
+++ b/src/code42cli/cmds/users.py
@@ -33,7 +33,9 @@ inactive_option = click.option(
 )
 
 
-user_uid_option = click.option("--user-id", help="The unique identifier of the user to be modified.", required=True)
+user_uid_option = click.option(
+    "--user-id", help="The unique identifier of the user to be modified.", required=True
+)
 
 
 def role_name_option(help):

--- a/src/code42cli/cmds/users.py
+++ b/src/code42cli/cmds/users.py
@@ -163,7 +163,7 @@ bulk.add_command(users_generate_template)
 @sdk_options()
 def bulk_update(state, csv_rows, format):
     """Update a list of users from the provided CSV."""
-    csv_rows[0]["updated"] = False
+    csv_rows[0]["updated"] = "False"
     formatter = OutputFormatter(format, {key: key for key in csv_rows[0].keys()})
 
     def handle_row(**row):

--- a/tests/cmds/test_devices.py
+++ b/tests/cmds/test_devices.py
@@ -822,7 +822,7 @@ def test_bulk_deactivate_uses_expected_arguments(runner, mocker, cli_state):
     assert bulk_processor.call_args[0][1] == [
         {
             "guid": "test",
-            "deactivated": False,
+            "deactivated": "False",
             "change_device_name": False,
             "purge_date": None,
         }

--- a/tests/cmds/test_users.py
+++ b/tests/cmds/test_users.py
@@ -81,6 +81,10 @@ def get_available_roles_success(cli_state, get_available_roles_response):
 def get_available_roles_success(cli_state, update_user_response):
     cli_state.sdk.users.update_user.return_value = update_user_response
 
+@pytest.fixture
+def update_user_success(cli_state, update_user_response):
+    cli_state.sdk.users.get_by_username.return_value = update_user_response
+
 
 def test_list_when_non_table_format_outputs_expected_columns(
     runner, cli_state, get_all_users_success
@@ -281,6 +285,6 @@ def test_update_user_calls_update_user_with_correct_parameters(runner, cli_state
         "test_email"
     ]
     result = runner.invoke(cli, command, obj=cli_state)
-    cli_state.sdk.users.remove_role.assert_called_once_with(
+    cli_state.sdk.users.update.assert_called_once_with(
         "12345", email="test_email"
     )

--- a/tests/cmds/test_users.py
+++ b/tests/cmds/test_users.py
@@ -49,9 +49,11 @@ def _create_py42_response(mocker, text):
 def get_all_users_generator():
     yield TEST_USERS_RESPONSE
 
+
 @pytest.fixture
 def update_user_response(mocker):
     return _create_py42_response(mocker, "")
+
 
 @pytest.fixture
 def get_available_roles_response(mocker):
@@ -76,6 +78,7 @@ def get_user_id_failure(cli_state):
 @pytest.fixture
 def get_available_roles_success(cli_state, get_available_roles_response):
     cli_state.sdk.users.get_available_roles.return_value = get_available_roles_response
+
 
 @pytest.fixture
 def update_user_success(cli_state, update_user_response):
@@ -271,23 +274,19 @@ def test_remove_user_role_raises_error_when_username_does_not_exist(
     assert result.exit_code == 1
     assert "User 'not_a_username@example.com' does not exist." in result.output
 
-def test_update_user_calls_update_user_with_correct_parameters(runner, cli_state, update_user_success):
-    command = [
-        "users",
-        "update",
-        "--user-id",
-        "12345",
-        "--email",
-        "test_email"
-    ]
-    result = runner.invoke(cli, command, obj=cli_state)
+
+def test_update_user_calls_update_user_with_correct_parameters(
+    runner, cli_state, update_user_success
+):
+    command = ["users", "update", "--user-id", "12345", "--email", "test_email"]
+    runner.invoke(cli, command, obj=cli_state)
     cli_state.sdk.users.update_user.assert_called_once_with(
-        "12345", 
+        "12345",
         username=None,
         email="test_email",
         password=None,
         first_name=None,
         last_name=None,
         notes=None,
-        archive_size_quota_bytes=None
+        archive_size_quota_bytes=None,
     )

--- a/tests/cmds/test_users.py
+++ b/tests/cmds/test_users.py
@@ -7,6 +7,8 @@ from requests import Response
 from code42cli.main import cli
 
 
+_NAMESPACE = "code42cli.cmds.users"
+
 TEST_ROLE_RETURN_DATA = {
     "data": [{"roleName": "Customer Cloud Admin", "roleId": "1234543"}]
 }
@@ -290,3 +292,29 @@ def test_update_user_calls_update_user_with_correct_parameters(
         notes=None,
         archive_size_quota_bytes=None,
     )
+
+def test_bulk_deactivate_uses_expected_arguments(runner, mocker, cli_state):
+    bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
+    with runner.isolated_filesystem():
+        with open("test_bulk_update.csv", "w") as csv:
+            csv.writelines([
+                "user_id,username,email,password,first_name,last_name,notes,archive_size_quota\n",
+                "12345,,test_email,,,,,\n"
+            ])
+        runner.invoke(
+            cli,
+            ["users","bulk","update","test_bulk_update.csv"],
+            obj=cli_state
+        )
+    assert bulk_processor.call_args[0][1] == [{
+        "user_id":"12345",
+        "username":'',
+        "email":"test_email",
+        "password":'',
+        "first_name":'',
+        "last_name":'',
+        "notes":'',
+        "archive_size_quota":'',
+        "updated":False
+    }]
+

--- a/tests/cmds/test_users.py
+++ b/tests/cmds/test_users.py
@@ -293,28 +293,30 @@ def test_update_user_calls_update_user_with_correct_parameters(
         archive_size_quota_bytes=None,
     )
 
+
 def test_bulk_deactivate_uses_expected_arguments(runner, mocker, cli_state):
     bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
     with runner.isolated_filesystem():
         with open("test_bulk_update.csv", "w") as csv:
-            csv.writelines([
-                "user_id,username,email,password,first_name,last_name,notes,archive_size_quota\n",
-                "12345,,test_email,,,,,\n"
-            ])
+            csv.writelines(
+                [
+                    "user_id,username,email,password,first_name,last_name,notes,archive_size_quota\n",
+                    "12345,,test_email,,,,,\n",
+                ]
+            )
         runner.invoke(
-            cli,
-            ["users","bulk","update","test_bulk_update.csv"],
-            obj=cli_state
+            cli, ["users", "bulk", "update", "test_bulk_update.csv"], obj=cli_state
         )
-    assert bulk_processor.call_args[0][1] == [{
-        "user_id":"12345",
-        "username":'',
-        "email":"test_email",
-        "password":'',
-        "first_name":'',
-        "last_name":'',
-        "notes":'',
-        "archive_size_quota":'',
-        "updated":False
-    }]
-
+    assert bulk_processor.call_args[0][1] == [
+        {
+            "user_id": "12345",
+            "username": "",
+            "email": "test_email",
+            "password": "",
+            "first_name": "",
+            "last_name": "",
+            "notes": "",
+            "archive_size_quota": "",
+            "updated": False,
+        }
+    ]

--- a/tests/cmds/test_users.py
+++ b/tests/cmds/test_users.py
@@ -78,12 +78,8 @@ def get_available_roles_success(cli_state, get_available_roles_response):
     cli_state.sdk.users.get_available_roles.return_value = get_available_roles_response
 
 @pytest.fixture
-def get_available_roles_success(cli_state, update_user_response):
-    cli_state.sdk.users.update_user.return_value = update_user_response
-
-@pytest.fixture
 def update_user_success(cli_state, update_user_response):
-    cli_state.sdk.users.get_by_username.return_value = update_user_response
+    cli_state.sdk.users.update_user.return_value = update_user_response
 
 
 def test_list_when_non_table_format_outputs_expected_columns(
@@ -285,6 +281,13 @@ def test_update_user_calls_update_user_with_correct_parameters(runner, cli_state
         "test_email"
     ]
     result = runner.invoke(cli, command, obj=cli_state)
-    cli_state.sdk.users.update.assert_called_once_with(
-        "12345", email="test_email"
+    cli_state.sdk.users.update_user.assert_called_once_with(
+        "12345", 
+        username=None,
+        email="test_email",
+        password=None,
+        first_name=None,
+        last_name=None,
+        notes=None,
+        archive_size_quota_bytes=None
     )


### PR DESCRIPTION
**Description of Change**

This change adds a method `code42 users update` to update a single user, and the corresponding bulk method `code42 users bulk update`

It partially addresses (but does not fully address) issue #259

**Testing Procedure**

```
code42 users update --user-id <user-id> --email <new email>
code42 users bulk update users_to_update.csv
```

**PR Checklist**

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes
