### PR TITLE
Fix 2 Bulk Bugs in the CLI (addressing QA feedback)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ### Fixed
 
-- Issue where `code42 devices bulk deactivate` and `code42 devices bulk reactivate` would 
+- Issue where `code42 devices bulk deactivate` and `code42 devices bulk reactivate` would
     output incorrect Successes and Failures at the end of the process.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ## Unreleased
 
+### Fixed
+
+- Issue where `code42 devices bulk deactivate` and `code42 devices bulk reactivate` would 
+    output incorrect Successes and Failures at the end of the process.
+
 ### Added
 
 - New command `code42 users update` to update a single user.

--- a/src/code42cli/bulk.py
+++ b/src/code42cli/bulk.py
@@ -74,6 +74,9 @@ def run_bulk_process(row_handler, rows, progress_label=None):
             either *args or **kwargs.
         rows (iterable): the rows to process.
         progress_label: a label that prints with the progress bar.
+    
+    Returns:
+        :class:`WorkerStats`: A class containing the successes and failures count.
     """
     processor = _create_bulk_processor(row_handler, rows, progress_label)
     return processor.run()

--- a/src/code42cli/bulk.py
+++ b/src/code42cli/bulk.py
@@ -74,7 +74,7 @@ def run_bulk_process(row_handler, rows, progress_label=None):
             either *args or **kwargs.
         rows (iterable): the rows to process.
         progress_label: a label that prints with the progress bar.
-    
+
     Returns:
         :class:`WorkerStats`: A class containing the successes and failures count.
     """

--- a/src/code42cli/cmds/devices.py
+++ b/src/code42cli/cmds/devices.py
@@ -592,18 +592,12 @@ def bulk_deactivate(state, csv_rows, change_device_name, purge_date, format):
             stats.increment_total_errors()
         return row
 
-    def handle_if_errors(*args, **kwargs):
-        """Still output rows to show individual row status by ignoring
-        the default CLI Log Error message.
-        """
-        pass
-
     result_rows = run_bulk_process(
         handle_row,
         csv_rows,
         progress_label="Deactivating devices:",
         stats=stats,
-        handle_if_errors=handle_if_errors,
+        raise_global_error=False,
     )
     formatter.echo_formatted_list(result_rows)
 
@@ -628,17 +622,11 @@ def bulk_reactivate(state, csv_rows, format):
             stats.increment_total_errors()
         return row
 
-    def handle_if_errors(*args, **kwargs):
-        """Still output rows to show individual row status by ignoring
-        the default CLI Log Error message.
-        """
-        pass
-
     result_rows = run_bulk_process(
         handle_row,
         csv_rows,
         progress_label="Reactivating devices:",
         stats=stats,
-        handle_if_errors=handle_if_errors,
+        raise_global_error=False,
     )
     formatter.echo_formatted_list(result_rows)

--- a/src/code42cli/cmds/devices.py
+++ b/src/code42cli/cmds/devices.py
@@ -587,6 +587,7 @@ def bulk_deactivate(state, csv_rows, change_device_name, purge_date, format):
             row["deactivated"] = "True"
         except Exception as err:
             row["deactivated"] = f"False: {err}"
