### PR TITLE
Chore/allow optional cols for bulk cmds

### DIFF
--- a/docs/guides.md
+++ b/docs/guides.md
@@ -11,3 +11,4 @@
 * [Configure Trusted Activities](userguides/trustedactivities.md)
 * [Configure Alert Rules](userguides/alertrules.md)
 * [Add and Manage Cases](userguides/cases.md)
+* [Use Bulk Commands](userguides/bulkcommands.md)

--- a/docs/userguides/bulkcommands.md
+++ b/docs/userguides/bulkcommands.md
@@ -1,0 +1,23 @@
+# Using Bulk Commands
+
+Bulk functionality is available for many Code42 CLI methods, more details on which commands have bulk capabilities can be found in the [Commands Documentation](../commands.md).
+
+All bulk methods take a CSV file as input.
+
+The `generate-template` command can be used to create a CSV file with the necessary headers for a particular command.
+
+For instance, the following command will create a file named `devices_bulk_deactivate.csv` with a single column header row of `guid`.
+```bash
+code42 devices bulk generate-template deactivate
+```
+
+The CSV file can contain more columns than are necessary for the command, however then the header row is **required**.
+
+If the CSV file contains the *exact* number of columns that are necessary for the command then the header row is **optional**.
+
+To run a bulk method, simple pass the CSV file to the desired command.  For example, you would use to following command to deactivate multiple devices within your organization at once:
+
+
+```bash
+code42 devices bulk deactivate devices_bulk_deactivate.csv
+```

--- a/docs/userguides/bulkcommands.md
+++ b/docs/userguides/bulkcommands.md
@@ -13,9 +13,9 @@ code42 devices bulk generate-template deactivate
 
 The CSV file can contain more columns than are necessary for the command, however then the header row is **required**.
 
-If the CSV file contains the *exact* number of columns that are necessary for the command then the header row is **optional**.
+If the CSV file contains the *exact* number of columns that are necessary for the command then the header row is **optional**, but columns are expected to be in the same order as the template.
 
-To run a bulk method, simple pass the CSV file to the desired command.  For example, you would use to following command to deactivate multiple devices within your organization at once:
+To run a bulk method, simple pass the CSV file path to the desired command.  For example, you would use to following command to deactivate multiple devices within your organization at once:
 
 
 ```bash

--- a/docs/userguides/bulkcommands.md
+++ b/docs/userguides/bulkcommands.md
@@ -15,7 +15,7 @@ The CSV file can contain more columns than are necessary for the command, howeve
 
 If the CSV file contains the *exact* number of columns that are necessary for the command then the header row is **optional**, but columns are expected to be in the same order as the template.
 
-To run a bulk method, simple pass the CSV file path to the desired command.  For example, you would use to following command to deactivate multiple devices within your organization at once:
+To run a bulk method, simply pass the CSV file path to the desired command.  For example, you would use to following command to deactivate multiple devices within your organization at once:
 
 
 ```bash

--- a/src/code42cli/cmds/departing_employee.py
+++ b/src/code42cli/cmds/departing_employee.py
@@ -15,7 +15,6 @@ from code42cli.cmds.detectionlists.options import username_arg
 from code42cli.cmds.shared import get_user_id
 from code42cli.errors import Code42CLIError
 from code42cli.file_readers import read_csv_arg
-from code42cli.file_readers import read_flat_file_arg
 from code42cli.options import format_option
 from code42cli.options import sdk_options
 
@@ -86,16 +85,21 @@ def bulk(state):
 
 DEPARTING_EMPLOYEE_CSV_HEADERS = ["username", "cloud_alias", "departure_date", "notes"]
 
+REMOVE_EMPLOYEE_HEADERS = ["username"]
+
 departing_employee_generate_template = generate_template_cmd_factory(
     group_name="departing_employee",
-    commands_dict={"add": DEPARTING_EMPLOYEE_CSV_HEADERS, "remove": "username"},
+    commands_dict={
+        "add": DEPARTING_EMPLOYEE_CSV_HEADERS,
+        "remove": REMOVE_EMPLOYEE_HEADERS,
+    },
 )
 bulk.add_command(departing_employee_generate_template)
 
 
 @bulk.command(
     name="add",
-    help="Bulk add users to the Departing Employees detection list using a CSV file with "
+    help="Bulk add users to the departing employees detection list using a CSV file with "
     f"format: {','.join(DEPARTING_EMPLOYEE_CSV_HEADERS)}.",
 )
 @read_csv_arg(headers=DEPARTING_EMPLOYEE_CSV_HEADERS)
