### PR TITLE
Feature/query for risk indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 - `code42 profile` commands that validate passwords (`create`, `update`, `reset-pw`) now have the `--debug` option available, and `create` and `update` can now also pass in `--totp` as an option.
 
+- New command options for `code42 security-data search`
+    - `--risk-indicator` to filter events by risk indicators.
+    - `--risk-severity` to filter events by risk severity.
+
 ### Changed
 
 - A TOTP token is now required on `code42 profile` commands that check for password validity when a user has MFA enabled.

--- a/docs/commands/alertrules.rst
+++ b/docs/commands/alertrules.rst
@@ -1,3 +1,3 @@
 .. click:: code42cli.cmds.alert_rules:alert_rules
   :prog: alert-rules
-  :show-nested:
+  :nested: full

--- a/docs/commands/alerts.rst
+++ b/docs/commands/alerts.rst
@@ -1,3 +1,3 @@
 .. click:: code42cli.cmds.alerts:alerts
   :prog: alerts
-  :show-nested:
+  :nested: full

--- a/docs/commands/auditlogs.rst
+++ b/docs/commands/auditlogs.rst
@@ -1,3 +1,3 @@
 .. click:: code42cli.cmds.auditlogs:audit_logs
   :prog: audit-logs
-  :show-nested:
+  :nested: full

--- a/docs/commands/cases.rst
+++ b/docs/commands/cases.rst
@@ -1,3 +1,3 @@
 .. click:: code42cli.cmds.cases:cases
   :prog: cases
-  :show-nested:
+  :nested: full

--- a/docs/commands/departingemployee.rst
+++ b/docs/commands/departingemployee.rst
@@ -1,3 +1,3 @@
 .. click:: code42cli.cmds.departing_employee:departing_employee
   :prog: departing-employee
-  :show-nested:
+  :nested: full

--- a/docs/commands/devices.rst
+++ b/docs/commands/devices.rst
@@ -1,3 +1,3 @@
 .. click:: code42cli.cmds.devices:devices
   :prog: devices
-  :show-nested:
+  :nested: full

--- a/docs/commands/highriskemployee.rst
+++ b/docs/commands/highriskemployee.rst
@@ -1,3 +1,3 @@
 .. click:: code42cli.cmds.high_risk_employee:high_risk_employee
   :prog: high-risk-employee
-  :show-nested:
+  :nested: full

--- a/docs/commands/legalhold.rst
+++ b/docs/commands/legalhold.rst
@@ -1,3 +1,3 @@
 .. click:: code42cli.cmds.legal_hold:legal_hold
   :prog: legal-hold
-  :show-nested:
+  :nested: full

--- a/docs/commands/profile.rst
+++ b/docs/commands/profile.rst
@@ -1,3 +1,3 @@
 .. click:: code42cli.cmds.profile:profile
   :prog: profile
-  :show-nested:
+  :nested: full

--- a/docs/commands/securitydata.rst
+++ b/docs/commands/securitydata.rst
@@ -1,3 +1,3 @@
 .. click:: code42cli.cmds.securitydata:security_data
   :prog: security-data
-  :show-nested:
+  :nested: full

--- a/docs/commands/users.rst
+++ b/docs/commands/users.rst
@@ -1,3 +1,3 @@
 .. click:: code42cli.cmds.users:users
   :prog: users
-  :show-nested:
+  :nested: full

--- a/src/code42cli/click_ext/types.py
+++ b/src/code42cli/click_ext/types.py
@@ -140,9 +140,14 @@ class MapChoice(click.Choice):
     in help text, but work when passed as a choice.
     """
 
-    def __init__(self, choices, extras_map, **kwargs):
+    def __init__(self, choices, extras_map, help_map=None, **kwargs):
         self.extras_map = extras_map
+        self.help_map = help_map
         super().__init__(choices, **kwargs)
+
+    def get_metavar(self, param):
+        choices = self.help_map or self.choices
+        return "[{}]".format("|".join(choices))
 
     def convert(self, value, param, ctx):
         if value in self.extras_map:

--- a/src/code42cli/click_ext/types.py
+++ b/src/code42cli/click_ext/types.py
@@ -140,32 +140,15 @@ class MapChoice(click.Choice):
     in help text, but work when passed as a choice.
     """
 
