### PR TITLE
remove broken OutputFormat.echo_formatted_generated_output()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 - `code42 profile use` now prompts you to select a profile when not given a profile name argument.
 
+### Fixed
+
+- Bug where `audit-logs search` with `--use-checkpoint` option was causing output formatting problems.
+
 ## 1.9.0 - 2021-08-19
 
 ### Added

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,5 +27,7 @@ ignore =
     E722
     # binary operation line break, different opinion from black
     W503
+    # exception chaining
+    B904
 # up to 88 allowed by bugbear B950
 max-line-length = 80

--- a/src/code42cli/cmds/auditlogs.py
+++ b/src/code42cli/cmds/auditlogs.py
@@ -141,18 +141,16 @@ def search(
         affected_user_ids=affected_user_id,
         affected_usernames=affected_username,
     )
-    if not events:
-        click.echo("No results found.")
-        return
 
     if use_checkpoint:
         checkpoint_name = use_checkpoint
-        events_gen = _dedupe_checkpointed_events_and_store_updated_checkpoint(
-            cursor, checkpoint_name, events
-        )
-        formatter.echo_formatted_generated_output(events_gen)
-    else:
-        formatter.echo_formatted_list(events)
+        events = list(_dedupe_checkpointed_events_and_store_updated_checkpoint(cursor, checkpoint_name, events))
+    
+    if not events:
+        click.echo("No results found.")
+        return
+    
+    formatter.echo_formatted_list(events)
 
 
 @audit_logs.command(cls=SendToCommand)

--- a/src/code42cli/cmds/auditlogs.py
+++ b/src/code42cli/cmds/auditlogs.py
@@ -147,7 +147,7 @@ def search(
         events = list(_dedupe_checkpointed_events_and_store_updated_checkpoint(cursor, checkpoint_name, events))
     
     if not events:
-        click.echo("No results found.")
+        click.echo("No results found.", err=True)
         return
     
     formatter.echo_formatted_list(events)

--- a/src/code42cli/cmds/auditlogs.py
+++ b/src/code42cli/cmds/auditlogs.py
@@ -144,12 +144,16 @@ def search(
 
     if use_checkpoint:
         checkpoint_name = use_checkpoint
-        events = list(_dedupe_checkpointed_events_and_store_updated_checkpoint(cursor, checkpoint_name, events))
-    
+        events = list(
+            _dedupe_checkpointed_events_and_store_updated_checkpoint(
+                cursor, checkpoint_name, events
+            )
+        )
+
     if not events:
         click.echo("No results found.", err=True)
         return
-    
+
     formatter.echo_formatted_list(events)
 
 

--- a/src/code42cli/output_formats.py
+++ b/src/code42cli/output_formats.py
@@ -136,7 +136,7 @@ class DataFrameOutputFormatter:
             click.echo_via_pager(str_output)
 
 
-def to_csv(output, include_header=True):
+def to_csv(output):
     """Output is a list of records"""
 
     if not output:
@@ -158,12 +158,12 @@ def to_table(output, header, include_header=True):
     return format_to_table(rows, column_size)
 
 
-def to_json(output, **kwargs):
+def to_json(output):
     """Output is a single record"""
     return f"{json.dumps(output)}\n"
 
 
-def to_formatted_json(output, **kwargs):
+def to_formatted_json(output):
     """Output is a single record"""
     return f"{json.dumps(output, indent=4)}\n"
 

--- a/src/code42cli/output_formats.py
+++ b/src/code42cli/output_formats.py
@@ -79,19 +79,6 @@ class OutputFormatter:
             if self.output_format in [OutputFormat.TABLE]:
                 click.echo()
 
-    def echo_formatted_generated_output(self, output_generator):
-        def _gen():
-            include_header = True
-            for output in output_generator:
-                if output:
-                    formatted_output = self._format_output(
-                        output, include_header=include_header
-                    )
-                    yield formatted_output
-                    include_header = False
-
-        click.echo_via_pager(_gen)
-
     @property
     def _requires_list_output(self):
         return self.output_format in (OutputFormat.TABLE, OutputFormat.CSV)
@@ -149,7 +136,7 @@ class DataFrameOutputFormatter:
             click.echo_via_pager(str_output)
 
 
-def to_csv(output):
+def to_csv(output, include_header=True):
     """Output is a list of records"""
 
     if not output:
@@ -171,12 +158,12 @@ def to_table(output, header, include_header=True):
     return format_to_table(rows, column_size)
 
 
-def to_json(output):
+def to_json(output, **kwargs):
     """Output is a single record"""
     return f"{json.dumps(output)}\n"
 
 
-def to_formatted_json(output):
+def to_formatted_json(output, **kwargs):
     """Output is a single record"""
     return f"{json.dumps(output, indent=4)}\n"
 

--- a/tests/cmds/test_auditlogs.py
+++ b/tests/cmds/test_auditlogs.py
@@ -586,23 +586,6 @@ def test_search_and_send_when_timestamps_have_nanoseconds_saves_checkpoint(
     assert call_args[0][1] == 1625150833.093616
 
 
-def test_search_if_error_occurs_when_processing_event_timestamp_still_outputs_results(
-    cli_state,
-    runner,
-    mock_audit_log_response_with_error_causing_timestamp,
-    audit_log_cursor_with_checkpoint,
-):
-    cli_state.sdk.auditlogs.get_all.return_value = (
-        mock_audit_log_response_with_error_causing_timestamp
-    )
-    res = runner.invoke(
-        cli, ["audit-logs", "search", "--use-checkpoint", "test"], obj=cli_state,
-    )
-    assert TEST_AUDIT_LOG_TIMESTAMP_1 in res.output
-    assert "I AM NOT A TIMESTAMP" in res.output
-    assert "Error: Unknown problem occurred." in res.output
-
-
 def test_search_if_error_occurs_when_processing_event_timestamp_does_not_store_error_timestamp(
     cli_state,
     runner,


### PR DESCRIPTION
`code42cli.output_formats.OutputFormatter.echo_formatted_generated_output()` was initially added because the `audit-logs` command processed events for checkpointing as a generator, and the thought was that if an error occurred halfway through sending events to the terminal, we'd only have checkpointed the most recent one sent.

However, the JSON, RAW-JSON, and CSV formatters weren't really designed with generators in mind, and thus they don't work with the current `echo_formatted_generated_output()`.

I'm simply reverting to calling `list()` on the generator prior to printing the output, so that formatting is no longer broken when using `--use-checkpoint`. I'd like to do some larger refactoring of output formats to handle generators down the line, but that work is too big for right now.