@@ -125,12 +129,11 @@ def bulk_add(state, csv_rows):
 
 @bulk.command(
     name="remove",
-    help="Bulk remove users from the Departing Employees detection list using a line-separated "
-    "file of usernames.",
+    help=f"Bulk remove users from the departing employees detection list using a CSV file with format {','.join(REMOVE_EMPLOYEE_HEADERS)}.",
 )
-@read_flat_file_arg
+@read_csv_arg(headers=REMOVE_EMPLOYEE_HEADERS)
 @sdk_options()
-def bulk_remove(state, file_rows):
+def bulk_remove(state, csv_rows):
     sdk = state.sdk
 
     def handle_row(username):
@@ -138,7 +141,7 @@ def bulk_remove(state, file_rows):
 
     run_bulk_process(
         handle_row,
-        file_rows,
+        csv_rows,
         progress_label="Removing users from the Departing Employees detection list:",
     )
 

--- a/src/code42cli/cmds/devices.py
+++ b/src/code42cli/cmds/devices.py
@@ -545,7 +545,6 @@ def bulk(state):
 
 _bulk_device_activation_headers = ["guid"]
 
-
 devices_generate_template = generate_template_cmd_factory(
     group_name="devices",
     commands_dict={

--- a/src/code42cli/cmds/high_risk_employee.py
+++ b/src/code42cli/cmds/high_risk_employee.py
@@ -18,7 +18,6 @@ from code42cli.cmds.detectionlists.options import notes_option
 from code42cli.cmds.detectionlists.options import username_arg
 from code42cli.cmds.shared import get_user_id
 from code42cli.file_readers import read_csv_arg
-from code42cli.file_readers import read_flat_file_arg
 from code42cli.options import format_option
 from code42cli.options import sdk_options
 
@@ -110,12 +109,13 @@ def bulk(state):
 
 HIGH_RISK_EMPLOYEE_CSV_HEADERS = ["username", "cloud_alias", "risk_tag", "notes"]
 RISK_TAG_CSV_HEADERS = ["username", "tag"]
+REMOVE_EMPLOYEE_HEADERS = ["username"]
 
 high_risk_employee_generate_template = generate_template_cmd_factory(
     group_name="high_risk_employee",
     commands_dict={
         "add": HIGH_RISK_EMPLOYEE_CSV_HEADERS,
-        "remove": "username",
+        "remove": REMOVE_EMPLOYEE_HEADERS,
         "add-risk-tags": RISK_TAG_CSV_HEADERS,
         "remove-risk-tags": RISK_TAG_CSV_HEADERS,
     },
@@ -145,12 +145,11 @@ def bulk_add(state, csv_rows):
 
 @bulk.command(
     name="remove",
-    help="Bulk remove users from the high risk employees detection list using a line-separated file "
-    "of usernames.",
+    help=f"Bulk remove users from the high risk employees detection list using a CSV file with format {','.join(REMOVE_EMPLOYEE_HEADERS)}.",
 )
-@read_flat_file_arg
+@read_csv_arg(headers=REMOVE_EMPLOYEE_HEADERS)
 @sdk_options()
-def bulk_remove(state, file_rows):
+def bulk_remove(state, csv_rows):
     sdk = state.sdk
 
     def handle_row(username):
@@ -158,7 +157,7 @@ def bulk_remove(state, file_rows):
 
     run_bulk_process(
         handle_row,
-        file_rows,
+        csv_rows,
         progress_label="Removing users from high risk employee detection list:",
     )
 

--- a/src/code42cli/file_readers.py
+++ b/src/code42cli/file_readers.py
@@ -58,21 +58,3 @@ def read_csv(file, headers):
     else:
         missing = [field for field in headers if field not in first_line]
         raise Code42CLIError(f"Missing required columns in csv: {missing}")
-
-
-def read_flat_file(file):
-    """Helper to read rows of a flat file, automatically removing header comment row if
-    it exists, and strips whitespace from each row automatically."""
-    first_row = next(file)
-    if first_row.startswith("#"):
-        return [row.strip() for row in file]
-    else:
-        return [first_row.strip(), *[row.strip() for row in file]]
-
-
-read_flat_file_arg = click.argument(
-    "file_rows",
-    type=AutoDecodedFile("r"),
-    metavar="FILE",
-    callback=lambda ctx, param, arg: read_flat_file(arg),
-)

--- a/src/code42cli/file_readers.py
+++ b/src/code42cli/file_readers.py
@@ -58,3 +58,21 @@ def read_csv(file, headers):
     else:
         missing = [field for field in headers if field not in first_line]
         raise Code42CLIError(f"Missing required columns in csv: {missing}")
+
+
+def read_flat_file(file):
+    """Helper to read rows of a flat file, automatically removing header comment row if
+    it exists, and strips whitespace from each row automatically."""
+    first_row = next(file)
+    if first_row.startswith("#"):
+        return [row.strip() for row in file]
+    else:
+        return [first_row.strip(), *[row.strip() for row in file]]
+
+
+read_flat_file_arg = click.argument(
+    "file_rows",
+    type=AutoDecodedFile("r"),
+    metavar="FILE",
+    callback=lambda ctx, param, arg: read_flat_file(arg),
+)

--- a/src/code42cli/file_readers.py
+++ b/src/code42cli/file_readers.py
@@ -28,6 +28,12 @@ def read_csv(file, headers):
     else error is raised.
     """
     lines = file.readlines()
+
+    # check if header is commented for flat-file backwards compatability
+    if lines[0].startswith("#"):
+        # strip comment character
+        lines[0] = (lines[0].split("#"))[1].strip()
+
     first_line = lines[0].strip().split(",")
 
     # handle when first row has all of our expected headers
@@ -52,21 +58,3 @@ def read_csv(file, headers):
     else:
         missing = [field for field in headers if field not in first_line]
         raise Code42CLIError(f"Missing required columns in csv: {missing}")
-
-
-def read_flat_file(file):
-    """Helper to read rows of a flat file, automatically removing header comment row if
-    it exists, and strips whitespace from each row automatically."""
-    first_row = next(file)
-    if first_row.startswith("#"):
-        return [row.strip() for row in file]
-    else:
-        return [first_row.strip(), *[row.strip() for row in file]]
-
-
-read_flat_file_arg = click.argument(
-    "file_rows",
-    type=AutoDecodedFile("r"),
-    metavar="FILE",
-    callback=lambda ctx, param, arg: read_flat_file(arg),
-)

--- a/src/code42cli/file_readers.py
+++ b/src/code42cli/file_readers.py
@@ -31,8 +31,8 @@ def read_csv(file, headers):
 
     # check if header is commented for flat-file backwards compatability
     if lines[0].startswith("#"):
-        # strip comment character
-        lines[0] = (lines[0].split("#"))[1].strip()
+        # strip comment line
+        lines.pop(0)
 
     first_line = lines[0].strip().split(",")
 

--- a/tests/cmds/test_departing_employee.py
+++ b/tests/cmds/test_departing_employee.py
@@ -277,13 +277,76 @@ def test_remove_bulk_users_uses_expected_arguments(runner, mocker, cli_state_wit
     bulk_processor = mocker.patch("code42cli.cmds.departing_employee.run_bulk_process")
     with runner.isolated_filesystem():
         with open("test_remove.csv", "w") as csv:
+            csv.writelines(["username\n", "test_user1\n", "test_user2\n"])
+        runner.invoke(
+            cli,
+            ["departing-employee", "bulk", "remove", "test_remove.csv"],
+            obj=cli_state_with_user,
+        )
+    assert bulk_processor.call_args[0][1] == [
+        {"username": "test_user1"},
+        {"username": "test_user2"},
+    ]
+
+
+def test_remove_bulk_users_uses_expected_arguments_when_no_header(
+    runner, mocker, cli_state_with_user
+):
+    bulk_processor = mocker.patch("code42cli.cmds.departing_employee.run_bulk_process")
+    with runner.isolated_filesystem():
+        with open("test_remove.csv", "w") as csv:
+            csv.writelines(["test_user1\n", "test_user2\n"])
+        runner.invoke(
+            cli,
+            ["departing-employee", "bulk", "remove", "test_remove.csv"],
+            obj=cli_state_with_user,
+        )
+    assert bulk_processor.call_args[0][1] == [
+        {"username": "test_user1"},
+        {"username": "test_user2"},
+    ]
+
+
+def test_remove_bulk_users_uses_expected_arguments_when_extra_columns(
+    runner, mocker, cli_state_with_user
+):
+    bulk_processor = mocker.patch("code42cli.cmds.departing_employee.run_bulk_process")
+    with runner.isolated_filesystem():
+        with open("test_remove.csv", "w") as csv:
+            csv.writelines(
+                [
+                    "username,test_column\n",
+                    "test_user1,test_value1\n",
+                    "test_user2,test_value2\n",
+                ]
+            )
+        runner.invoke(
+            cli,
+            ["departing-employee", "bulk", "remove", "test_remove.csv"],
+            obj=cli_state_with_user,
+        )
+    assert bulk_processor.call_args[0][1] == [
+        {"username": "test_user1"},
+        {"username": "test_user2"},
+    ]
+
+
+def test_remove_bulk_users_uses_expected_arguments_when_header_commented_out(
+    runner, mocker, cli_state_with_user
+):
+    bulk_processor = mocker.patch("code42cli.cmds.departing_employee.run_bulk_process")
+    with runner.isolated_filesystem():
+        with open("test_remove.csv", "w") as csv:
             csv.writelines(["# username\n", "test_user1\n", "test_user2\n"])
         runner.invoke(
             cli,
             ["departing-employee", "bulk", "remove", "test_remove.csv"],
             obj=cli_state_with_user,
         )
-    assert bulk_processor.call_args[0][1] == ["test_user1", "test_user2"]
+    assert bulk_processor.call_args[0][1] == [
+        {"username": "test_user1"},
+        {"username": "test_user2"},
+    ]
 
 
 def test_add_departing_employee_when_invalid_date_validation_raises_error(
@@ -350,7 +413,7 @@ def test_remove_departing_employee_when_user_not_on_list_prints_expected_error(
         (f"{DEPARTING_EMPLOYEE_COMMAND} add", "Missing argument 'USERNAME'."),
         (f"{DEPARTING_EMPLOYEE_COMMAND} remove", "Missing argument 'USERNAME'.",),
         (f"{DEPARTING_EMPLOYEE_COMMAND} bulk add", "Missing argument 'CSV_FILE'.",),
-        (f"{DEPARTING_EMPLOYEE_COMMAND} bulk remove", "Missing argument 'FILE'.",),
+        (f"{DEPARTING_EMPLOYEE_COMMAND} bulk remove", "Missing argument 'CSV_FILE'.",),
     ],
 )
 def test_departing_employee_command_when_missing_required_parameters_returns_error(

--- a/tests/cmds/test_departing_employee.py
+++ b/tests/cmds/test_departing_employee.py
@@ -331,16 +331,16 @@ def test_remove_bulk_users_uses_expected_arguments_when_extra_columns(
     ]
 
 
-def test_remove_bulk_users_uses_expected_arguments_when_header_commented_out(
+def test_remove_bulk_users_uses_expected_arguments_when_flat_file(
     runner, mocker, cli_state_with_user
 ):
     bulk_processor = mocker.patch("code42cli.cmds.departing_employee.run_bulk_process")
     with runner.isolated_filesystem():
-        with open("test_remove.csv", "w") as csv:
+        with open("test_remove.txt", "w") as csv:
             csv.writelines(["# username\n", "test_user1\n", "test_user2\n"])
         runner.invoke(
             cli,
-            ["departing-employee", "bulk", "remove", "test_remove.csv"],
+            ["departing-employee", "bulk", "remove", "test_remove.txt"],
             obj=cli_state_with_user,
         )
     assert bulk_processor.call_args[0][1] == [

--- a/tests/cmds/test_devices.py
+++ b/tests/cmds/test_devices.py
@@ -886,6 +886,28 @@ def test_bulk_deactivate_uses_expected_arguments(runner, mocker, cli_state):
     ]
 
 
+def test_bulk_deactivate_uses_expected_arguments_when_no_header(
+    runner, mocker, cli_state
+):
+    bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
+    with runner.isolated_filesystem():
+        with open("test_bulk_deactivate.csv", "w") as csv:
+            csv.writelines(["test_guid1\n"])
+        runner.invoke(
+            cli,
+            ["devices", "bulk", "deactivate", "test_bulk_deactivate.csv"],
+            obj=cli_state,
+        )
+    assert bulk_processor.call_args[0][1] == [
+        {
+            "guid": "test_guid1",
+            "deactivated": "False",
+            "change_device_name": False,
+            "purge_date": None,
+        }
+    ]
+
+
 def test_bulk_deactivate_ignores_blank_lines(runner, mocker, cli_state):
     bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
     with runner.isolated_filesystem():
@@ -943,6 +965,23 @@ def test_bulk_reactivate_uses_expected_arguments(runner, mocker, cli_state):
             obj=cli_state,
         )
     assert bulk_processor.call_args[0][1] == [{"guid": "test", "reactivated": "False"}]
+
+
+def test_bulk_reactivate_uses_expected_arguments_when_no_header(
+    runner, mocker, cli_state
+):
+    bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
+    with runner.isolated_filesystem():
+        with open("test_bulk_reactivate.csv", "w") as csv:
+            csv.writelines(["test_guid1\n"])
+        runner.invoke(
+            cli,
+            ["devices", "bulk", "reactivate", "test_bulk_reactivate.csv"],
+            obj=cli_state,
+        )
+    assert bulk_processor.call_args[0][1] == [
+        {"guid": "test_guid1", "reactivated": "False"},
+    ]
 
 
 def test_bulk_reactivate_ignores_blank_lines(runner, mocker, cli_state):

--- a/tests/cmds/test_high_risk_employee.py
+++ b/tests/cmds/test_high_risk_employee.py
@@ -289,6 +289,48 @@ def test_bulk_remove_employees_uses_expected_arguments(runner, cli_state, mocker
     bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
     with runner.isolated_filesystem():
         with open("test_remove.csv", "w") as csv:
+            csv.writelines(["username\n", "test@example.com\n", "test2@example.com"])
+        runner.invoke(
+            cli,
+            ["high-risk-employee", "bulk", "remove", "test_remove.csv"],
+            obj=cli_state,
+        )
+        assert bulk_processor.call_args[0][1] == [
+            {"username": "test@example.com"},
+            {"username": "test2@example.com"},
+        ]
+
+
+def test_bulk_remove_employees_uses_expected_arguments_when_extra_columns(
+    runner, cli_state, mocker
+):
+    bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
+    with runner.isolated_filesystem():
+        with open("test_remove.csv", "w") as csv:
+            csv.writelines(
+                [
+                    "username,test_column\n",
+                    "test@example.com,test_value1\n",
+                    "test2@example.com,test_value2\n",
+                ]
+            )
+        runner.invoke(
+            cli,
+            ["high-risk-employee", "bulk", "remove", "test_remove.csv"],
+            obj=cli_state,
+        )
+        assert bulk_processor.call_args[0][1] == [
+            {"username": "test@example.com"},
+            {"username": "test2@example.com"},
+        ]
+
+
+def test_bulk_remove_employees_uses_expected_arguments_when_header_commented_out(
+    runner, cli_state, mocker
+):
+    bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
+    with runner.isolated_filesystem():
+        with open("test_remove.csv", "w") as csv:
             csv.writelines(["# username\n", "test@example.com\n", "test2@example.com"])
         runner.invoke(
             cli,
@@ -296,8 +338,26 @@ def test_bulk_remove_employees_uses_expected_arguments(runner, cli_state, mocker
             obj=cli_state,
         )
         assert bulk_processor.call_args[0][1] == [
-            "test@example.com",
-            "test2@example.com",
+            {"username": "test@example.com"},
+            {"username": "test2@example.com"},
+        ]
+
+
+def test_bulk_remove_employees_uses_expected_arguments_when_no_header(
+    runner, cli_state, mocker
+):
+    bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
+    with runner.isolated_filesystem():
+        with open("test_remove.csv", "w") as csv:
+            csv.writelines(["test@example.com\n", "test2@example.com"])
+        runner.invoke(
+            cli,
+            ["high-risk-employee", "bulk", "remove", "test_remove.csv"],
+            obj=cli_state,
+        )
+        assert bulk_processor.call_args[0][1] == [
+            {"username": "test@example.com"},
+            {"username": "test2@example.com"},
         ]
 
 
@@ -364,7 +424,7 @@ def test_remove_high_risk_employee_when_user_not_on_list_prints_expected_error(
         (f"{HR_EMPLOYEE_COMMAND} add", "Missing argument 'USERNAME'."),
         (f"{HR_EMPLOYEE_COMMAND} remove", "Missing argument 'USERNAME'."),
         (f"{HR_EMPLOYEE_COMMAND} bulk add", "Missing argument 'CSV_FILE'."),
-        (f"{HR_EMPLOYEE_COMMAND} bulk remove", "Missing argument 'FILE'."),
+        (f"{HR_EMPLOYEE_COMMAND} bulk remove", "Missing argument 'CSV_FILE'."),
         (f"{HR_EMPLOYEE_COMMAND} bulk add-risk-tags", "Missing argument 'CSV_FILE'."),
         (
             f"{HR_EMPLOYEE_COMMAND} bulk remove-risk-tags",

--- a/tests/cmds/test_high_risk_employee.py
+++ b/tests/cmds/test_high_risk_employee.py
@@ -325,16 +325,16 @@ def test_bulk_remove_employees_uses_expected_arguments_when_extra_columns(
         ]
 
 
-def test_bulk_remove_employees_uses_expected_arguments_when_header_commented_out(
+def test_bulk_remove_employees_uses_expected_arguments_when_flat_file(
     runner, cli_state, mocker
 ):
     bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
     with runner.isolated_filesystem():
-        with open("test_remove.csv", "w") as csv:
+        with open("test_remove.txt", "w") as csv:
             csv.writelines(["# username\n", "test@example.com\n", "test2@example.com"])
         runner.invoke(
             cli,
-            ["high-risk-employee", "bulk", "remove", "test_remove.csv"],
+            ["high-risk-employee", "bulk", "remove", "test_remove.txt"],
             obj=cli_state,
         )
         assert bulk_processor.call_args[0][1] == [

--- a/tests/cmds/test_trustedactivities.py
+++ b/tests/cmds/test_trustedactivities.py
@@ -365,13 +365,13 @@ def test_bulk_update_trusted_activities_uses_expected_arguments(
     ]
 
 
-def test_bulk_remove_trusted_activities_uses_expected_arguments(
+def test_bulk_remove_trusted_activities_uses_expected_arguments_when_no_header(
     runner, mocker, cli_state_with_user
 ):
     bulk_processor = mocker.patch("code42cli.cmds.trustedactivities.run_bulk_process")
     with runner.isolated_filesystem():
         with open("test_remove.csv", "w") as csv:
-            csv.writelines(["resource_id\n", "1\n", "2\n"])
+            csv.writelines(["1\n", "2\n"])
         command = ["trusted-activities", "bulk", "remove", "test_remove.csv"]
         runner.invoke(
             cli, command, obj=cli_state_with_user,

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -128,25 +128,12 @@ class TestBulkProcessor:
         processor.run()
         assert processed_rows == [1]
 
-    def test_run_when_reader_returns_strs_processes_strs(self):
-        processed_rows = []
-
-        def func_for_bulk(test):
-            processed_rows.append(test)
-
-        rows = ["row1", "row2", "row3"]
-        processor = BulkProcessor(func_for_bulk, rows)
-        processor.run()
-        assert "row1" in processed_rows
-        assert "row2" in processed_rows
-        assert "row3" in processed_rows
-
     def test_run_when_error_occurs_raises_expected_logged_cli_error(self):
         def func_for_bulk(test):
             if test == "row2":
                 raise Exception()
 
-        rows = ["row1", "row2", "row3"]
+        rows = [{"test": "row1"}, {"test": "row2"}, {"test": "row3"}]
         with pytest.raises(errors.LoggedCLIError) as err:
             processor = BulkProcessor(func_for_bulk, rows)
             processor.run()
@@ -157,7 +144,7 @@ class TestBulkProcessor:
         def func_for_bulk(test):
             pass
 
-        rows = ["row1", "row2", "row3"]
+        rows = [{"test": "row1"}, {"test": "row2"}, {"test": "row3"}]
         processor = BulkProcessor(func_for_bulk, rows)
 
         processor.run()
@@ -170,7 +157,7 @@ class TestBulkProcessor:
         def func_for_bulk(test):
             processed_rows.append(test)
 
-        rows = ["row1", "row2", "\n"]
+        rows = [{"test": "row1"}, {"test": "row2"}, {"test": "\n"}]
         processor = BulkProcessor(func_for_bulk, rows)
         processor.run()
 
@@ -196,7 +183,7 @@ class TestBulkProcessor:
         def func_for_bulk(test):
             return test
 
-        rows = ["row1", "row2", "row3"]
+        rows = [{"test": "row1"}, {"test": "row2"}, {"test": "row3"}]
         processor = BulkProcessor(func_for_bulk, rows)
         processor.run()
         assert "row1" in processor._stats.results


### PR DESCRIPTION
- Switched over the `code42 departing-employee bulk remove` and `code42 high-risk-employee bulk remove` commands to use the CSV input rather than the flat file because we wanted the header the input file to be optional.  Previously they took flat files as input. 

The CSV file reader already has optional headers if there's an exact number of columns matching the argument and allows for more columns than necessary if headers are provided.

- Added unit tests to check the optional header functionality.
- Included a short user guide about bulk commands in general and how their headers work.