### PR TITLE
Bugfix/windows unicode with pipes

### DIFF
--- a/src/code42cli/click_ext/groups.py
+++ b/src/code42cli/click_ext/groups.py
@@ -107,7 +107,7 @@ class ExceptionHandlingGroup(click.Group):
             else:
                 cmd = 'export PYTHONIOENCODING="utf-8"'
             raise Code42CLIError(
-                f"Error writing unicode character using environment's detected encoding, try running:\n\n  {cmd}\n\nand then re-run your `code42` command."
+                f"Failed to handle unicode character using environment's detected encoding, try running:\n\n  {cmd}\n\nand then re-run your `code42` command."
             )
 
         except OSError:

--- a/src/code42cli/click_ext/groups.py
+++ b/src/code42cli/click_ext/groups.py
@@ -1,4 +1,5 @@
 import difflib
+import platform
 import re
 from collections import OrderedDict
 
@@ -99,6 +100,15 @@ class ExceptionHandlingGroup(click.Group):
         except Py42HTTPError as err:
             self.logger.log_verbose_error(self._original_args, err.response.request)
             raise LoggedCLIError("Problem making request to server.")
+
+        except UnicodeEncodeError:
+            if platform.system() == "Windows":
+                cmd = '$ENV:PYTHONIOENCODING="utf-16"'
+            else:
+                cmd = 'export PYTHONIOENCODING="utf-8"'
+            raise Code42CLIError(
+                f"Error writing unicode to output, run:\n\n\t{cmd}\n\nand then re-run your `code42` command."
+            )
 
         except OSError:
             raise

--- a/src/code42cli/click_ext/groups.py
+++ b/src/code42cli/click_ext/groups.py
@@ -107,7 +107,7 @@ class ExceptionHandlingGroup(click.Group):
             else:
                 cmd = 'export PYTHONIOENCODING="utf-8"'
             raise Code42CLIError(
-                f"Error writing unicode to output, run:\n\n\t{cmd}\n\nand then re-run your `code42` command."
+                f"Error writing unicode character using environment's detected encoding, try running:\n\n  {cmd}\n\nand then re-run your `code42` command."
             )
 
         except OSError:

--- a/src/code42cli/output_formats.py
+++ b/src/code42cli/output_formats.py
@@ -112,7 +112,7 @@ class DataFrameOutputFormatter:
             return df.to_json(**defaults)
 
         elif self.output_format == OutputFormat.CSV:
-            defaults = {"index": False}
+            defaults = {"index": False, "line_terminator": "\n"}
             defaults.update(kwargs)
             df = df.fillna("")
             return df.to_csv(**defaults)

--- a/src/code42cli/output_formats.py
+++ b/src/code42cli/output_formats.py
@@ -96,6 +96,7 @@ class DataFrameOutputFormatter:
                 "orient": "records",
                 "lines": True,
                 "index": True,
+                "force_ascii": False,
                 "default_handler": str,
             }
             defaults.update(kwargs)
@@ -106,6 +107,7 @@ class DataFrameOutputFormatter:
                 "orient": "records",
                 "lines": False,
                 "index": True,
+                "force_ascii": False,
                 "default_handler": str,
             }
             defaults.update(kwargs)


### PR DESCRIPTION
On Windows, the encoding Python detects on stdout changes when printing to the terminal vs piping to another process or file:

```
PS C:\Users\Tim> python -c "import sys; print(sys.stdout.encoding, file=sys.stderr)"
utf-8

PS C:\Users\Tim> python -c "import sys; print(sys.stdout.encoding, file=sys.stderr)" | select-string ".*"
cp1252
```

cp1252 encoding can't represent every unicode character, so if the code42 CLI tries to print one of those characters it causes an error.  

Steps to recreate: 
- In the admin console update a user's name to contain the following unicode character: `é`
- On Windows, run the cli command: `code42 users list -f CSV > test.csv`
- The CLI should report an error and log the following to the cli error logs:
```
UnicodeEncodeError: 'charmap' codec can't encode character '\u0119' in position 11485: character maps to <undefined> 
```

The most reliable solution to this problem is to have the user set the `PYTHONIOENCODING` environment variable to utf-8 on Mac/Linux, and utf-16 on Windows. So the "fix" for this is just catching this specific error and raising a Code42CLIError with instructions, like this:

```
PS C:\Users\Tim> code42 users list -f CSV > test.csv
Error: Failed to handle unicode character using environment's detected encoding, try running:

  $ENV:PYTHONIOENCODING="utf-16"

and then re-run your `code42` command.
```

On Linux/Mac the error's command will be: `export PYTHONIOENCODING="utf-8"`

This PR handles the error, and also adds arguments to `to_json()` to output actual unicode chars in JSON (previous default was to convert to `\u0119` representation), and also forces use of `\n` as the explicit newline character in `to_csv()` (otherwise newlines for some reason get duplicated when `PYTHONIOENCODING="utf-16"` on Windows and you pipe to a file).

