### PR TITLE
Fix error messages on latest py42

### DIFF
--- a/src/code42cli/click_ext/groups.py
+++ b/src/code42cli/click_ext/groups.py
@@ -87,8 +87,9 @@ class ExceptionHandlingGroup(click.Group):
             Py42TrustedActivityInvalidCharacterError,
             Py42TrustedActivityIdNotFound,
         ) as err:
-            self.logger.log_error(err)
-            raise Code42CLIError(str(err))
+            msg = err.args[0]
+            self.logger.log_error(msg)
+            raise Code42CLIError(msg)
 
         except Py42ForbiddenError as err:
             self.logger.log_verbose_error(self._original_args, err.response.request)


### PR DESCRIPTION
py42 1.20.0 now includes additional exception args, allowing users to pull the specific data (like a user_id) from an Exception without having to parse the message string. 

Because the CLI was just calling `str()` on those exceptions when logging/printing them to stdout, we now are getting the tuple of the args instead of just the message string. 

So we started getting: 
```
2022-01-12 09:15:47,379 ("The organization with UID '1234' was not found.", '1234')
```
instead of:
```
2022-01-12 09:17:04,177 The organization with UID '1234' was not found.
```

We only want the first arg (the formatted message string) when logging/printing.