-    def __init__(self, choices, extras_map, help_map=None, **kwargs):
+    def __init__(self, choices, extras_map, **kwargs):
         self.extras_map = extras_map
-        self.help_map = help_map
         super().__init__(choices, **kwargs)
-
-    def get_metavar(self, param):
-        choices = self.help_map or self.choices
-        return "[{}]".format("|".join(choices))
 
     def convert(self, value, param, ctx):
         if value in self.extras_map:
             value = self.extras_map[value]
 
-        try:
-            return super().convert(value, param, ctx)
-        except BadParameter:
-            if self.help_map:
-                self.fail(
-                    "invalid choice: {}. (choose from {})".format(
-                        value, ", ".join(self.help_map)
-                    ),
-                    param,
-                    ctx,
-                )
-            else:
-                raise
+        return super().convert(value, param, ctx)
 
 
 class TOTP(click.ParamType):

--- a/src/code42cli/click_ext/types.py
+++ b/src/code42cli/click_ext/types.py
@@ -152,7 +152,20 @@ class MapChoice(click.Choice):
     def convert(self, value, param, ctx):
         if value in self.extras_map:
             value = self.extras_map[value]
-        return super().convert(value, param, ctx)
+
+        try:
+            return super().convert(value, param, ctx)
+        except BadParameter:
+            if self.help_map:
+                self.fail(
+                    "invalid choice: {}. (choose from {})".format(
+                        value, ", ".join(self.help_map)
+                    ),
+                    param,
+                    ctx,
+                )
+            else:
+                raise
 
 
 class TOTP(click.ParamType):

--- a/src/code42cli/cmds/securitydata.py
+++ b/src/code42cli/cmds/securitydata.py
@@ -4,8 +4,8 @@ import click
 import py42.sdk.queries.fileevents.filters as f
 from c42eventextractor.extractors import FileEventExtractor
 from click import echo
-from py42.sdk.queries.fileevents.filters import RiskIndicator
-from py42.sdk.queries.fileevents.filters import RiskSeverity
+from py42.sdk.queries.fileevents.filters.risk_filter import RiskIndicator
+from py42.sdk.queries.fileevents.filters.risk_filter import RiskSeverity
 from py42.sdk.queries.fileevents.filters.exposure_filter import ExposureType
 from py42.sdk.queries.fileevents.filters.file_filter import FileCategory
 

--- a/src/code42cli/cmds/securitydata.py
+++ b/src/code42cli/cmds/securitydata.py
@@ -4,6 +4,8 @@ import click
 import py42.sdk.queries.fileevents.filters as f
 from c42eventextractor.extractors import FileEventExtractor
 from click import echo
+from py42.sdk.queries.fileevents.filters import RiskIndicator
+from py42.sdk.queries.fileevents.filters import RiskSeverity
 from py42.sdk.queries.fileevents.filters.exposure_filter import ExposureType
 from py42.sdk.queries.fileevents.filters.file_filter import FileCategory
 
