### PR TITLE
fix python version requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 - Incorrect column title on `code42 trusted-activities bulk create` command help text.
 - `code42 devices list` will now process `--exclude-most-recently-connected` prior to `--last-connected-before` instead of after.
+- The minimum required version of Python for code42cli is now correctly set as 3.6.2.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ Use the `code42` command to interact with your Code42 environment.
 
 ## Requirements
 
-- Python 3.6.0+
-- Code42 Server 6.8.x+
+- Python 3.6.2+
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,
     zip_safe=False,
-    python_requires=">3, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4",
+    python_requires=">=3.6.2, <4",
     install_requires=[
         "chardet",
         "click>=7.1.1, <8",
@@ -37,7 +37,7 @@ setup(
         "colorama>=0.4.3",
         "keyring==18.0.1",
         "keyrings.alt==3.2.0",
-        "ipython>=7.16.1",
+        "ipython==7.16.1",
         "pandas>=1.1.3",
         "py42>=1.19.1",
     ],


### PR DESCRIPTION
When running the cli on python 3.6.1 or 3.6.0, you will get

```
ImportError: cannot import name 'NoReturn'
```

On startup. This is because `typing.NoReturn` was not introduced until python 3.6.2, and ipython references this module.

This correctly updates our install requirements to require 3.6.2.