+            raise
         return row
 
     result_rows = run_bulk_process(
@@ -602,7 +603,7 @@ def bulk_deactivate(state, csv_rows, change_device_name, purge_date, format):
 def bulk_reactivate(state, csv_rows, format):
     """Reactivate all devices from the provided CSV containing a 'guid' column."""
     sdk = state.sdk
-    csv_rows[0]["reactivated"] = False
+    csv_rows[0]["reactivated"] = "False"
     formatter = OutputFormatter(format, {key: key for key in csv_rows[0].keys()})
 
     def handle_row(**row):
@@ -611,6 +612,7 @@ def bulk_reactivate(state, csv_rows, format):
             row["reactivated"] = "True"
         except Exception as err:
             row["reactivated"] = f"False: {err}"
+            raise
         return row
 
     result_rows = run_bulk_process(

--- a/src/code42cli/cmds/users.py
+++ b/src/code42cli/cmds/users.py
@@ -164,7 +164,7 @@ def change_organization(state, username, org_id):
 @users.group(cls=OrderedGroup)
 @sdk_options(hidden=True)
 def bulk(state):
-    """Tools for managing users in bulk"""
+    """Tools for managing users in bulk."""
     pass
 
 
@@ -181,7 +181,7 @@ bulk.add_command(users_generate_template)
 
 @bulk.command(
     name="update",
-    help=f"Update a list of users from the provided CSV in format: "
+    help="Update a list of users from the provided CSV in format: "
     f"{','.join(_bulk_user_update_headers)}",
 )
 @read_csv_arg(headers=_bulk_user_update_headers)
@@ -222,7 +222,7 @@ def bulk_update(state, csv_rows, format):
 
 @bulk.command(
     name="move",
-    help=f"Change the organization of the list of users from the provided CSV in format: "
+    help="Change the organization of the list of users from the provided CSV in format: "
     f"{','.join(_bulk_user_move_headers)}",
 )
 @read_csv_arg(headers=_bulk_user_move_headers)

--- a/src/code42cli/cmds/users.py
+++ b/src/code42cli/cmds/users.py
@@ -184,7 +184,8 @@ bulk.add_command(users_generate_template)
 @format_option
 @sdk_options()
 def bulk_update(state, csv_rows, format):
-    """Update a list of users from the provided CSV."""
+    """Update a list of users from the provided CSV 
+    in format: user_id,username,email,password,first_name,last_name,notes,archive_size_quota."""
     csv_rows[0]["updated"] = "False"
     formatter = OutputFormatter(format, {key: key for key in csv_rows[0].keys()})
     stats = create_worker_stats(len(csv_rows))
@@ -221,7 +222,8 @@ def bulk_update(state, csv_rows, format):
 @format_option
 @sdk_options()
 def bulk_move(state, csv_rows, format):
-    """Change the organization of the list of users from the provided CSV."""
+    """Change the organization of the list of users from the provided CSV in format: 
+    username,org_id."""
     csv_rows[0]["moved"] = "False"
     formatter = OutputFormatter(format, {key: key for key in csv_rows[0].keys()})
     stats = create_worker_stats(len(csv_rows))

--- a/src/code42cli/cmds/users.py
+++ b/src/code42cli/cmds/users.py
@@ -188,8 +188,7 @@ bulk.add_command(users_generate_template)
 @format_option
 @sdk_options()
 def bulk_update(state, csv_rows, format):
-    """Update a list of users from the provided CSV
-    in format: user_id,username,email,password,first_name,last_name,notes,archive_size_quota."""
+    """Update a list of users from the provided CSV."""
     csv_rows[0]["updated"] = "False"
     formatter = OutputFormatter(format, {key: key for key in csv_rows[0].keys()})
     stats = create_worker_stats(len(csv_rows))
@@ -230,7 +229,7 @@ def bulk_update(state, csv_rows, format):
 @format_option
 @sdk_options()
 def bulk_move(state, csv_rows, format):
-    """Change the organization of the list of users from the provided CSV in format."""
+    """Change the organization of the list of users from the provided CSV."""
     csv_rows[0]["moved"] = "False"
     formatter = OutputFormatter(format, {key: key for key in csv_rows[0].keys()})
     stats = create_worker_stats(len(csv_rows))

--- a/src/code42cli/cmds/users.py
+++ b/src/code42cli/cmds/users.py
@@ -156,7 +156,8 @@ _bulk_user_move_headers = ["username", "org_id"]
 @org_id_option
 @sdk_options()
 def change_organization(state, username, org_id):
-    """Change the organization of the user with the given username to the org with the given org ID."""
+    """Change the organization of the user with the given username 
+    to the org with the given org ID."""
     _change_organization(state.sdk, username, org_id)
 
 

--- a/src/code42cli/cmds/users.py
+++ b/src/code42cli/cmds/users.py
@@ -195,6 +195,7 @@ def bulk_update(state, csv_rows, format):
             row["updated"] = "True"
         except Exception as err:
             row["updated"] = f"False: {err}"
+            raise
         return row
 
     result_rows = run_bulk_process(
@@ -220,6 +221,7 @@ def bulk_move(state, csv_rows, format):
             row["moved"] = "True"
         except Exception as err:
             row["moved"] = f"False: {err}"
+            raise
         return row
 
     result_rows = run_bulk_process(handle_row, csv_rows, progress_label="Moving users:")

--- a/src/code42cli/cmds/users.py
+++ b/src/code42cli/cmds/users.py
@@ -204,18 +204,12 @@ def bulk_update(state, csv_rows, format):
             stats.increment_total_errors()
         return row
 
-    def handle_if_errors(*args, **kwargs):
-        """Still output rows to show individual row status by ignoring
-        the default CLI Log Error message.
-        """
-        pass
-
     result_rows = run_bulk_process(
         handle_row,
         csv_rows,
         progress_label="Updating users:",
         stats=stats,
-        handle_if_errors=handle_if_errors,
+        raise_global_error=False,
     )
     formatter.echo_formatted_list(result_rows)
 
@@ -245,18 +239,12 @@ def bulk_move(state, csv_rows, format):
             stats.increment_total_errors()
         return row
 
-    def handle_if_errors(*args, **kwargs):
-        """Still output rows to show individual row status by ignoring
-        the default CLI Log Error message.
-        """
-        pass
-
     result_rows = run_bulk_process(
         handle_row,
         csv_rows,
         progress_label="Moving users:",
         stats=stats,
-        handle_if_errors=handle_if_errors,
+        raise_global_error=False,
     )
     formatter.echo_formatted_list(result_rows)
 

--- a/src/code42cli/cmds/users.py
+++ b/src/code42cli/cmds/users.py
@@ -45,7 +45,6 @@ org_id_option = click.option(
     "--org-id",
     help="The identifier for the organization to which the user will be moved.",
     required=True,
-    type=int,
 )
 
 
@@ -156,7 +155,7 @@ _bulk_user_move_headers = ["username", "org_id"]
 @org_id_option
 @sdk_options()
 def change_organization(state, username, org_id):
-    """Change the organization of the user with the given username 
+    """Change the organization of the user with the given username
     to the org with the given org ID."""
     _change_organization(state.sdk, username, org_id)
 
@@ -292,4 +291,10 @@ def _update_user(
 
 def _change_organization(sdk, username, org_id):
     user_id = _get_user_id(sdk, username)
+    org_id = _get_org_id(sdk, org_id)
     return sdk.users.change_org_assignment(user_id=int(user_id), org_id=int(org_id))
+
+
+def _get_org_id(sdk, org_id):
+    org = sdk.orgs.get_by_uid(org_id)
+    return org["orgId"]

--- a/src/code42cli/cmds/users.py
+++ b/src/code42cli/cmds/users.py
@@ -179,7 +179,11 @@ users_generate_template = generate_template_cmd_factory(
 bulk.add_command(users_generate_template)
 
 
-@bulk.command(name="update")
+@bulk.command(
+    name="update",
+    help=f"Update a list of users from the provided CSV in format: "
+    f"{','.join(_bulk_user_update_headers)}",
+)
 @read_csv_arg(headers=_bulk_user_update_headers)
 @format_option
 @sdk_options()
@@ -217,13 +221,16 @@ def bulk_update(state, csv_rows, format):
     formatter.echo_formatted_list(result_rows)
 
 
-@bulk.command(name="move")
+@bulk.command(
+    name="move",
+    help=f"Change the organization of the list of users from the provided CSV in format: "
+    f"{','.join(_bulk_user_move_headers)}",
+)
 @read_csv_arg(headers=_bulk_user_move_headers)
 @format_option
 @sdk_options()
 def bulk_move(state, csv_rows, format):
-    """Change the organization of the list of users from the provided CSV in format:
-    username,org_id."""
+    """Change the organization of the list of users from the provided CSV in format."""
     csv_rows[0]["moved"] = "False"
     formatter = OutputFormatter(format, {key: key for key in csv_rows[0].keys()})
     stats = create_worker_stats(len(csv_rows))

--- a/src/code42cli/cmds/users.py
+++ b/src/code42cli/cmds/users.py
@@ -184,7 +184,7 @@ bulk.add_command(users_generate_template)
 @format_option
 @sdk_options()
 def bulk_update(state, csv_rows, format):
-    """Update a list of users from the provided CSV 
+    """Update a list of users from the provided CSV
     in format: user_id,username,email,password,first_name,last_name,notes,archive_size_quota."""
     csv_rows[0]["updated"] = "False"
     formatter = OutputFormatter(format, {key: key for key in csv_rows[0].keys()})
@@ -222,7 +222,7 @@ def bulk_update(state, csv_rows, format):
 @format_option
 @sdk_options()
 def bulk_move(state, csv_rows, format):
-    """Change the organization of the list of users from the provided CSV in format: 
+    """Change the organization of the list of users from the provided CSV in format:
     username,org_id."""
     csv_rows[0]["moved"] = "False"
     formatter = OutputFormatter(format, {key: key for key in csv_rows[0].keys()})

--- a/src/code42cli/worker.py
+++ b/src/code42cli/worker.py
@@ -10,6 +10,10 @@ from code42cli.errors import Code42CLIError
 from code42cli.logger import get_main_cli_logger
 
 
+def create_worker_stats(total):
+    return WorkerStats(total)
+
+
 class WorkerStats:
     """Stats about the tasks that have run."""
 
@@ -66,15 +70,15 @@ class WorkerStats:
 
 
 class Worker:
-    def __init__(self, thread_count, expected_total, bar=None):
+    def __init__(self, thread_count, expected_total, bar=None, stats=None):
         self._queue = queue.Queue()
         self._thread_count = thread_count
-        self._stats = WorkerStats(expected_total)
+        self._bar = bar
+        self._stats = stats or WorkerStats(expected_total)
         self._tasks = 0
         self.__started = False
         self.__start_lock = Lock()
         self._logger = get_main_cli_logger()
-        self._bar = bar
 
     def do_async(self, func, *args, **kwargs):
         """Execute the given func asynchronously given *args and **kwargs.

--- a/tests/cmds/test_devices.py
+++ b/tests/cmds/test_devices.py
@@ -829,6 +829,44 @@ def test_bulk_deactivate_uses_expected_arguments(runner, mocker, cli_state):
     ]
 
 
+def test_bulk_deactivate_ignores_blank_lines(runner, mocker, cli_state):
+    bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
+    with runner.isolated_filesystem():
+        with open("test_bulk_deactivate.csv", "w") as csv:
+            csv.writelines(["guid,username\n", "\n", "test,value\n\n",])
+        runner.invoke(
+            cli,
+            ["devices", "bulk", "deactivate", "test_bulk_deactivate.csv"],
+            obj=cli_state,
+        )
+    assert bulk_processor.call_args[0][1] == [
+        {
+            "guid": "test",
+            "deactivated": "False",
+            "change_device_name": False,
+            "purge_date": None,
+        }
+    ]
+
+
+def test_bulk_deactivate_provides_handler_that_raises_caught_errors(runner, mocker, cli_state):
+    bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
+    with runner.isolated_filesystem():
+        with open("test_bulk_deactivate.csv", "w") as csv:
+            csv.writelines(["guid,username\n", "\n", "test,value\n\n",])
+        runner.invoke(
+            cli,
+            ["devices", "bulk", "deactivate", "test_bulk_deactivate.csv"],
+            obj=cli_state,
+        )
+
+    handler = bulk_processor.call_args[0][0]
+
+    # This test fails when the handler is implemented such that is swallows exceptions.
+    with pytest.raises(Exception):
+        handler()
+
+
 def test_bulk_reactivate_uses_expected_arguments(runner, mocker, cli_state):
     bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
     with runner.isolated_filesystem():
@@ -840,3 +878,40 @@ def test_bulk_reactivate_uses_expected_arguments(runner, mocker, cli_state):
             obj=cli_state,
         )
     assert bulk_processor.call_args[0][1] == [{"guid": "test", "reactivated": False}]
+
+
+def test_bulk_reactivate_ignores_blank_lines(runner, mocker, cli_state):
+    bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
+    with runner.isolated_filesystem():
+        with open("test_bulk_reactivate.csv", "w") as csv:
+            csv.writelines(["guid,username\n", "\n", "test,value\n\n",])
+        runner.invoke(
+            cli,
+            ["devices", "bulk", "reactivate", "test_bulk_reactivate.csv"],
+            obj=cli_state,
+        )
+    assert bulk_processor.call_args[0][1] == [
+        {
+            "guid": "test",
+            "reactivated": "False",
+        }
+    ]
+    bulk_processor.assert_called_once()
+
+
+def test_bulk_reactivate_provides_handler_that_raises_caught_errors(runner, mocker, cli_state):
+    bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
+    with runner.isolated_filesystem():
+        with open("test_bulk_reactivate.csv", "w") as csv:
+            csv.writelines(["guid,username\n", "\n", "test,value\n\n",])
+        runner.invoke(
+            cli,
+            ["devices", "bulk", "reactivate", "test_bulk_reactivate.csv"],
+            obj=cli_state,
+        )
+
+    handler = bulk_processor.call_args[0][0]
+
+    # This test fails when the handler is implemented such that is swallows exceptions.
+    with pytest.raises(Exception):
+        handler()

--- a/tests/cmds/test_devices.py
+++ b/tests/cmds/test_devices.py
@@ -833,7 +833,7 @@ def test_bulk_deactivate_ignores_blank_lines(runner, mocker, cli_state):
     bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
     with runner.isolated_filesystem():
         with open("test_bulk_deactivate.csv", "w") as csv:
-            csv.writelines(["guid,username\n", "\n", "test,value\n\n",])
+            csv.writelines(["guid,username\n", "\n", "test,value\n\n"])
         runner.invoke(
             cli,
             ["devices", "bulk", "deactivate", "test_bulk_deactivate.csv"],
@@ -849,11 +849,13 @@ def test_bulk_deactivate_ignores_blank_lines(runner, mocker, cli_state):
     ]
 
 
-def test_bulk_deactivate_provides_handler_that_raises_caught_errors(runner, mocker, cli_state):
+def test_bulk_deactivate_provides_handler_that_raises_caught_errors(
+    runner, mocker, cli_state
+):
     bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
     with runner.isolated_filesystem():
         with open("test_bulk_deactivate.csv", "w") as csv:
-            csv.writelines(["guid,username\n", "\n", "test,value\n\n",])
+            csv.writelines(["guid,username\n", "\n", "test,value\n\n"])
         runner.invoke(
             cli,
             ["devices", "bulk", "deactivate", "test_bulk_deactivate.csv"],
@@ -884,26 +886,23 @@ def test_bulk_reactivate_ignores_blank_lines(runner, mocker, cli_state):
     bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
     with runner.isolated_filesystem():
         with open("test_bulk_reactivate.csv", "w") as csv:
-            csv.writelines(["guid,username\n", "\n", "test,value\n\n",])
+            csv.writelines(["guid,username\n", "\n", "test,value\n\n"])
         runner.invoke(
             cli,
             ["devices", "bulk", "reactivate", "test_bulk_reactivate.csv"],
             obj=cli_state,
         )
-    assert bulk_processor.call_args[0][1] == [
-        {
-            "guid": "test",
-            "reactivated": "False",
-        }
-    ]
+    assert bulk_processor.call_args[0][1] == [{"guid": "test", "reactivated": "False"}]
     bulk_processor.assert_called_once()
 
 
-def test_bulk_reactivate_provides_handler_that_raises_caught_errors(runner, mocker, cli_state):
+def test_bulk_reactivate_provides_handler_that_raises_caught_errors(
+    runner, mocker, cli_state
+):
     bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
     with runner.isolated_filesystem():
         with open("test_bulk_reactivate.csv", "w") as csv:
-            csv.writelines(["guid,username\n", "\n", "test,value\n\n",])
+            csv.writelines(["guid,username\n", "\n", "test,value\n\n"])
         runner.invoke(
             cli,
             ["devices", "bulk", "reactivate", "test_bulk_reactivate.csv"],

--- a/tests/cmds/test_devices.py
+++ b/tests/cmds/test_devices.py
@@ -879,7 +879,7 @@ def test_bulk_reactivate_uses_expected_arguments(runner, mocker, cli_state):
             ["devices", "bulk", "reactivate", "test_bulk_reactivate.csv"],
             obj=cli_state,
         )
-    assert bulk_processor.call_args[0][1] == [{"guid": "test", "reactivated": False}]
+    assert bulk_processor.call_args[0][1] == [{"guid": "test", "reactivated": "False"}]
 
 
 def test_bulk_reactivate_ignores_blank_lines(runner, mocker, cli_state):

--- a/tests/cmds/test_users.py
+++ b/tests/cmds/test_users.py
@@ -444,11 +444,9 @@ def test_bulk_deactivate_uses_expected_arguments_when_all_are_passed(
             "updated": "False",
         }
     ]
-    
 
-def test_bulk_deactivate_ignores_blank_lines(
-    runner, mocker, cli_state
-):
+
+def test_bulk_deactivate_ignores_blank_lines(runner, mocker, cli_state):
     bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
     with runner.isolated_filesystem():
         with open("test_bulk_update.csv", "w") as csv:
@@ -516,11 +514,9 @@ def test_bulk_move_ignores_blank_lines(runner, mocker, cli_state):
         with open("test_bulk_move.csv", "w") as csv:
             csv.writelines(["username,org_id\n\n\n", f"{TEST_USERNAME},4321\n\n\n"])
         runner.invoke(
-            cli, [
-                "users", "bulk", "move", "test_bulk_move.csv"], obj=cli_state
+            cli, ["users", "bulk", "move", "test_bulk_move.csv"], obj=cli_state
         )
     assert bulk_processor.call_args[0][1] == [
         {"username": TEST_USERNAME, "org_id": "4321", "moved": "False"}
     ]
     bulk_processor.assert_called_once()
-

--- a/tests/cmds/test_users.py
+++ b/tests/cmds/test_users.py
@@ -458,7 +458,7 @@ def test_move_calls_change_org_assignment_with_correct_parameters(
         "1007744453331222111",
     ]
     runner.invoke(cli, command, obj=cli_state)
-    expected_org_id = TEST_GET_ORG_RESPONSE["orgId"]x
+    expected_org_id = TEST_GET_ORG_RESPONSE["orgId"]
     cli_state.sdk.users.change_org_assignment.assert_called_once_with(
         user_id=TEST_USER_ID, org_id=expected_org_id
     )

--- a/tests/cmds/test_users.py
+++ b/tests/cmds/test_users.py
@@ -1,7 +1,6 @@
 import json
 
 import pytest
-from py42.exceptions import Py42BadRequestError
 from py42.response import Py42Response
 from requests import Response
 
@@ -477,14 +476,16 @@ def test_bulk_update_ignores_blank_lines(runner, mocker, cli_state):
     ]
 
 
-def test_bulk_update_provides_handler_that_raises_caught_errors(runner, mocker, cli_state):
+def test_bulk_update_provides_handler_that_raises_caught_errors(
+    runner, mocker, cli_state
+):
     bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
 
     with runner.isolated_filesystem():
         with open("test_bulk_update.csv", "w") as csv:
             lines = [
                 "user_id,username,email,password,first_name,last_name,notes,archive_size_quota\n",
-                "12345,test_username,test_email,test_pword,test_fname,test_lname,test notes,4321\n"
+                "12345,test_username,test_email,test_pword,test_fname,test_lname,test notes,4321\n",
             ]
             csv.writelines(lines)
         runner.invoke(
@@ -544,7 +545,9 @@ def test_bulk_move_ignores_blank_lines(runner, mocker, cli_state):
     bulk_processor.assert_called_once()
 
 
-def test_bulk_move_provides_handler_that_raises_caught_errors(runner, mocker, cli_state):
+def test_bulk_move_provides_handler_that_raises_caught_errors(
+    runner, mocker, cli_state
+):
     bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
 
     with runner.isolated_filesystem():

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -78,7 +78,7 @@ def test_run_bulk_process_creates_processor(bulk_processor_factory):
     rows = [1, 2]
     run_bulk_process(func_with_one_arg, rows)
     bulk_processor_factory.assert_called_once_with(
-        func_with_one_arg, rows, None, stats=None, handle_if_errors=None
+        func_with_one_arg, rows, None, stats=None, raise_global_error=True
     )
 
 

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -77,7 +77,9 @@ def test_run_bulk_process_creates_processor(bulk_processor_factory):
     errors.ERRORED = False
     rows = [1, 2]
     run_bulk_process(func_with_one_arg, rows)
-    bulk_processor_factory.assert_called_once_with(func_with_one_arg, rows, None)
+    bulk_processor_factory.assert_called_once_with(
+        func_with_one_arg, rows, None, stats=None, handle_if_errors=None
+    )
 
 
 class TestBulkProcessor:


### PR DESCRIPTION
* `code42 users move` (unreleased) now uses the uid of the org as the ID instead of the legacy ID. Legacy IDs should not be in the CLI. This hinders performance, but there are plans to make API endpoints (soon I think) that accepts `orgUid`s instead of `orgId`s. We should rely on the backend to fix this issue and not have that in the CLI, especially if the fix is coming soon, that way we are not confusing users and we are using the most modern IDs and **to avoid breaking changes**.
* Fixes bug in certain bulk methods where it would output the incorrect successes and failures by the end of the process because it was swallowing all exceptions within its handlers.
* Additionally, Nikunj reported that newlines are not being handled correctly on Windows machines. I wrote some unit tests to prove that they at least work for Linux / OSX machines... Further investigation will be needed there.

Note of Caution: remember that weird shell issue where the text you type suddenly disappears and does not come back in the same shell process? If that happens, you will not see the stats at all in any circumstance... Weird right?