@@ -127,7 +129,7 @@ process_owner_option = click.option(
     callback=searchopt.is_in_filter(f.ProcessOwner),
     cls=searchopt.AdvancedQueryAndSavedSearchIncompatible,
     help="Limits exposure events by process owner, as reported by the device’s operating system. "
-    "Applies only to `Printed` and `Browser or app read` events.",
+    "Applies only to ,Printed, and ,Browser or app read, events.",
 )
 tab_url_option = click.option(
     "--tab-url",
@@ -142,6 +144,89 @@ include_non_exposure_option = click.option(
     callback=searchopt.exists_filter(f.ExposureType),
     cls=incompatible_with(["advanced_query", "type", "saved_search"]),
     help="Get all events including non-exposure events.",
+)
+risk_indicator_map = {
+    "PUBLIC_CORPORATE_BOX": RiskIndicator.CloudDataExposures.PUBLIC_CORPORATE_BOX,
+    "PUBLIC_CORPORATE_GOOGLE": RiskIndicator.CloudDataExposures.PUBLIC_CORPORATE_GOOGLE_DRIVE,
+    "PUBLIC_CORPORATE_ONEDRIVE": RiskIndicator.CloudDataExposures.PUBLIC_CORPORATE_ONEDRIVE,
+    "SENT_CORPORATE_GMAIL": RiskIndicator.CloudDataExposures.SENT_CORPORATE_GMAIL,
+    "SHARED_CORPORATE_BOX": RiskIndicator.CloudDataExposures.SHARED_CORPORATE_BOX,
+    "SHARED_CORPORATE_GOOGLE_DRIVE": RiskIndicator.CloudDataExposures.SHARED_CORPORATE_GOOGLE_DRIVE,
+    "SHARED_CORPORATE_ONEDRIVE": RiskIndicator.CloudDataExposures.SHARED_CORPORATE_ONEDRIVE,
+    "AMAZON_DRIVE": RiskIndicator.CloudStorageUploads.AMAZON_DRIVE,
+    "BOX": RiskIndicator.CloudStorageUploads.BOX,
+    "DROPBOX": RiskIndicator.CloudStorageUploads.DROPBOX,
+    "GOOGLE_DRIVE": RiskIndicator.CloudStorageUploads.GOOGLE_DRIVE,
+    "ICLOUD": RiskIndicator.CloudStorageUploads.ICLOUD,
+    "MEGA": RiskIndicator.CloudStorageUploads.MEGA,
+    "ONEDRIVE": RiskIndicator.CloudStorageUploads.ONEDRIVE,
+    "ZOHO": RiskIndicator.CloudStorageUploads.ZOHO,
+    "BITBUCKET": RiskIndicator.CodeRepositoryUploads.BITBUCKET,
+    "GITHUB": RiskIndicator.CodeRepositoryUploads.GITHUB,
+    "GITLAB": RiskIndicator.CodeRepositoryUploads.GITLAB,
+    "SOURCEFORGE": RiskIndicator.CodeRepositoryUploads.SOURCEFORGE,
+    "STASH": RiskIndicator.CodeRepositoryUploads.STASH,
+    "163.COM": RiskIndicator.EmailServiceUploads.ONESIXTHREE_DOT_COM,
+    "126.COM": RiskIndicator.EmailServiceUploads.ONETWOSIX_DOT_COM,
+    "AOL": RiskIndicator.EmailServiceUploads.AOL,
+    "COMCAST": RiskIndicator.EmailServiceUploads.COMCAST,
+    "GMAIL": RiskIndicator.EmailServiceUploads.GMAIL,
+    "ICLOUD_MAIL": RiskIndicator.EmailServiceUploads.ICLOUD,
+    "MAIL.COM": RiskIndicator.EmailServiceUploads.MAIL_DOT_COM,
+    "OUTLOOK": RiskIndicator.EmailServiceUploads.OUTLOOK,
+    "PROTONMAIL": RiskIndicator.EmailServiceUploads.PROTONMAIL,
+    "QQMAIL": RiskIndicator.EmailServiceUploads.QQMAIL,
+    "SINA_MAIL": RiskIndicator.EmailServiceUploads.SINA_MAIL,
+    "SOHU_MAIl": RiskIndicator.EmailServiceUploads.SOHU_MAIl,
+    "YAHOO": RiskIndicator.EmailServiceUploads.YAHOO,
+    "ZOHO_MAIL": RiskIndicator.EmailServiceUploads.ZOHO_MAIL,
+    "AIRDROP": RiskIndicator.ExternalDevices.AIRDROP,
+    "REMOVABLE_MEDIA": RiskIndicator.ExternalDevices.REMOVABLE_MEDIA,
+    "AUDIO": RiskIndicator.FileCategories.AUDIO,
+    "DOCUMENT": RiskIndicator.FileCategories.DOCUMENT,
+    "EXECUTABLE": RiskIndicator.FileCategories.EXECUTABLE,
+    "IMAGE": RiskIndicator.FileCategories.IMAGE,
+    "PDF": RiskIndicator.FileCategories.PDF,
+    "PRESENTATION": RiskIndicator.FileCategories.PRESENTATION,
+    "SCRIPT": RiskIndicator.FileCategories.SCRIPT,
+    "SOURCE_CODE": RiskIndicator.FileCategories.SOURCE_CODE,
+    "SPREADSHEET": RiskIndicator.FileCategories.SPREADSHEET,
+    "VIDEO": RiskIndicator.FileCategories.VIDEO,
+    "VIRTUAL_DISK_IMAGE": RiskIndicator.FileCategories.VIRTUAL_DISK_IMAGE,
+    "ZIP": RiskIndicator.FileCategories.ZIP,
+    "FACEBOOK_MESSENGER": RiskIndicator.MessagingServiceUploads.FACEBOOK_MESSENGER,
+    "MICROSOFT_TEAMS": RiskIndicator.MessagingServiceUploads.MICROSOFT_TEAMS,
+    "SLACK": RiskIndicator.MessagingServiceUploads.SLACK,
+    "WHATSAPP": RiskIndicator.MessagingServiceUploads.WHATSAPP,
+    "OTHER": RiskIndicator.Other.OTHER,
+    "UNKNOWN": RiskIndicator.Other.UNKNOWN,
+    "FACEBOOK": RiskIndicator.SocialMediaUploads.FACEBOOK,
+    "LINKEDIN": RiskIndicator.SocialMediaUploads.LINKEDIN,
+    "REDDIT": RiskIndicator.SocialMediaUploads.REDDIT,
+    "TWITTER": RiskIndicator.SocialMediaUploads.TWITTER,
+    "FILE_MISMATCH": RiskIndicator.UserBehavior.FILE_MISMATCH,
+    "OFF_HOURS": RiskIndicator.UserBehavior.OFF_HOURS,
+    "REMOTE": RiskIndicator.UserBehavior.REMOTE,
+}
+risk_indicator_option = click.option(
+    "--risk-indicator",
+    multiple=True,
+    type=MapChoice(
+        choices=list(RiskIndicator.choices()),
+        extras_map=risk_indicator_map,
+        help_map=list(risk_indicator_map.keys()),
+    ),
+    callback=searchopt.is_in_filter(f.RiskIndicator),
+    cls=searchopt.AdvancedQueryAndSavedSearchIncompatible,
+    help="Limits events to those classified by the given risk indicator categories.",
+)
+risk_severity_option = click.option(
+    "--risk-severity",
+    multiple=True,
+    type=click.Choice(list(RiskSeverity.choices())),
+    callback=searchopt.is_in_filter(f.RiskSeverity),
+    cls=searchopt.AdvancedQueryAndSavedSearchIncompatible,
+    help="Limits events to those classified by the given risk severity.",
 )
 begin_option = opt.begin_option(
     SECURITY_DATA_KEYWORD,
@@ -186,6 +271,8 @@ def _create_search_header_map():
         "fileOwner": "FileOwner",
         "md5Checksum": "MD5Checksum",
         "sha256Checksum": "SHA256Checksum",
+        "riskIndicators": "RiskIndicator",
+        "riskSeverity": "RiskSeverity",
     }
 
 
@@ -210,6 +297,8 @@ def file_event_options(f):
     f = process_owner_option(f)
     f = tab_url_option(f)
     f = include_non_exposure_option(f)
+    f = risk_indicator_option(f)
+    f = risk_severity_option(f)
     f = _get_saved_search_option()(f)
     return f
 
@@ -226,7 +315,7 @@ def security_data(state):
 @click.argument("checkpoint-name")
 @sdk_options()
 def clear_checkpoint(state, checkpoint_name):
-    """Remove the saved file event checkpoint from `--use-checkpoint/-c` mode."""
+    """Remove the saved file event checkpoint from ,--use-checkpoint/-c, mode."""
     _get_file_event_cursor_store(state.profile.name).delete(checkpoint_name)
 
 

--- a/src/code42cli/cmds/securitydata.py
+++ b/src/code42cli/cmds/securitydata.py
@@ -129,7 +129,7 @@ process_owner_option = click.option(
     callback=searchopt.is_in_filter(f.ProcessOwner),
     cls=searchopt.AdvancedQueryAndSavedSearchIncompatible,
     help="Limits exposure events by process owner, as reported by the device’s operating system. "
-    "Applies only to ,Printed, and ,Browser or app read, events.",
+    "Applies only to `Printed` and `Browser or app read` events.",
 )
 tab_url_option = click.option(
     "--tab-url",

--- a/src/code42cli/cmds/securitydata.py
+++ b/src/code42cli/cmds/securitydata.py
@@ -4,10 +4,10 @@ import click
 import py42.sdk.queries.fileevents.filters as f
 from c42eventextractor.extractors import FileEventExtractor
 from click import echo
-from py42.sdk.queries.fileevents.filters.risk_filter import RiskIndicator
-from py42.sdk.queries.fileevents.filters.risk_filter import RiskSeverity
 from py42.sdk.queries.fileevents.filters.exposure_filter import ExposureType
 from py42.sdk.queries.fileevents.filters.file_filter import FileCategory
+from py42.sdk.queries.fileevents.filters.risk_filter import RiskIndicator
+from py42.sdk.queries.fileevents.filters.risk_filter import RiskSeverity
 
 import code42cli.cmds.search.extraction as ext
 import code42cli.cmds.search.options as searchopt

--- a/src/code42cli/cmds/securitydata.py
+++ b/src/code42cli/cmds/securitydata.py
@@ -315,7 +315,7 @@ def security_data(state):
 @click.argument("checkpoint-name")
 @sdk_options()
 def clear_checkpoint(state, checkpoint_name):
-    """Remove the saved file event checkpoint from ,--use-checkpoint/-c, mode."""
+    """Remove the saved file event checkpoint from `--use-checkpoint/-c` mode."""
     _get_file_event_cursor_store(state.profile.name).delete(checkpoint_name)
 
 

--- a/src/code42cli/cmds/securitydata.py
+++ b/src/code42cli/cmds/securitydata.py
@@ -208,15 +208,26 @@ risk_indicator_map = {
     "OFF_HOURS": RiskIndicator.UserBehavior.OFF_HOURS,
     "REMOTE": RiskIndicator.UserBehavior.REMOTE,
 }
+risk_indicator_map_reversed = {v: k for k, v in risk_indicator_map.items()}
+
+
+def risk_indicator_callback(filter_cls):
+    def callback(ctx, param, arg):
+        if arg:
+            mapped_arg = (risk_indicator_map[arg[0]],)
+            filter_func = searchopt.is_in_filter(filter_cls)
+            return filter_func(ctx, param, mapped_arg)
+
+    return callback
+
+
 risk_indicator_option = click.option(
     "--risk-indicator",
     multiple=True,
     type=MapChoice(
-        choices=list(RiskIndicator.choices()),
-        extras_map=risk_indicator_map,
-        help_map=list(risk_indicator_map.keys()),
+        choices=list(risk_indicator_map.keys()), extras_map=risk_indicator_map_reversed,
     ),
-    callback=searchopt.is_in_filter(f.RiskIndicator),
+    callback=risk_indicator_callback(f.RiskIndicator),
     cls=searchopt.AdvancedQueryAndSavedSearchIncompatible,
     help="Limits events to those classified by the given risk indicator categories.",
 )

--- a/tests/cmds/test_securitydata.py
+++ b/tests/cmds/test_securitydata.py
@@ -5,6 +5,8 @@ import py42.sdk.queries.fileevents.filters as f
 import pytest
 from c42eventextractor.extractors import FileEventExtractor
 from py42.sdk.queries.fileevents.file_event_query import FileEventQuery
+from py42.sdk.queries.fileevents.filters import RiskIndicator
+from py42.sdk.queries.fileevents.filters import RiskSeverity
 from py42.sdk.queries.fileevents.filters.file_filter import FileCategory
 from tests.cmds.conftest import filter_term_is_in_call_args
 from tests.cmds.conftest import get_filter_value_from_json
@@ -107,6 +109,8 @@ advanced_query_incompat_test_params = pytest.mark.parametrize(
         ("--tab-url", "https://example.com"),
         ("--type", "SharedViaLink"),
         ("--include-non-exposure",),
+        ("--risk-indicator", "PUBLIC_CORPORATE_BOX"),
+        ("--risk-severity", "LOW"),
     ],
 )
 saved_search_incompat_test_params = pytest.mark.parametrize(
@@ -127,6 +131,8 @@ saved_search_incompat_test_params = pytest.mark.parametrize(
         ("--type", "SharedViaLink"),
         ("--include-non-exposure",),
         ("--use-checkpoint", "test"),
+        ("--risk-indicator", "PUBLIC_CORPORATE_BOX"),
+        ("--risk-severity", "LOW"),
     ],
 )
 search_and_send_to_test = get_mark_for_search_and_send_to("security-data")
@@ -787,6 +793,132 @@ def test_search_and_send_to_when_given_include_non_exposure_and_exposure_types_c
         obj=cli_state,
     )
     assert result.exit_code == 2
