### PR TITLE
Enable json deserialization of backup set data

### DIFF
--- a/src/code42cli/cmds/devices.py
+++ b/src/code42cli/cmds/devices.py
@@ -517,9 +517,9 @@ def _add_backup_set_settings_to_dataframe(sdk, devices_dataframe):
                     "destinations": [
                         destination for destination in backup_set.destinations.values()
                     ],
-                    "included files": backup_set.included_files,
-                    "excluded files": backup_set.excluded_files,
-                    "filename exclusions": backup_set.filename_exclusions,
+                    "included files": list(backup_set.included_files),
+                    "excluded files": list(backup_set.excluded_files),
+                    "filename exclusions": list(backup_set.filename_exclusions),
                     "locked": backup_set.locked,
                 }
                 for backup_set in current_device_settings.backup_sets


### PR DESCRIPTION
The filename inclusions/exclusions in a device's backup set data are stored as a [TrackedFileSelectionList](https://github.com/code42/py42/blob/main/src/py42/clients/settings/device_settings.py#L455), which the json serializer doesn't know how to handle. This causes an error when running `code42 devices list-backup-sets -f JSON`. 

Converting these to regular lists when building the DataFrame resolves this. 