### PR TITLE
Bugfix/2FA logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,13 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ## Unreleased
 
-### Added 
+### Added
 
 - `code42 profile` commands that validate passwords (`create`, `update`, `reset-pw`) now have `--totp` and `--debug` options available.
 
 ### Changed
 
-- A TOTP token is now required on `code42 profile` commands that check for password validity when a user has MFA enabled. 
+- A TOTP token is now required on `code42 profile` commands that check for password validity when a user has MFA enabled.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ### Added
 
-- `code42 profile` commands that validate passwords (`create`, `update`, `reset-pw`) now have `--totp` and `--debug` options available.
+- `code42 profile` commands that validate passwords (`create`, `update`, `reset-pw`) now have the `--debug` option available, and `create` and `update` can now also pass in `--totp` as an option.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+## Unreleased
+
+### Added 
+
+- `code42 profile` commands that validate passwords (`create`, `update`, `reset-pw`) now have `--totp` and `--debug` options available.
+
+### Changed
+
+- A TOTP token is now required on `code42 profile` commands that check for password validity when a user has MFA enabled. 
+
+### Fixed
+
+- `code42 profile delete` command now prints a clear error message when deletion target doesn't exist.
+
 ## 1.8.1 - 2021-07-14
 
 ### Fixed

--- a/docs/userguides/profile.md
+++ b/docs/userguides/profile.md
@@ -36,6 +36,5 @@ code42 profile list
 
 ## Profiles with Multi-Factor Authentication
 
-If your Code42 user account requires multi-factor authentication, the token is not required to create your profile but
-will be required for any subsequent CLI commands. The MFA token can either be passed in with the `--totp` option, or if
-not passed you will be prompted to enter it before the command executes.
+If your Code42 user account requires multi-factor authentication, the MFA token can either be passed in with the `--totp` 
+option, or if not passed you will be prompted to enter it before the command executes.

--- a/docs/userguides/profile.md
+++ b/docs/userguides/profile.md
@@ -36,5 +36,5 @@ code42 profile list
 
 ## Profiles with Multi-Factor Authentication
 
-If your Code42 user account requires multi-factor authentication, the MFA token can either be passed in with the `--totp` 
+If your Code42 user account requires multi-factor authentication, the MFA token can either be passed in with the `--totp`
 option, or if not passed you will be prompted to enter it before the command executes.

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "keyrings.alt==3.2.0",
         "ipython>=7.16.1",
         "pandas>=1.1.3",
