### PR TITLE
add move and bulk move methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 - New command `code42 users bulk update` to update users in bulk.
 
+- New command `code42 users move` to move a single user to a different organization.
+
+- New command `code42 users bulk move` to move users in bulk.
+
 ### Changed
 
 - `code42 alerts search` now uses microsecond precision when searching by alerts' date observed.

--- a/src/code42cli/cmds/users.py
+++ b/src/code42cli/cmds/users.py
@@ -290,5 +290,5 @@ def _update_user(
 
 
 def _change_organization(sdk, username, org_id):
-    user_id=_get_user_id(sdk, username)
+    user_id = _get_user_id(sdk, username)
     return sdk.users.change_org_assignment(user_id=int(user_id), org_id=int(org_id))

--- a/src/code42cli/cmds/users.py
+++ b/src/code42cli/cmds/users.py
@@ -171,7 +171,10 @@ def bulk(state):
 
 users_generate_template = generate_template_cmd_factory(
     group_name="users",
-    commands_dict={"update": _bulk_user_update_headers},
+    commands_dict={
+        "update": _bulk_user_update_headers,
+        "move": _bulk_user_move_headers,
+    },
     help_message="Generate the CSV template needed for bulk user commands.",
 )
 bulk.add_command(users_generate_template)

--- a/src/code42cli/cmds/users.py
+++ b/src/code42cli/cmds/users.py
@@ -152,11 +152,11 @@ _bulk_user_move_headers = ["username", "org_id"]
 
 
 @users.command(name="move")
-@username_option("The username of the user to be moved.", required=True)
+@username_option("The username of the user to move.", required=True)
 @org_id_option
 @sdk_options()
 def change_organization(state, username, org_id):
-    """Move the user with the given username to the org with the given org ID"""
+    """Change the organization of the user with the given username to the org with the given org ID."""
     _change_organization(state.sdk, username, org_id)
 
 
@@ -208,7 +208,7 @@ def bulk_update(state, csv_rows, format):
 @format_option
 @sdk_options()
 def bulk_move(state, csv_rows, format):
-    """Move the list of users from the provided CSV."""
+    """Change the organization of the list of users from the provided CSV."""
     csv_rows[0]["moved"] = "False"
     formatter = OutputFormatter(format, {key: key for key in csv_rows[0].keys()})
 

--- a/src/code42cli/cmds/users.py
+++ b/src/code42cli/cmds/users.py
@@ -53,8 +53,8 @@ def role_name_option(help):
     return click.option("--role-name", help=help)
 
 
-def username_option(help):
-    return click.option("--username", help=help)
+def username_option(help, required=False):
+    return click.option("--username", help=help, required=required)
 
 
 @users.command(name="list")
@@ -148,18 +148,16 @@ _bulk_user_update_headers = [
     "archive_size_quota",
 ]
 
-_bulk_user_move_headers = ["user_id", "org_id"]
+_bulk_user_move_headers = ["username", "org_id"]
 
 
 @users.command(name="move")
-@click.option(
-    "--user-id", help="The identifier for the user to be moved", required=True, type=int
-)
+@username_option("The username of the user to be moved.", required=True)
 @org_id_option
 @sdk_options()
-def change_organization(state, user_id, org_id):
-    """Move the user with the given user ID to the org with the given org ID"""
-    _change_organization(state.sdk, user_id, org_id)
+def change_organization(state, username, org_id):
+    """Move the user with the given username to the org with the given org ID"""
+    _change_organization(state.sdk, username, org_id)
 
 
 @users.group(cls=OrderedGroup)
@@ -291,5 +289,6 @@ def _update_user(
     )
 
 
-def _change_organization(sdk, user_id, org_id):
+def _change_organization(sdk, username, org_id):
+    user_id=_get_user_id(sdk, username)
     return sdk.users.change_org_assignment(user_id=int(user_id), org_id=int(org_id))

--- a/tests/cmds/test_users.py
+++ b/tests/cmds/test_users.py
@@ -401,12 +401,12 @@ def test_bulk_deactivate_uses_expected_arguments_when_all_are_passed(
 
 
 def test_change_org_calls_change_org_assignment_with_correct_parameters(
-    runner, cli_state, change_org_success
+    runner, cli_state, change_org_success, get_user_id_success
 ):
-    command = ["users", "move", "--user-id", "12345", "--org-id", "54321"]
+    command = ["users", "move", "--username", TEST_USERNAME, "--org-id", "54321"]
     runner.invoke(cli, command, obj=cli_state)
     cli_state.sdk.users.change_org_assignment.assert_called_once_with(
-        user_id=12345, org_id=54321
+        user_id=TEST_USER_ID, org_id=54321
     )
 
 
@@ -414,10 +414,10 @@ def test_bulk_move_uses_expected_arguments(runner, mocker, cli_state):
     bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
     with runner.isolated_filesystem():
         with open("test_bulk_move.csv", "w") as csv:
-            csv.writelines(["user_id,org_id\n", "12345,4321\n"])
+            csv.writelines(["username,org_id\n", f"{TEST_USERNAME},4321\n"])
         runner.invoke(
             cli, ["users", "bulk", "move", "test_bulk_move.csv"], obj=cli_state
         )
     assert bulk_processor.call_args[0][1] == [
-        {"user_id": "12345", "org_id": "4321", "moved": "False"}
+        {"username": TEST_USERNAME, "org_id": "4321", "moved": "False"}
     ]

--- a/tests/cmds/test_users.py
+++ b/tests/cmds/test_users.py
@@ -421,3 +421,4 @@ def test_bulk_move_uses_expected_arguments(runner, mocker, cli_state):
     assert bulk_processor.call_args[0][1] == [
         {"username": TEST_USERNAME, "org_id": "4321", "moved": "False"}
     ]
+    bulk_processor.assert_called_once()


### PR DESCRIPTION
**Description of Change**

This change adds `users move` and `users bulk move` methods to change a user's organization.

**Testing Procedure**

```
code42 users move --username <username> --org-id <org_id>
code42 users bulk move bulk_move_spreadsheet.csv
```

**Checklist**

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes