### PR TITLE
Chore/Incorporate-update-user-custom-errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "keyrings.alt==3.2.0",
         "ipython>=7.16.1",
         "pandas>=1.1.3",
-        "py42>=1.15.1",
+        "py42>=1.15.2",
     ],
     extras_require={
         "dev": [

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "keyrings.alt==3.2.0",
         "ipython>=7.16.1",
         "pandas>=1.1.3",
-        "py42>=1.15.2",
+        "py42>=1.16.0",
     ],
     extras_require={
         "dev": [

--- a/src/code42cli/click_ext/groups.py
+++ b/src/code42cli/click_ext/groups.py
@@ -8,7 +8,10 @@ from py42.exceptions import Py42CaseNameExistsError
 from py42.exceptions import Py42DescriptionLimitExceededError
 from py42.exceptions import Py42ForbiddenError
 from py42.exceptions import Py42HTTPError
+from py42.exceptions import Py42InvalidEmailError
+from py42.exceptions import Py42InvalidPasswordError
 from py42.exceptions import Py42InvalidRuleOperationError
+from py42.exceptions import Py42InvalidUsernameError
 from py42.exceptions import Py42LegalHoldNotFoundOrPermissionDeniedError
 from py42.exceptions import Py42UpdateClosedCaseError
 from py42.exceptions import Py42UserAlreadyAddedError
@@ -69,6 +72,9 @@ class ExceptionHandlingGroup(click.Group):
             Py42CaseAlreadyHasEventError,
             Py42UpdateClosedCaseError,
             Py42UsernameMustBeEmailError,
+            Py42InvalidEmailError,
+            Py42InvalidPasswordError,
+            Py42InvalidUsernameError,
         ) as err:
             self.logger.log_error(err)
             raise Code42CLIError(str(err))

--- a/src/code42cli/cmds/cases.py
+++ b/src/code42cli/cmds/cases.py
@@ -4,7 +4,9 @@ import os
 import click
 from py42.clients.cases import CaseStatus
 from py42.exceptions import Py42BadRequestError
+from py42.exceptions import Py42CaseAlreadyHasEventError
 from py42.exceptions import Py42NotFoundError
+from py42.exceptions import Py42UpdateClosedCaseError
 
 from code42cli.bulk import generate_template_cmd_factory
 from code42cli.bulk import run_bulk_process
@@ -244,6 +246,10 @@ def add(state, case_number, event_id):
     """Associate a file event to a case, by event ID."""
     try:
         state.sdk.cases.file_events.add(case_number, event_id)
+    except Py42UpdateClosedCaseError:
+        raise
+    except Py42CaseAlreadyHasEventError:
+        raise
     except Py42BadRequestError:
         raise Code42CLIError("Invalid case-number or event-id.")
 

--- a/src/code42cli/cmds/cases.py
+++ b/src/code42cli/cmds/cases.py
@@ -4,9 +4,7 @@ import os
 import click
 from py42.clients.cases import CaseStatus
 from py42.exceptions import Py42BadRequestError
-from py42.exceptions import Py42CaseAlreadyHasEventError
 from py42.exceptions import Py42NotFoundError
-from py42.exceptions import Py42UpdateClosedCaseError
 
 from code42cli.bulk import generate_template_cmd_factory
 from code42cli.bulk import run_bulk_process
@@ -246,10 +244,6 @@ def add(state, case_number, event_id):
     """Associate a file event to a case, by event ID."""
     try:
         state.sdk.cases.file_events.add(case_number, event_id)
-    except Py42UpdateClosedCaseError:
-        raise
-    except Py42CaseAlreadyHasEventError:
-        raise
     except Py42BadRequestError:
         raise Code42CLIError("Invalid case-number or event-id.")
 

--- a/tests/cmds/conftest.py
+++ b/tests/cmds/conftest.py
@@ -4,12 +4,12 @@ import threading
 import pytest
 from py42.exceptions import Py42UserAlreadyAddedError
 from py42.exceptions import Py42UserNotOnListError
-from py42.response import Py42Response
 from py42.sdk import SDKClient
 from requests import HTTPError
-from requests import Request
 from requests import Response
 from tests.conftest import convert_str_to_date
+from tests.conftest import create_mock_http_error
+from tests.conftest import create_mock_response
 from tests.conftest import TEST_ID
 
 from code42cli.logger import CliLogger
@@ -20,12 +20,8 @@ TEST_EMPLOYEE = "risky employee"
 
 def get_user_not_on_list_side_effect(mocker, list_name):
     def side_effect(*args, **kwargs):
-        err = mocker.MagicMock(spec=HTTPError)
-        resp = mocker.MagicMock(spec=Response)
-        resp.text = "TEST_ERR"
-        err.response = resp
-        err.response.request = mocker.MagicMock(spec=Request)
-        raise Py42UserNotOnListError(err, TEST_ID, list_name)
+        mock_http_error = create_mock_http_error(mocker, data="TEST_ERR")
+        raise Py42UserNotOnListError(mock_http_error, TEST_ID, list_name)
 
     return side_effect
 
@@ -117,9 +113,7 @@ def get_generator_for_get_all(mocker, mock_return_items):
     mock_return_items = mock_return_items or ""
 
     def gen(*args, **kwargs):
-        response = mocker.MagicMock(spec=Request)
-        response.text = f'{{"items": [{mock_return_items}]}}'
-        yield Py42Response(response)
+        yield create_mock_response(mocker, data={"items": [{mock_return_items}]})
 
     return gen
 

--- a/tests/cmds/conftest.py
+++ b/tests/cmds/conftest.py
@@ -1,3 +1,4 @@
+import json
 import json as json_module
 import threading
 
@@ -110,10 +111,13 @@ def thread_safe_side_effect():
 
 
 def get_generator_for_get_all(mocker, mock_return_items):
-    mock_return_items = mock_return_items or ""
+    if not mock_return_items:
+        mock_return_items = []
+    elif not isinstance(mock_return_items, dict):
+        mock_return_items = [json.loads(mock_return_items)]
 
     def gen(*args, **kwargs):
-        yield create_mock_response(mocker, data={"items": [{mock_return_items}]})
+        yield create_mock_response(mocker, data={"items": mock_return_items})
 
     return gen
 

--- a/tests/cmds/detectionlists/test_init.py
+++ b/tests/cmds/detectionlists/test_init.py
@@ -1,9 +1,7 @@
 import pytest
-from py42.response import Py42Response
-from requests import Response
+from tests.conftest import create_mock_response
 
 from code42cli.cmds.detectionlists import update_user
-
 
 MOCK_USER_ID = "USER-ID"
 MOCK_USER_NAME = "test@example.com"
@@ -24,9 +22,7 @@ MOCK_USER_PROFILE_RESPONSE = f"""
 
 @pytest.fixture
 def user_response_with_cloud_aliases(mocker):
-    response = mocker.MagicMock(spec=Response)
-    response.text = MOCK_USER_PROFILE_RESPONSE
-    return Py42Response(response)
+    return create_mock_response(mocker, data=MOCK_USER_PROFILE_RESPONSE)
 
 
 @pytest.fixture

--- a/tests/cmds/search/test_extraction.py
+++ b/tests/cmds/search/test_extraction.py
@@ -1,7 +1,6 @@
 import pytest
 from c42eventextractor.extractors import BaseExtractor
-from py42.response import Py42Response
-from requests import Response
+from tests.conftest import create_mock_response
 
 from code42cli import errors
 from code42cli.cmds.search.cursor_store import BaseCursorStore
@@ -9,7 +8,6 @@ from code42cli.cmds.search.extraction import create_handlers
 from code42cli.cmds.search.extraction import create_send_to_handlers
 from code42cli.cmds.search.extraction import try_get_default_header
 from code42cli.output_formats import OutputFormat
-
 
 key = "events"
 
@@ -59,10 +57,9 @@ def test_create_handlers_creates_handlers_that_pass_events_to_output_formatter(
     handlers = create_handlers(
         sdk, TestExtractor, cursor_store, "chk-name", formatter, force_pager=False
     )
-    http_response = mocker.MagicMock(spec=Response)
     events = [{"property": "bar"}]
-    http_response.text = f'{{"{key}": [{{"property": "bar"}}]}}'
-    py42_response = Py42Response(http_response)
+    data = f'{{"{key}": [{{"property": "bar"}}]}}'
+    py42_response = create_mock_response(mocker, data=data)
     handlers.handle_response(py42_response)
     formatter.echo_formatted_list.assert_called_once_with(events, force_pager=False)
 
@@ -82,9 +79,8 @@ def test_send_to_handlers_creates_handlers_that_pass_events_to_logger(
     handlers = create_send_to_handlers(
         sdk, TestExtractor, cursor_store, "chk-name", event_extractor_logger
     )
-    http_response = mocker.MagicMock(spec=Response)
     events = [{"property": "bar"}]
-    http_response.text = f'{{"{key}": [{{"property": "bar"}}]}}'
-    py42_response = Py42Response(http_response)
+    data = f'{{"{key}": [{{"property": "bar"}}]}}'
+    py42_response = create_mock_response(mocker, data=data)
     handlers.handle_response(py42_response)
     event_extractor_logger.info.assert_called_once_with(events[0])

--- a/tests/cmds/test_alert_rules.py
+++ b/tests/cmds/test_alert_rules.py
@@ -1,14 +1,14 @@
-import json
 import logging
 
 import pytest
 from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42InternalServerError
 from py42.exceptions import Py42InvalidRuleOperationError
-from py42.response import Py42Response
 from requests import HTTPError
 from requests import Request
 from requests import Response
+from tests.conftest import create_mock_http_error
+from tests.conftest import create_mock_response
 
 from code42cli.main import cli
 
@@ -16,11 +16,8 @@ TEST_RULE_ID = "rule-id"
 TEST_USER_ID = "test-user-id"
 TEST_USERNAME = "test@example.com"
 TEST_SOURCE = "rule source"
-
 TEST_EMPTY_RULE_RESPONSE = {"ruleMetadata": []}
-
 ALERT_RULES_COMMAND = "alert-rules"
-
 TEST_RULE_RESPONSE = {
     "ruleMetadata": [
         {
@@ -33,7 +30,6 @@ TEST_RULE_RESPONSE = {
         }
     ]
 }
-
 TEST_GET_ALL_RESPONSE_EXFILTRATION = {
     "ruleMetadata": [
         {"observerRuleId": TEST_RULE_ID, "type": "FED_ENDPOINT_EXFILTRATION"}
@@ -51,19 +47,14 @@ TEST_GET_ALL_RESPONSE_FILE_TYPE_MISMATCH = {
 
 def get_rule_not_found_side_effect(mocker):
     def side_effect(*args, **kwargs):
-        response = mocker.MagicMock(spec=Response)
-        response.text = json.dumps(TEST_EMPTY_RULE_RESPONSE)
-        return Py42Response(response)
+        return create_mock_response(mocker, data=TEST_EMPTY_RULE_RESPONSE)
 
     return side_effect
 
 
 def get_user_not_on_alert_rule_side_effect(mocker):
     def side_effect(*args, **kwargs):
-        err = mocker.MagicMock(spec=HTTPError)
-        resp = mocker.MagicMock(spec=Response)
-        resp.text = "TEST_ERR"
-        err.response = resp
+        err = create_mock_http_error(mocker, data="TEST_ERR", status=400)
         raise Py42BadRequestError(err)
 
     return side_effect
@@ -71,10 +62,7 @@ def get_user_not_on_alert_rule_side_effect(mocker):
 
 def create_invalid_rule_type_side_effect(mocker):
     def side_effect(*args, **kwargs):
-        err = mocker.MagicMock(spec=HTTPError)
-        resp = mocker.MagicMock(spec=Response)
-        resp.text = "TEST_ERR"
-        err.response = resp
+        err = create_mock_http_error(mocker, data="TEST_ERR", status=400)
         raise Py42InvalidRuleOperationError(err, TEST_RULE_ID, TEST_SOURCE)
 
     return side_effect

--- a/tests/cmds/test_alerts.py
+++ b/tests/cmds/test_alerts.py
@@ -5,12 +5,11 @@ import py42.sdk.queries.alerts.filters as f
 import pytest
 from c42eventextractor.extractors import AlertExtractor
 from py42.exceptions import Py42NotFoundError
-from py42.response import Py42Response
 from py42.sdk.queries.alerts.filters import AlertState
-from requests import Response
 from tests.cmds.conftest import filter_term_is_in_call_args
 from tests.cmds.conftest import get_filter_value_from_json
 from tests.cmds.conftest import get_mark_for_search_and_send_to
+from tests.conftest import create_mock_response
 from tests.conftest import get_test_date_str
 
 from code42cli import errors
@@ -344,9 +343,7 @@ def send_to_logger_factory(mocker):
 
 @pytest.fixture
 def full_alert_details_response(mocker):
-    response = mocker.MagicMock(spec=Response)
-    response.text = json.dumps(ALERT_DETAILS_FULL_RESPONSE)
-    return Py42Response(response)
+    return create_mock_response(mocker, data=ALERT_DETAILS_FULL_RESPONSE)
 
 
 @search_and_send_to_test
@@ -992,11 +989,11 @@ def test_show_when_alert_has_note_includes_note(
 def test_show_when_alert_has_no_note_excludes_note(
     mocker, cli_state, runner, full_alert_details_response
 ):
-    response = mocker.MagicMock(spec=Response)
-    sans_note_text = dict(ALERT_DETAILS_FULL_RESPONSE)
-    sans_note_text["alerts"][0]["note"] = None
-    response.text = json.dumps(sans_note_text)
-    cli_state.sdk.alerts.get_details.return_value = Py42Response(response)
+    response_data = dict(ALERT_DETAILS_FULL_RESPONSE)
+    response_data["alerts"][0]["note"] = None
+    cli_state.sdk.alerts.get_details.return_value = create_mock_response(
+        mocker, data=response_data
+    )
     result = runner.invoke(cli, ["alerts", "show", "TEST-ALERT-ID"], obj=cli_state)
     # Note is included in `full_alert_details_response` initially.
     assert "Note" not in result.output
@@ -1037,11 +1034,11 @@ def test_show_when_alert_has_observations_and_excludes_observations_does_not_out
 def test_show_when_alert_does_not_have_observations_and_includes_observations_outputs_no_observations(
     mocker, cli_state, runner
 ):
-    response = mocker.MagicMock(spec=Response)
-    response_text = dict(ALERT_DETAILS_FULL_RESPONSE)
-    response_text["alerts"][0]["observations"] = None
-    response.text = json.dumps(response_text)
-    cli_state.sdk.alerts.get_details.return_value = Py42Response(response)
+    response_data = dict(ALERT_DETAILS_FULL_RESPONSE)
+    response_data["alerts"][0]["observations"] = None
+    cli_state.sdk.alerts.get_details.return_value = create_mock_response(
+        mocker, data=response_data
+    )
     result = runner.invoke(
         cli,
         ["alerts", "show", "TEST-ALERT-ID", "--include-observations"],

--- a/tests/cmds/test_auditlogs.py
+++ b/tests/cmds/test_auditlogs.py
@@ -105,10 +105,10 @@ def send_to_logger(mocker, send_to_logger_factory):
 @pytest.fixture
 def mock_audit_log_response(mocker):
     response1 = create_mock_response(
-        mocker, {"events": TEST_EVENTS_WITH_SAME_TIMESTAMP}
+        mocker, data={"events": TEST_EVENTS_WITH_SAME_TIMESTAMP}
     )
     response2 = create_mock_response(
-        mocker, {"events": TEST_EVENTS_WITH_DIFFERENT_TIMESTAMPS}
+        mocker, data={"events": TEST_EVENTS_WITH_DIFFERENT_TIMESTAMPS}
     )
 
     def response_gen():
@@ -123,7 +123,7 @@ def mock_audit_log_response_with_10_records(mocker):
     data = json.dumps({"events": TEST_EVENTS_WITH_SAME_TIMESTAMP})
     responses = []
     for _ in range(0, 10):
-        responses.append(create_mock_response(mocker, data))
+        responses.append(create_mock_response(mocker, data=data))
 
     def response_gen():
         yield from responses
@@ -136,7 +136,7 @@ def mock_audit_log_response_with_only_same_timestamps(mocker):
     data = {"events": TEST_EVENTS_WITH_SAME_TIMESTAMP}
 
     def response_gen():
-        yield create_mock_response(mocker, data)
+        yield create_mock_response(mocker, data=data)
 
     return response_gen()
 
@@ -148,7 +148,7 @@ def mock_audit_log_response_with_missing_ms_timestamp(mocker):
     response_data = {"events": [event]}
 
     def response_gen():
-        yield create_mock_response(mocker, response_data)
+        yield create_mock_response(mocker, data=response_data)
 
     return response_gen()
 
@@ -159,7 +159,7 @@ def mock_audit_log_response_with_micro_seconds(mocker):
     event["timestamp"] = "2021-07-01T14:47:13.093616Z"
 
     def response_gen():
-        yield create_mock_response(mocker, {"events": [event]})
+        yield create_mock_response(mocker, data={"events": [event]})
 
     return response_gen()
 
@@ -170,7 +170,7 @@ def mock_audit_log_response_with_nano_seconds(mocker):
     event["timestamp"] = "2021-07-01T14:47:13.093616500Z"
 
     def response_gen():
-        yield create_mock_response(mocker, {"events": [event]})
+        yield create_mock_response(mocker, data={"events": [event]})
 
     return response_gen()
 
@@ -185,7 +185,7 @@ def mock_audit_log_response_with_error_causing_timestamp(mocker):
     response_data = {"events": [good_event, bad_event]}
 
     def response_gen():
-        yield create_mock_response(mocker, response_data)
+        yield create_mock_response(mocker, data=response_data)
 
     return response_gen()
 

--- a/tests/cmds/test_auditlogs.py
+++ b/tests/cmds/test_auditlogs.py
@@ -105,10 +105,10 @@ def send_to_logger(mocker, send_to_logger_factory):
 @pytest.fixture
 def mock_audit_log_response(mocker):
     response1 = create_mock_response(
-        mocker, json.dumps({"events": TEST_EVENTS_WITH_SAME_TIMESTAMP})
+        mocker, {"events": TEST_EVENTS_WITH_SAME_TIMESTAMP}
     )
     response2 = create_mock_response(
-        mocker, json.dumps({"events": TEST_EVENTS_WITH_DIFFERENT_TIMESTAMPS})
+        mocker, {"events": TEST_EVENTS_WITH_DIFFERENT_TIMESTAMPS}
     )
 
     def response_gen():
@@ -120,10 +120,10 @@ def mock_audit_log_response(mocker):
 
 @pytest.fixture
 def mock_audit_log_response_with_10_records(mocker):
-    text = json.dumps({"events": TEST_EVENTS_WITH_SAME_TIMESTAMP})
+    data = json.dumps({"events": TEST_EVENTS_WITH_SAME_TIMESTAMP})
     responses = []
     for _ in range(0, 10):
-        responses.append(create_mock_response(mocker, text))
+        responses.append(create_mock_response(mocker, data))
 
     def response_gen():
         yield from responses
@@ -133,10 +133,10 @@ def mock_audit_log_response_with_10_records(mocker):
 
 @pytest.fixture
 def mock_audit_log_response_with_only_same_timestamps(mocker):
-    text = json.dumps({"events": TEST_EVENTS_WITH_SAME_TIMESTAMP})
+    data = {"events": TEST_EVENTS_WITH_SAME_TIMESTAMP}
 
     def response_gen():
-        yield create_mock_response(mocker, text)
+        yield create_mock_response(mocker, data)
 
     return response_gen()
 
@@ -146,10 +146,9 @@ def mock_audit_log_response_with_missing_ms_timestamp(mocker):
     event = dict(TEST_EVENTS_WITH_SAME_TIMESTAMP[0])
     event["timestamp"] = "2020-01-01T12:00:00Z"
     response_data = {"events": [event]}
-    text = json.dumps(response_data)
 
     def response_gen():
-        yield create_mock_response(mocker, text)
+        yield create_mock_response(mocker, response_data)
 
     return response_gen()
 
@@ -158,11 +157,9 @@ def mock_audit_log_response_with_missing_ms_timestamp(mocker):
 def mock_audit_log_response_with_micro_seconds(mocker):
     event = dict(TEST_EVENTS_WITH_SAME_TIMESTAMP[0])
     event["timestamp"] = "2021-07-01T14:47:13.093616Z"
-    response_data = {"events": [event]}
-    text = json.dumps(response_data)
 
     def response_gen():
-        yield create_mock_response(mocker, text)
+        yield create_mock_response(mocker, {"events": [event]})
 
     return response_gen()
 
@@ -171,11 +168,9 @@ def mock_audit_log_response_with_micro_seconds(mocker):
 def mock_audit_log_response_with_nano_seconds(mocker):
     event = dict(TEST_EVENTS_WITH_SAME_TIMESTAMP[0])
     event["timestamp"] = "2021-07-01T14:47:13.093616500Z"
-    response_data = {"events": [event]}
-    text = json.dumps(response_data)
 
     def response_gen():
-        yield create_mock_response(mocker, text)
+        yield create_mock_response(mocker, {"events": [event]})
 
     return response_gen()
 
@@ -185,13 +180,12 @@ def mock_audit_log_response_with_error_causing_timestamp(mocker):
     good_event = dict(TEST_EVENTS_WITH_SAME_TIMESTAMP[0])
     bad_event = dict(TEST_EVENTS_WITH_SAME_TIMESTAMP[0])
     bad_event["timestamp"] = "I AM NOT A TIMESTAMP"  # Will cause a ValueError.
-    response_data = {
-        "events": [good_event, bad_event]
-    }  # good_event should still get processed.
-    text = json.dumps(response_data)
+
+    # good_event should still get processed.
+    response_data = {"events": [good_event, bad_event]}
 
     def response_gen():
-        yield create_mock_response(mocker, text)
+        yield create_mock_response(mocker, response_data)
 
     return response_gen()
 

--- a/tests/cmds/test_devices.py
+++ b/tests/cmds/test_devices.py
@@ -10,8 +10,7 @@ from pandas._testing import assert_series_equal
 from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42ForbiddenError
 from py42.exceptions import Py42NotFoundError
-from py42.response import Py42Response
-from requests import Response
+from tests.conftest import create_mock_response
 
 from code42cli.cmds.devices import _add_backup_set_settings_to_dataframe
 from code42cli.cmds.devices import _add_legal_hold_membership_to_device_dataframe
@@ -311,14 +310,6 @@ ALL_CUSTODIANS_RESPONSE = {
 }
 
 
-def _create_py42_response(mocker, text):
-    response = mocker.MagicMock(spec=Response)
-    response.text = text
-    response._content_consumed = mocker.MagicMock()
-    response.status_code = 200
-    return Py42Response(response)
-
-
 @pytest.fixture
 def mock_device_settings(mocker, mock_backup_set):
     device_settings = mocker.MagicMock()
@@ -342,12 +333,12 @@ def mock_backup_set(mocker):
 
 @pytest.fixture
 def empty_successful_response(mocker):
-    return _create_py42_response(mocker, "")
+    return create_mock_response(mocker)
 
 
 @pytest.fixture
 def device_info_response(mocker):
-    return _create_py42_response(mocker, TEST_DEVICE_RESPONSE)
+    return create_mock_response(mocker, data=TEST_DEVICE_RESPONSE)
 
 
 def archives_list_generator():
@@ -372,12 +363,12 @@ def custodian_list_generator():
 
 @pytest.fixture
 def backupusage_response(mocker):
-    return _create_py42_response(mocker, TEST_BACKUPUSAGE_RESPONSE)
+    return create_mock_response(mocker, data=TEST_BACKUPUSAGE_RESPONSE)
 
 
 @pytest.fixture
 def empty_backupusage_response(mocker):
-    return _create_py42_response(mocker, TEST_EMPTY_BACKUPUSAGE_RESPONSE)
+    return create_mock_response(mocker, data=TEST_EMPTY_BACKUPUSAGE_RESPONSE)
 
 
 @pytest.fixture
@@ -870,7 +861,7 @@ def test_bulk_deactivate_uses_handler_that_when_encounters_error_increments_tota
     def _get(guid):
         if guid == "test":
             raise Exception("TEST")
-        return _create_py42_response(mocker, TEST_DEVICE_RESPONSE)
+        return create_mock_response(mocker, data=TEST_DEVICE_RESPONSE)
 
     cli_state.sdk.devices.get_by_guid.side_effect = _get
     bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
@@ -923,7 +914,7 @@ def test_bulk_reactivate_uses_handler_that_when_encounters_error_increments_tota
     def _get(guid):
         if guid == "test":
             raise Exception("TEST")
-        return _create_py42_response(mocker, TEST_DEVICE_RESPONSE)
+        return create_mock_response(mocker, data=TEST_DEVICE_RESPONSE)
 
     cli_state.sdk.devices.get_by_guid.side_effect = _get
     bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")

--- a/tests/cmds/test_users.py
+++ b/tests/cmds/test_users.py
@@ -79,12 +79,12 @@ def update_user_response(mocker):
 
 @pytest.fixture
 def get_available_roles_response(mocker):
-    return create_mock_response(mocker, TEST_ROLE_RETURN_DATA)
+    return create_mock_response(mocker, data=TEST_ROLE_RETURN_DATA)
 
 
 @pytest.fixture
 def get_users_response(mocker):
-    return create_mock_response(mocker, TEST_USERS_RESPONSE)
+    return create_mock_response(mocker, data=TEST_USERS_RESPONSE)
 
 
 @pytest.fixture
@@ -94,7 +94,7 @@ def change_org_response(mocker):
 
 @pytest.fixture
 def get_org_response(mocker):
-    return create_mock_response(mocker, TEST_GET_ORG_RESPONSE)
+    return create_mock_response(mocker, data=TEST_GET_ORG_RESPONSE)
 
 
 @pytest.fixture
@@ -116,18 +116,13 @@ def get_user_id_success(cli_state, get_users_response):
 @pytest.fixture
 def get_user_id_failure(mocker, cli_state):
     cli_state.sdk.users.get_by_username.return_value = create_mock_response(
-        mocker, TEST_EMPTY_USERS_RESPONSE
+        mocker, data=TEST_EMPTY_USERS_RESPONSE
     )
 
 
 @pytest.fixture
 def get_available_roles_success(cli_state, get_available_roles_response):
     cli_state.sdk.users.get_available_roles.return_value = get_available_roles_response
-
-
-@pytest.fixture
-def update_user_success(cli_state, update_user_response):
-    cli_state.sdk.users.update_user.return_value = update_user_response
 
 
 @pytest.fixture
@@ -539,7 +534,7 @@ def test_bulk_update_uses_handler_that_when_encounters_error_increments_total_er
     def _update(user_id, *args, **kwargs):
         if user_id == "12345":
             raise Exception("TEST")
-        return create_mock_response(mocker, TEST_USERS_RESPONSE)
+        return create_mock_response(mocker, data=TEST_USERS_RESPONSE)
 
     cli_state.sdk.users.update_user.side_effect = _update
     bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 from datetime import timedelta
 
@@ -5,6 +6,7 @@ import pytest
 from click.testing import CliRunner
 from py42.response import Py42Response
 from py42.sdk import SDKClient
+from requests import HTTPError
 from requests import Response
 
 import code42cli.errors as error_tracker
@@ -285,10 +287,17 @@ def mock_dataframe_to_string(mocker):
     return mocker.patch("pandas.DataFrame.to_string")
 
 
-def create_mock_response(mocker, text):
+def create_mock_response(mocker, text=None, status=200):
+    text = json.dumps(text) if text else ""
     response = mocker.MagicMock(spec=Response)
     response.text = text
-    response.status_code = 200
+    response.status_code = status
     response.encoding = None
     response._content_consumed = ""
     return Py42Response(response)
+
+
+def create_mock_http_error(mocker, text=None, status=400):
+    mock_http_error = mocker.MagicMock(spec=HTTPError)
+    mock_http_error.response = create_mock_response(mocker, text, status=status)
+    return mock_http_error

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -287,17 +287,20 @@ def mock_dataframe_to_string(mocker):
     return mocker.patch("pandas.DataFrame.to_string")
 
 
-def create_mock_response(mocker, text=None, status=200):
-    text = json.dumps(text) if text else ""
+def create_mock_response(mocker, data=None, status=200):
+    if isinstance(data, dict):
+        data = json.dumps(data)
+    elif not data:
+        data = ""
     response = mocker.MagicMock(spec=Response)
-    response.text = text
+    response.text = data
     response.status_code = status
     response.encoding = None
     response._content_consumed = ""
     return Py42Response(response)
 
 
-def create_mock_http_error(mocker, text=None, status=400):
+def create_mock_http_error(mocker, data=None, status=400):
     mock_http_error = mocker.MagicMock(spec=HTTPError)
-    mock_http_error.response = create_mock_response(mocker, text, status=status)
+    mock_http_error.response = create_mock_response(mocker, data=data, status=status)
     return mock_http_error


### PR DESCRIPTION
* Addresses feedback from QA where the error message could be improved in the CLI by making use of the new custom errors just added to py42 1.16.0.
* Refactors creating mock responses to use a shared method in the tests, same with mock error responses.