-        "py42>=1.16.0",
+        "py42>=1.17.0",
     ],
     extras_require={
         "dev": [

--- a/src/code42cli/click_ext/types.py
+++ b/src/code42cli/click_ext/types.py
@@ -148,3 +148,17 @@ class MapChoice(click.Choice):
         if value in self.extras_map:
             value = self.extras_map[value]
         return super().convert(value, param, ctx)
+
+
+class TOTP(click.ParamType):
+    """Validates param to be a 6-digit integer, which is what all Code42 TOTP tokens will be."""
+
+    def convert(self, value, param, ctx):
+        try:
+            int(value)
+            assert len(value) == 6
+            return value
+        except Exception:
+            raise BadParameter(
+                f"TOTP tokens should be a 6-digit integer. '{value}' was provided."
+            )

--- a/src/code42cli/click_ext/types.py
+++ b/src/code42cli/click_ext/types.py
@@ -152,7 +152,10 @@ class MapChoice(click.Choice):
 
 class TOTP(click.ParamType):
     """Validates param to be a 6-digit integer, which is what all Code42 TOTP tokens will be."""
-
+    
+    def get_metavar(self, param):
+        return "TEXT"
+    
     def convert(self, value, param, ctx):
         try:
             int(value)

--- a/src/code42cli/click_ext/types.py
+++ b/src/code42cli/click_ext/types.py
@@ -152,10 +152,10 @@ class MapChoice(click.Choice):
 
 class TOTP(click.ParamType):
     """Validates param to be a 6-digit integer, which is what all Code42 TOTP tokens will be."""
-    
+
     def get_metavar(self, param):
         return "TEXT"
-    
+
     def convert(self, value, param, ctx):
         try:
             int(value)

--- a/src/code42cli/cmds/profile.py
+++ b/src/code42cli/cmds/profile.py
@@ -23,6 +23,7 @@ debug_option = click.option(
 )
 totp_option = click.option("--totp", help="TOTP token for multi-factor authentication.")
 
+
 def profile_name_arg(required=False):
     return click.argument("profile_name", required=required)
 

--- a/src/code42cli/cmds/profile.py
+++ b/src/code42cli/cmds/profile.py
@@ -5,6 +5,7 @@ from click import echo
 from click import secho
 
 import code42cli.profile as cliprofile
+from code42cli.click_ext.types import TOTP
 from code42cli.errors import Code42CLIError
 from code42cli.options import yes_option
 from code42cli.profile import CREATE_PROFILE_HELP
@@ -21,7 +22,9 @@ def profile():
 debug_option = click.option(
     "-d", "--debug", is_flag=True, help="Turn on debug logging.",
 )
-totp_option = click.option("--totp", help="TOTP token for multi-factor authentication.")
+totp_option = click.option(
+    "--totp", help="TOTP token for multi-factor authentication.", type=TOTP()
+)
 
 
 def profile_name_arg(required=False):

--- a/src/code42cli/cmds/profile.py
+++ b/src/code42cli/cmds/profile.py
@@ -93,10 +93,10 @@ def show(profile_name):
 @server_option(required=True)
 @username_option(required=True)
 @password_option
+@totp_option
 @yes_option(hidden=True)
 @disable_ssl_option
 @debug_option
-@totp_option
 def create(name, server, username, password, disable_ssl_errors, debug, totp):
     """Create profile settings. The first profile created will be the default."""
     cliprofile.create_profile(name, server, username, disable_ssl_errors)
@@ -112,9 +112,9 @@ def create(name, server, username, password, disable_ssl_errors, debug, totp):
 @server_option()
 @username_option()
 @password_option
+@totp_option
 @disable_ssl_option
 @debug_option
-@totp_option
 def update(name, server, username, password, disable_ssl_errors, debug, totp):
     """Update an existing profile."""
     c42profile = cliprofile.get_profile(name)

--- a/src/code42cli/options.py
+++ b/src/code42cli/options.py
@@ -1,6 +1,7 @@
 import click
 
 from code42cli.click_ext.types import MagicDate
+from code42cli.click_ext.types import TOTP
 from code42cli.cmds.search.options import AdvancedQueryAndSavedSearchIncompatible
 from code42cli.cmds.search.options import BeginOption
 from code42cli.date_helper import convert_datetime_to_timestamp
@@ -115,6 +116,7 @@ def debug_option(hidden=False):
 def totp_option(hidden=False):
     opt = click.option(
         "--totp",
+        type=TOTP(),
         expose_value=False,
         callback=set_totp,
         hidden=hidden,

--- a/src/code42cli/sdk_client.py
+++ b/src/code42cli/sdk_client.py
@@ -8,6 +8,7 @@ from py42.exceptions import Py42UnauthorizedError
 from requests.exceptions import ConnectionError
 from requests.exceptions import SSLError
 
+from code42cli.click_ext.types import TOTP
 from code42cli.errors import Code42CLIError
 from code42cli.errors import LoggedCLIError
 from code42cli.logger import get_main_cli_logger
@@ -51,7 +52,7 @@ def _validate_connection(authority_url, username, password, totp=None):
         if "LoginConfig: LOCAL_2FA" in str(err):
             if totp is None:
                 totp = prompt(
-                    "Multi-factor authentication required. Enter TOTP", type=int
+                    "Multi-factor authentication required. Enter TOTP", type=TOTP()
                 )
                 return _validate_connection(authority_url, username, password, totp)
             else:

--- a/src/code42cli/sdk_client.py
+++ b/src/code42cli/sdk_client.py
@@ -4,7 +4,6 @@ import py42.settings.debug as debug
 import requests
 from click import prompt
 from click import secho
-from py42.exceptions import Py42MFARequiredError
 from py42.exceptions import Py42UnauthorizedError
 from requests.exceptions import ConnectionError
 from requests.exceptions import SSLError
@@ -47,13 +46,18 @@ def _validate_connection(authority_url, username, password, totp=None):
     except ConnectionError as err:
         logger.log_error(err)
         raise LoggedCLIError(f"Problem connecting to {authority_url}.")
-    except Py42MFARequiredError:
-        totp = prompt("Multi-factor authentication required. Enter TOTP", type=int)
-        return _validate_connection(authority_url, username, password, totp)
     except Py42UnauthorizedError as err:
         logger.log_error(err)
-        if "INVALID_TIME_BASED_ONE_TIME_PASSWORD" in err.response.text:
-            raise Code42CLIError(f"Invalid TOTP token for user {username}.")
+        if "LoginConfig: LOCAL_2FA" in str(err):
+            if totp is None:
+                totp = prompt(
+                    "Multi-factor authentication required. Enter TOTP", type=int
+                )
+                return _validate_connection(authority_url, username, password, totp)
+            else:
+                raise Code42CLIError(
+                    f"Invalid credentials or TOTP token for user {username}."
+                )
         else:
             raise Code42CLIError(f"Invalid credentials for user {username}.")
     except Exception as err:

--- a/tests/cmds/test_profile.py
+++ b/tests/cmds/test_profile.py
@@ -549,8 +549,8 @@ def test_totp_option_passes_token_to_sdk_on_profile_cmds_that_init_sdk(
         ],
         obj=cli_state,
     )
-    assert mock_create_sdk.call_args_list[0].kwargs["totp"] == totp1
-    assert mock_create_sdk.call_args_list[1].kwargs["totp"] == totp2
+    assert mock_create_sdk.call_args_list[0][1]["totp"] == totp1
+    assert mock_create_sdk.call_args_list[1][1]["totp"] == totp2
 
 
 def test_debug_option_passed_to_sdk_on_profile_cmds_that_init_sdk(
@@ -579,5 +579,5 @@ def test_debug_option_passed_to_sdk_on_profile_cmds_that_init_sdk(
         ["profile", "update", "-n", "foo", "--password", "updatedpass", "--debug"],
         obj=cli_state,
     )
-    assert mock_create_sdk.call_args_list[0].kwargs["is_debug_mode"] is True
-    assert mock_create_sdk.call_args_list[1].kwargs["is_debug_mode"] is True
+    assert mock_create_sdk.call_args_list[0][1]["is_debug_mode"] is True
+    assert mock_create_sdk.call_args_list[1][1]["is_debug_mode"] is True

--- a/tests/cmds/test_profile.py
+++ b/tests/cmds/test_profile.py
@@ -386,6 +386,11 @@ def test_delete_profile_requires_profile_name_arg(runner, mock_cliprofile_namesp
     assert mock_cliprofile_namespace.delete_profile.call_count == 0
 
 
+def test_delete_profile_raises_CLIError_when_profile_does_not_exist(runner):
+    result = runner.invoke(cli, ["profile", "delete", "not_a_real_profile"])
+    assert result.output == "Error: Profile 'not_a_real_profile' does not exist.\n"
+
+
 def test_delete_profile_does_nothing_if_user_doesnt_agree(
     runner, user_disagreement, mock_cliprofile_namespace
 ):

--- a/tests/cmds/test_profile.py
+++ b/tests/cmds/test_profile.py
@@ -1,8 +1,5 @@
 import pytest
-from py42.exceptions import Py42MFARequiredError
 from py42.sdk import SDKClient
-from requests import Response
-from requests.exceptions import HTTPError
 
 from ..conftest import create_mock_profile
 from code42cli.errors import Code42CLIError
@@ -210,29 +207,6 @@ def test_create_profile_with_password_option_if_credentials_valid_password_saved
     )
     mock_cliprofile_namespace.set_password.assert_called_once_with(password, mocker.ANY)
     assert "Would you like to set a password?" not in result.output
-
-
-def test_create_profile_stores_password_and_prints_message_when_user_requires_mfa(
-    runner, mocker, mock_verify, mock_cliprofile_namespace
-):
-    mock_verify.side_effect = Py42MFARequiredError(HTTPError(response=Response()))
-    result = runner.invoke(
-        cli,
-        [
-            "profile",
-            "create",
-            "-n",
-            "mfa",
-            "-s",
-            "bar",
-            "-u",
-            "baz",
-            "--password",
-            "pass",
-        ],
-    )
-    assert "Multi-factor account detected." in result.output
-    mock_cliprofile_namespace.set_password.assert_called_once_with("pass", mocker.ANY)
 
 
 def test_create_profile_outputs_confirmation(

--- a/tests/cmds/test_profile.py
+++ b/tests/cmds/test_profile.py
@@ -509,3 +509,75 @@ def test_use_profile(runner, mock_cliprofile_namespace, profile):
         profile.name
     )
     assert f"{profile.name} has been set as the default profile." in result.output
+
+
+def test_totp_option_passes_token_to_sdk_on_profile_cmds_that_init_sdk(
+    runner, mocker, mock_cliprofile_namespace, cli_state
+):
+    totp1 = "123456"
+    totp2 = "234567"
+    mock_create_sdk = mocker.patch("code42cli.cmds.profile.create_sdk")
+    runner.invoke(
+        cli,
+        [
+            "profile",
+            "create",
+            "-n",
+            "foo",
+            "-s",
+            "bar",
+            "-u",
+            "baz",
+            "--password",
+            "testpass",
+            "--totp",
+            totp1,
+        ],
+        obj=cli_state,
+    )
+    runner.invoke(
+        cli,
+        [
+            "profile",
+            "update",
+            "-n",
+            "foo",
+            "--password",
+            "updatedpass",
+            "--totp",
+            totp2,
+        ],
+        obj=cli_state,
+    )
+    assert mock_create_sdk.call_args_list[0].kwargs["totp"] == totp1
+    assert mock_create_sdk.call_args_list[1].kwargs["totp"] == totp2
+
+
+def test_debug_option_passed_to_sdk_on_profile_cmds_that_init_sdk(
+    runner, mocker, mock_cliprofile_namespace, cli_state
+):
+    mock_create_sdk = mocker.patch("code42cli.cmds.profile.create_sdk")
+    runner.invoke(
+        cli,
+        [
+            "profile",
+            "create",
+            "-n",
+            "foo",
+            "-s",
+            "bar",
+            "-u",
+            "baz",
+            "--password",
+            "testpass",
+            "--debug",
+        ],
+        obj=cli_state,
+    )
+    runner.invoke(
+        cli,
+        ["profile", "update", "-n", "foo", "--password", "updatedpass", "--debug"],
+        obj=cli_state,
+    )
+    assert mock_create_sdk.call_args_list[0].kwargs["is_debug_mode"] is True
+    assert mock_create_sdk.call_args_list[1].kwargs["is_debug_mode"] is True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,6 +122,7 @@ def cli_state(mocker, sdk, profile):
     mock_state._sdk = sdk
     mock_state.profile = profile
     mock_state.search_filters = []
+    mock_state.totp = None
     mock_state.assume_yes = False
     return mock_state
 

--- a/tests/test_sdk_client.py
+++ b/tests/test_sdk_client.py
@@ -147,7 +147,7 @@ def test_totp_option_when_passed_is_passed_to_sdk_initialization(
 ):
     mock_py42 = mocker.patch("code42cli.sdk_client.py42.sdk.from_local_account")
     cli_state = CLIState()
-    totp = "1234"
+    totp = "123456"
     profile.authority_url = "example.com"
     profile.username = "user"
     profile.get_password.return_value = "password"

--- a/tests/test_sdk_client.py
+++ b/tests/test_sdk_client.py
@@ -3,7 +3,6 @@ from io import StringIO
 import py42.sdk
 import py42.settings.debug as debug
 import pytest
-from py42.exceptions import Py42MFARequiredError
 from py42.exceptions import Py42UnauthorizedError
 from requests import Response
 from requests.exceptions import ConnectionError
@@ -117,15 +116,14 @@ def test_create_sdk_uses_given_credentials(
     )
 
 
-def test_create_sdk_connection_when_mfa_required_exception_raised_prompts_for_totp(
+def test_create_sdk_connection_when_2FA_login_config_detected_prompts_for_totp(
     mocker, monkeypatch, mock_sdk_factory, capsys, mock_profile_with_password
 ):
     monkeypatch.setattr("sys.stdin", StringIO("101010"))
     response = mocker.MagicMock(spec=Response)
-    mock_sdk_factory.side_effect = [
-        Py42MFARequiredError(HTTPError(response=response)),
-        None,
-    ]
+    exception = Py42UnauthorizedError(HTTPError(response=response))
+    exception.args = ("LoginConfig: LOCAL_2FA",)
+    mock_sdk_factory.side_effect = [exception, None]
     create_sdk(mock_profile_with_password, False)
     output = capsys.readouterr()
     assert "Multi-factor authentication required. Enter TOTP:" in output.out
@@ -135,11 +133,13 @@ def test_create_sdk_connection_when_mfa_token_invalid_raises_expected_cli_error(
     mocker, mock_sdk_factory, mock_profile_with_password
 ):
     response = mocker.MagicMock(spec=Response)
-    response.text = '{"data":null,"error":[{"primaryErrorKey":"INVALID_TIME_BASED_ONE_TIME_PASSWORD","otherErrors":null}],"warnings":null}'
-    mock_sdk_factory.side_effect = Py42UnauthorizedError(HTTPError(response=response))
+    exception = Py42UnauthorizedError(HTTPError(response=response))
+    error_text = "SDK initialization failed, double-check username/password, and provide two-factor TOTP token if Multi-Factor Auth configured for your user. User LoginConfig: LOCAL_2FA"
+    exception.args = (error_text,)
+    mock_sdk_factory.side_effect = exception
     with pytest.raises(Code42CLIError) as err:
         create_sdk(mock_profile_with_password, False, totp="1234")
-    assert str(err.value) == "Invalid TOTP token for user foo."
+    assert str(err.value) == "Invalid credentials or TOTP token for user foo."
 
 
 def test_totp_option_when_passed_is_passed_to_sdk_initialization(


### PR DESCRIPTION
Updates CLI MFA logic to key off of new py42's new Py42Unauthorized exception text that contains the LoginConfig value.

Now profile commands that validate password (`create`, `update`, `reset-pw`) require a TOTP token to be provided (either via `--totp` option or when prompted), as the server no longer returns any indication the password is correct but the 2FA token is not. 

I also added the `--debug` option to profile commands that make API calls, to aide future potential troubleshooting needs.

And since I noticed that if you try to delete a profile name that doesn't exist it didn't print a clear error (just pointed you to the log file), I added a fix for that as well.

FYI: This is dependent on next release of py42, so builds/tests will fail until then. 