### PR TITLE
PATH troubleshooting helpers/docs

### DIFF
--- a/docs/userguides/gettingstarted.md
+++ b/docs/userguides/gettingstarted.md
@@ -148,7 +148,7 @@ Add the above to your shell configuration file to persist the change.
 
 #### On Windows:
 
-```powershell 
+```powershell
 $env:Path += ";$(python -m code42cli --script-dir)"
 ```
 

--- a/docs/userguides/gettingstarted.md
+++ b/docs/userguides/gettingstarted.md
@@ -135,7 +135,7 @@ You can execute the CLI by calling the python module directly:
 python3 -m code42cli
 ```
 
-And the base `code42` command now has a `--script-dir` option that will print out the directory the `code42` script was 
+And the base `code42` command now has a `--script-dir` option that will print out the directory the `code42` script was
 installed into, so you can manually add it to your PATH, enabling the `code42` command to work.
 
 #### On Mac/Linux:

--- a/docs/userguides/gettingstarted.md
+++ b/docs/userguides/gettingstarted.md
@@ -123,7 +123,7 @@ To learn more about authenticating in the CLI, follow the [Configure profile gui
 
 ## Troubleshooting and support
 
-### PATH issues
+### Code42 command not found
 
 If your python installation has added itself to your environment's PATH variable, then running `code42` _should_ just work.
 
@@ -140,11 +140,11 @@ installed into, so you can manually add it to your PATH, enabling the `code42` c
 
 #### On Mac/Linux:
 
+Run the following to make `code42` visible in your shell's PATH (to persist the change, add it to your shell's configuration file):
+
 ```bash
 export PATH=$PATH:$(python3 -m code42cli --script-dir)
 ```
-
-Add the above to your shell configuration file to persist the change.
 
 #### On Windows:
 
@@ -152,7 +152,7 @@ Add the above to your shell configuration file to persist the change.
 $env:Path += ";$(python -m code42cli --script-dir)"
 ```
 
-Then to store the updated PATH variable permanently:
+To persist the change, add the updated PATH to your registry:
 
 ```powershell
 Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $env:Path

--- a/docs/userguides/gettingstarted.md
+++ b/docs/userguides/gettingstarted.md
@@ -123,6 +123,41 @@ To learn more about authenticating in the CLI, follow the [Configure profile gui
 
 ## Troubleshooting and support
 
+### PATH issues
+
+If your python installation has added itself to your environment's PATH variable, then running `code42` _should_ just work.
+
+However, if after installation the `code42` command is not found, the CLI has some helpers for this (added in version 1.10):
+
+You can execute the CLI by calling the python module directly:
+
+```bash
+python3 -m code42cli
+```
+
+And the base `code42` command now has a `--script-dir` option that will print out the directory the `code42` script was 
+installed into, so you can manually add it to your PATH, enabling the `code42` command to work.
+
+#### On Mac/Linux:
+
+```bash
+export PATH=$PATH:$(python3 -m code42cli --script-dir)
+```
+
+Add the above to your shell configuration file to persist the change.
+
+#### On Windows:
+
+```bash
+$env:Path += ";$(python -m code42cli --script-dir)"
+```
+
+Then to store the updated PATH variable permanently:
+
+```bash
+Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $env:Path
+```
+
 ### Debug mode
 
 Debug mode may be useful if you are trying to determine if you are experiencing permissions issues. When debug mode is

--- a/docs/userguides/gettingstarted.md
+++ b/docs/userguides/gettingstarted.md
@@ -22,7 +22,7 @@ python3 -m pip install code42cli
 ```
 
 To install a previous version of the Code42 CLI via `pip`, add the version number. For example, to install version
-0.4.1, enter:
+0.5.3, enter:
 
 ```bash
 python3 -m pip install code42cli==0.5.3

--- a/docs/userguides/gettingstarted.md
+++ b/docs/userguides/gettingstarted.md
@@ -148,13 +148,13 @@ Add the above to your shell configuration file to persist the change.
 
 #### On Windows:
 
-```bash
+```powershell 
 $env:Path += ";$(python -m code42cli --script-dir)"
 ```
 
 Then to store the updated PATH variable permanently:
 
-```bash
+```powershell
 Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $env:Path
 ```
 

--- a/src/code42cli/__main__.py
+++ b/src/code42cli/__main__.py
@@ -1,0 +1,6 @@
+from setuptools import Distribution
+from setuptools.command.install import install
+
+i = install(Distribution())
+i.ensure_finalized()
+print(i.install_scripts)

--- a/src/code42cli/__main__.py
+++ b/src/code42cli/__main__.py
@@ -1,6 +1,3 @@
-from setuptools import Distribution
-from setuptools.command.install import install
+from code42cli.main import cli
 
-i = install(Distribution())
-i.ensure_finalized()
-print(i.install_scripts)
+cli(prog_name="code42")

--- a/src/code42cli/main.py
+++ b/src/code42cli/main.py
@@ -60,7 +60,7 @@ CONTEXT_SETTINGS = {
 @click.option(
     "--script-dir",
     is_flag=True,
-    help="Print the directory the `code42` script was installed in (for adding to your PATH if needed)."
+    help="Print the directory the `code42` script was installed in (for adding to your PATH if needed).",
 )
 @sdk_options(hidden=True)
 def cli(state, python, script_dir):
@@ -68,12 +68,12 @@ def cli(state, python, script_dir):
         click.echo(sys.executable)
         sys.exit(0)
     if script_dir:
-        for root, dirs, files in os.walk(site.PREFIXES[0]):
+        for root, _dirs, files in os.walk(site.PREFIXES[0]):
             if "code42" in files or "code42.exe" in files:
                 print(root)
                 sys.exit(0)
 
-        for root, dirs, files in os.walk(site.USER_BASE):
+        for root, _dirs, files in os.walk(site.USER_BASE):
             if "code42" in files or "code42.exe" in files:
                 print(root)
                 sys.exit(0)

--- a/src/code42cli/main.py
+++ b/src/code42cli/main.py
@@ -1,4 +1,6 @@
+import os
 import signal
+import site
 import sys
 
 import click
@@ -53,13 +55,28 @@ CONTEXT_SETTINGS = {
 @click.option(
     "--python",
     is_flag=True,
-    help="Print path to the python interpreter env that `code42` is installed in.",
+    help="Print path to the python interpreter env that `code42cli` is installed in.",
+)
+@click.option(
+    "--script-dir",
+    is_flag=True,
+    help="Print the directory the `code42` script was installed in (for adding to your PATH if needed)."
 )
 @sdk_options(hidden=True)
-def cli(state, python):
+def cli(state, python, script_dir):
     if python:
         click.echo(sys.executable)
         sys.exit(0)
+    if script_dir:
+        for root, dirs, files in os.walk(site.PREFIXES[0]):
+            if "code42" in files or "code42.exe" in files:
+                print(root)
+                sys.exit(0)
+
+        for root, dirs, files in os.walk(site.USER_BASE):
+            if "code42" in files or "code42.exe" in files:
+                print(root)
+                sys.exit(0)
 
 
 cli.add_command(alerts)


### PR DESCRIPTION
This change enables the CLI to be called as a module: `python -m code42cli <command>` is now equivalent to `code42 <command>` 

This makes it possible to still use the CLI if python hasn't installed its scripts directory into the user's PATH. 

Additionally, the `--script-dir` option has been added to the base command, which prints the directory the `code42` script had been installed into, which can then be used to add the correct directory to PATH so `code42` can be called directly.

GettingStarted guide has also been updated to include the above info. 