+
+
+@search_and_send_to_test
+def test_search_and_send_to_when_given_risk_indicator_uses_risk_indicator_filter(
+    runner, cli_state, file_event_extractor, command
+):
+    risk_indicator = RiskIndicator.MessagingServiceUploads.SLACK
+    command = [*command, "--begin", "1h", "--risk-indicator", risk_indicator]
+    runner.invoke(
+        cli, command, obj=cli_state,
+    )
+    filter_strings = [str(arg) for arg in file_event_extractor.extract.call_args[0]]
+    assert str(f.RiskIndicator.is_in([risk_indicator])) in filter_strings
+
+
+@pytest.mark.parametrize(
+    "indicator_choice",
+    [
+        ("PUBLIC_CORPORATE_BOX", RiskIndicator.CloudDataExposures.PUBLIC_CORPORATE_BOX),
+        (
+            "PUBLIC_CORPORATE_GOOGLE",
+            RiskIndicator.CloudDataExposures.PUBLIC_CORPORATE_GOOGLE_DRIVE,
+        ),
+        (
+            "PUBLIC_CORPORATE_ONEDRIVE",
+            RiskIndicator.CloudDataExposures.PUBLIC_CORPORATE_ONEDRIVE,
+        ),
+        ("SENT_CORPORATE_GMAIL", RiskIndicator.CloudDataExposures.SENT_CORPORATE_GMAIL),
+        ("SHARED_CORPORATE_BOX", RiskIndicator.CloudDataExposures.SHARED_CORPORATE_BOX),
+        (
+            "SHARED_CORPORATE_GOOGLE_DRIVE",
+            RiskIndicator.CloudDataExposures.SHARED_CORPORATE_GOOGLE_DRIVE,
+        ),
+        (
+            "SHARED_CORPORATE_ONEDRIVE",
+            RiskIndicator.CloudDataExposures.SHARED_CORPORATE_ONEDRIVE,
+        ),
+        ("AMAZON_DRIVE", RiskIndicator.CloudStorageUploads.AMAZON_DRIVE),
+        ("BOX", RiskIndicator.CloudStorageUploads.BOX),
+        ("DROPBOX", RiskIndicator.CloudStorageUploads.DROPBOX),
+        ("GOOGLE_DRIVE", RiskIndicator.CloudStorageUploads.GOOGLE_DRIVE),
+        ("ICLOUD", RiskIndicator.CloudStorageUploads.ICLOUD),
+        ("MEGA", RiskIndicator.CloudStorageUploads.MEGA),
+        ("ONEDRIVE", RiskIndicator.CloudStorageUploads.ONEDRIVE),
+        ("ZOHO", RiskIndicator.CloudStorageUploads.ZOHO),
+        ("BITBUCKET", RiskIndicator.CodeRepositoryUploads.BITBUCKET),
+        ("GITHUB", RiskIndicator.CodeRepositoryUploads.GITHUB),
+        ("GITLAB", RiskIndicator.CodeRepositoryUploads.GITLAB),
+        ("SOURCEFORGE", RiskIndicator.CodeRepositoryUploads.SOURCEFORGE),
+        ("STASH", RiskIndicator.CodeRepositoryUploads.STASH),
+        ("163.COM", RiskIndicator.EmailServiceUploads.ONESIXTHREE_DOT_COM),
+        ("126.COM", RiskIndicator.EmailServiceUploads.ONETWOSIX_DOT_COM),
+        ("AOL", RiskIndicator.EmailServiceUploads.AOL),
+        ("COMCAST", RiskIndicator.EmailServiceUploads.COMCAST),
+        ("GMAIL", RiskIndicator.EmailServiceUploads.GMAIL),
+        ("ICLOUD_MAIL", RiskIndicator.EmailServiceUploads.ICLOUD),
+        ("MAIL.COM", RiskIndicator.EmailServiceUploads.MAIL_DOT_COM),
+        ("OUTLOOK", RiskIndicator.EmailServiceUploads.OUTLOOK),
+        ("PROTONMAIL", RiskIndicator.EmailServiceUploads.PROTONMAIL),
+        ("QQMAIL", RiskIndicator.EmailServiceUploads.QQMAIL),
+        ("SINA_MAIL", RiskIndicator.EmailServiceUploads.SINA_MAIL),
+        ("SOHU_MAIl", RiskIndicator.EmailServiceUploads.SOHU_MAIl),
+        ("YAHOO", RiskIndicator.EmailServiceUploads.YAHOO),
+        ("ZOHO_MAIL", RiskIndicator.EmailServiceUploads.ZOHO_MAIL),
+        ("AIRDROP", RiskIndicator.ExternalDevices.AIRDROP),
+        ("REMOVABLE_MEDIA", RiskIndicator.ExternalDevices.REMOVABLE_MEDIA),
+        ("AUDIO", RiskIndicator.FileCategories.AUDIO),
+        ("DOCUMENT", RiskIndicator.FileCategories.DOCUMENT),
+        ("EXECUTABLE", RiskIndicator.FileCategories.EXECUTABLE),
+        ("IMAGE", RiskIndicator.FileCategories.IMAGE),
+        ("PDF", RiskIndicator.FileCategories.PDF),
+        ("PRESENTATION", RiskIndicator.FileCategories.PRESENTATION),
+        ("SCRIPT", RiskIndicator.FileCategories.SCRIPT),
+        ("SOURCE_CODE", RiskIndicator.FileCategories.SOURCE_CODE),
+        ("SPREADSHEET", RiskIndicator.FileCategories.SPREADSHEET),
+        ("VIDEO", RiskIndicator.FileCategories.VIDEO),
+        ("VIRTUAL_DISK_IMAGE", RiskIndicator.FileCategories.VIRTUAL_DISK_IMAGE),
+        ("ZIP", RiskIndicator.FileCategories.ZIP),
+        (
+            "FACEBOOK_MESSENGER",
+            RiskIndicator.MessagingServiceUploads.FACEBOOK_MESSENGER,
+        ),
+        ("MICROSOFT_TEAMS", RiskIndicator.MessagingServiceUploads.MICROSOFT_TEAMS),
+        ("SLACK", RiskIndicator.MessagingServiceUploads.SLACK),
+        ("WHATSAPP", RiskIndicator.MessagingServiceUploads.WHATSAPP),
+        ("OTHER", RiskIndicator.Other.OTHER),
+        ("UNKNOWN", RiskIndicator.Other.UNKNOWN),
+        ("FACEBOOK", RiskIndicator.SocialMediaUploads.FACEBOOK),
+        ("LINKEDIN", RiskIndicator.SocialMediaUploads.LINKEDIN),
+        ("REDDIT", RiskIndicator.SocialMediaUploads.REDDIT),
+        ("TWITTER", RiskIndicator.SocialMediaUploads.TWITTER),
+        ("FILE_MISMATCH", RiskIndicator.UserBehavior.FILE_MISMATCH),
+        ("OFF_HOURS", RiskIndicator.UserBehavior.OFF_HOURS),
+        ("REMOTE", RiskIndicator.UserBehavior.REMOTE),
+    ],
+)
+def test_all_caps_risk_indicator_choices_convert_to_risk_indicator_string(
+    runner, cli_state, file_event_extractor, indicator_choice
+):
+    ALL_CAPS_VALUE, string_value = indicator_choice
+    command = [
+        "security-data",
+        "search",
+        "--begin",
+        "1h",
+        "--risk-indicator",
+        ALL_CAPS_VALUE,
+    ]
+    runner.invoke(
+        cli, command, obj=cli_state,
+    )
+    filter_strings = [str(arg) for arg in file_event_extractor.extract.call_args[0]]
+    assert str(f.RiskIndicator.is_in([string_value])) in filter_strings
+
+
+@search_and_send_to_test
+def test_search_and_send_to_when_given_risk_severity_uses_risk_severity_filter(
+    runner, cli_state, file_event_extractor, command
+):
+    risk_severity = RiskSeverity.LOW
+    command = [*command, "--begin", "1h", "--risk-severity", risk_severity]
+    runner.invoke(
+        cli, command, obj=cli_state,
+    )
+    filter_strings = [str(arg) for arg in file_event_extractor.extract.call_args[0]]
+    assert str(f.RiskSeverity.is_in([risk_severity])) in filter_strings
 
 
 @search_and_send_to_test


### PR DESCRIPTION
Added command options for `code42 security-data search` to allow users to filter event queries by `--risk-severity` and `--risk-indicator`.

Because the attribute values for the different `RiskIndicator` classes are all full strings (with whitespace, ex: `PUBLIC_CORPORATE_GOOGLE_DRIVE = "Public link from corporate Google Drive"`), I used a dictionary to map shorter arg values to these strings.  This also cleans up the the `-h` print output when it prints out all possible type values - its still a pretty big block of text though. 