### PR TITLE
implement user alias management

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,4 +57,4 @@ jobs:
       - name: Start up the mock servers
         run: cd code42-mock-servers; docker-compose up -d --build
       - name: Run the integration tests
-        run: cd code42cli; tox -e integration
+        run: sleep 15; cd code42cli; tox -e integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+## Unreleased
+
+### Added
+- `users add-alias`, `users remove-alias`, `users bulk add-alias`, and `users bulk remove-alias` for managing cloud aliases for users.
+
 ## 1.12.1 - 2022-01-21
 
 ### Fixed

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "keyrings.alt==3.2.0",
         "ipython==7.16.3",
         "pandas>=1.1.3",
-        "py42>=1.19.3",
+        "py42>=1.21.1",
     ],
     extras_require={
         "dev": [

--- a/src/code42cli/click_ext/groups.py
+++ b/src/code42cli/click_ext/groups.py
@@ -7,6 +7,8 @@ import click
 from py42.exceptions import Py42ActiveLegalHoldError
 from py42.exceptions import Py42CaseAlreadyHasEventError
 from py42.exceptions import Py42CaseNameExistsError
+from py42.exceptions import Py42CloudAliasCharacterLimitExceededError
+from py42.exceptions import Py42CloudAliasLimitExceededError
 from py42.exceptions import Py42DescriptionLimitExceededError
 from py42.exceptions import Py42ForbiddenError
 from py42.exceptions import Py42HTTPError
@@ -86,6 +88,8 @@ class ExceptionHandlingGroup(click.Group):
             Py42TrustedActivityConflictError,
             Py42TrustedActivityInvalidCharacterError,
             Py42TrustedActivityIdNotFound,
+            Py42CloudAliasLimitExceededError,
+            Py42CloudAliasCharacterLimitExceededError,
         ) as err:
             msg = err.args[0]
             self.logger.log_error(msg)

--- a/src/code42cli/cmds/users.py
+++ b/src/code42cli/cmds/users.py
@@ -4,7 +4,6 @@ import click
 from pandas import DataFrame
 from pandas import json_normalize
 from py42.exceptions import Py42BadRequestError
-from py42.exceptions import Py42CloudAliasLimitExceededError
 from py42.exceptions import Py42NotFoundError
 
 from code42cli.bulk import generate_template_cmd_factory
@@ -246,6 +245,19 @@ def add_alias(state, username, alias):
 def remove_alias(state, username, alias):
     """Remove a cloud alias for a given user."""
     _remove_cloud_alias(state.sdk, username, alias)
+
+
+@users.command()
+@click.argument("username")
+@sdk_options()
+def list_aliases(state, username):
+    """List the cloud aliases for a given user."""
+    user = _get_user(state.sdk, username)
+    aliases = user["cloudUsernames"]
+    if aliases:
+        click.echo(aliases)
+    else:
+        click.echo(f"No cloud aliases for user '{username}' found.")
 
 
 @users.group(cls=OrderedGroup)
@@ -772,27 +784,19 @@ def _reactivate_user(sdk, username):
     sdk.users.reactivate(user_id)
 
 
-def _get_user_id(sdk, username):
+def _get_user(sdk, username):
+    # use when retrieving the user information from the detectionlists module
     try:
-        return sdk.detectionlists.get_user(username).data["userId"]
+        return sdk.detectionlists.get_user(username).data
     except Py42BadRequestError:
-        raise Code42CLIError(
-            f"Unable to find user {username}. Either it does not exist, or you do not have permission to view it."
-        )
+        raise UserDoesNotExistError(username)
 
 
 def _add_cloud_alias(sdk, username, alias):
-    user_id = _get_user_id(sdk, username)
-    if len(str(alias)) > 50:
-        raise Code42CLIError(
-            f"Unable to add alias {alias} because it is greater than 50 characters."
-        )
-    try:
-        sdk.detectionlists.add_user_cloud_alias(user_id, alias)
-    except Py42CloudAliasLimitExceededError:
-        raise Code42CLIError(f"User {username} cannot have more than two aliases.")
+    user = _get_user(sdk, username)
+    sdk.detectionlists.add_user_cloud_alias(user["userId"], alias)
 
 
 def _remove_cloud_alias(sdk, username, alias):
-    user_id = _get_user_id(sdk, username)
-    sdk.detectionlists.remove_user_cloud_alias(user_id, alias)
+    user = _get_user(sdk, username)
+    sdk.detectionlists.remove_user_cloud_alias(user["userId"], alias)

--- a/src/code42cli/cmds/users.py
+++ b/src/code42cli/cmds/users.py
@@ -783,10 +783,12 @@ def _get_user_id(sdk, username):
 
 def _add_cloud_alias(sdk, username, alias):
     user_id = _get_user_id(sdk, username)
+    if(len(str(alias)) > 50):
+        raise Code42CLIError(f"Unable to add alias {alias} because it is greater than 50 characters.")
     try:
         sdk.detectionlists.add_user_cloud_alias(user_id, alias)
     except Py42CloudAliasLimitExceededError:
-        raise Code42CLIError(f"Alias {alias} exceeds maximum length.")
+        raise Code42CLIError(f"User {username} cannot have more than two aliases.")
 
 
 def _remove_cloud_alias(sdk, username, alias):

--- a/src/code42cli/cmds/users.py
+++ b/src/code42cli/cmds/users.py
@@ -783,8 +783,10 @@ def _get_user_id(sdk, username):
 
 def _add_cloud_alias(sdk, username, alias):
     user_id = _get_user_id(sdk, username)
-    if(len(str(alias)) > 50):
-        raise Code42CLIError(f"Unable to add alias {alias} because it is greater than 50 characters.")
+    if len(str(alias)) > 50:
+        raise Code42CLIError(
+            f"Unable to add alias {alias} because it is greater than 50 characters."
+        )
     try:
         sdk.detectionlists.add_user_cloud_alias(user_id, alias)
     except Py42CloudAliasLimitExceededError:

--- a/tests/cmds/test_users.py
+++ b/tests/cmds/test_users.py
@@ -1576,8 +1576,21 @@ def test_add_alias_raises_error_when_alias_is_too_long(
         "users",
         "add-alias",
         "fake@notreal.com",
-        "alias-is-too-long-its-very-long-for-real@example.com",
+        "alias-is-too-long-its-very-long-for-real-more-than-50-characters@example.com",
     ]
     result = runner.invoke(cli, command, obj=cli_state)
     assert result.exit_code == 1
-    assert "exceeds maximum length" in result.output
+    assert "it is greater than 50 characters" in result.output
+
+def test_add_alias_raises_error_when_user_has_two_aliases(
+    runner, cli_state, add_alias_failure
+):
+    command = [
+        "users",
+        "add-alias",
+        "fake@notreal.com",
+        "second_alias",
+    ]
+    result = runner.invoke(cli, command, obj=cli_state)
+    assert result.exit_code == 1
+    assert "cannot have more than two" in result.output

--- a/tests/cmds/test_users.py
+++ b/tests/cmds/test_users.py
@@ -1434,6 +1434,17 @@ def test_list_aliases_calls_get_user_with_expected_parameters(runner, cli_state)
     cli_state.sdk.detectionlists.get_user.assert_called_once_with("alias@example")
 
 
+def test_list_aliases_prints_no_aliases_found_when_empty_list(runner, cli_state, mocker):
+    cli_state.sdk.detectionlists.get_user.return_value = create_mock_response(mocker, data={
+        "cloudUsernames": []
+    })
+    username = "alias@example"
+    command = ["users", "list-aliases", username]
+    result = runner.invoke(cli, command, obj=cli_state)
+    assert result.exit_code == 0
+    assert f"No cloud aliases for user '{username}' found" in result.output
+
+
 def test_list_aliases_prints_expected_data(runner, cli_state, get_user_uid_success):
     result = runner.invoke(
         cli, ["users", "list-aliases", "alias@example.com"], obj=cli_state

--- a/tests/cmds/test_users.py
+++ b/tests/cmds/test_users.py
@@ -40,6 +40,25 @@ TEST_USERS_RESPONSE = {
         }
     ]
 }
+TEST_USER_RESPONSE = {
+    "tenantId": "SampleTenant1",
+    "userId": 12345,
+    "userName": "Sample.User1@samplecase.com",
+    "displayName": "Sample User1",
+    "notes": "This is an example of notes about Sample User1.",
+    "cloudUsernames": ["Sample.User1@samplecase.com", "Sample.User1@gmail.com"],
+    "managerUid": 12345,
+    "managerUsername": "manager.user1@samplecase.com",
+    "managerDisplayName": "Manager Name",
+    "title": "Software Engineer",
+    "division": "Engineering",
+    "department": "Research and Development",
+    "employmentType": "Full-time",
+    "city": "Anytown",
+    "state": "MN",
+    "country": "US",
+    "riskFactors": ["FLIGHT_RISK", "HIGH_IMPACT_EMPLOYEE"],
+}
 TEST_MATTER_RESPONSE = {
     "legalHolds": [
         {"legalHoldUid": "123456789", "name": "Legal Hold #1", "active": True},
@@ -78,7 +97,9 @@ TEST_EMPTY_CUSTODIANS_RESPONSE = {"legalHoldMemberships": []}
 TEST_EMPTY_MATTERS_RESPONSE = {"legalHolds": []}
 TEST_EMPTY_USERS_RESPONSE = {"users": []}
 TEST_USERNAME = TEST_USERS_RESPONSE["users"][0]["username"]
+TEST_ALIAS = TEST_USER_RESPONSE["cloudUsernames"][0]
 TEST_USER_ID = TEST_USERS_RESPONSE["users"][0]["userId"]
+TEST_USER_UID = TEST_USER_RESPONSE["userId"]
 TEST_ROLE_NAME = TEST_ROLE_RETURN_DATA["data"][0]["roleName"]
 TEST_GET_ORG_RESPONSE = {
     "orgId": 9087,
@@ -129,6 +150,11 @@ def get_users_response(mocker):
 
 
 @pytest.fixture
+def get_user_response(mocker):
+    return create_mock_response(mocker, data=TEST_USER_RESPONSE)
+
+
+@pytest.fixture
 def change_org_response(mocker):
     return create_mock_response(mocker)
 
@@ -171,6 +197,12 @@ def get_all_users_success(mocker, cli_state):
 def get_user_id_success(cli_state, get_users_response):
     """Get by username returns a list of users"""
     cli_state.sdk.users.get_by_username.return_value = get_users_response
+
+
+@pytest.fixture
+def get_user_uid_success(cli_state, get_user_response):
+    """detectionlists.get_user returns a single user"""
+    cli_state.sdk.detectionlists.get_user.return_value = get_user_response
 
 
 @pytest.fixture
@@ -246,6 +278,20 @@ def reactivate_user_success(mocker, cli_state):
 @pytest.fixture
 def change_org_success(cli_state, change_org_response):
     cli_state.sdk.users.change_org_assignment.return_value = change_org_response
+
+
+@pytest.fixture
+def add_alias_success(mocker, cli_state):
+    cli_state.sdk.detectionlists.add_user_cloud_alias.return_value = create_mock_response(
+        mocker
+    )
+
+
+@pytest.fixture
+def remove_alias_success(mocker, cli_state):
+    cli_state.sdk.detectionlists.remove_user_cloud_alias.return_value = create_mock_response(
+        mocker
+    )
 
 
 @pytest.fixture
@@ -1356,3 +1402,137 @@ def test_orgs_show_when_invalid_org_uid_raises_error(runner, cli_state, custom_e
     result = runner.invoke(cli, ["users", "orgs", "show", TEST_ORG_UID], obj=cli_state)
     assert result.exit_code == 1
     assert f"Invalid org UID {TEST_ORG_UID}." in result.output
+
+
+def test_add_cloud_alias_calls_add_cloud_alias_with_correct_parameters(
+    runner, cli_state, get_user_uid_success, add_alias_success
+):
+    command = ["users", "add-alias", "test@example.com", "alias@example.com"]
+    runner.invoke(cli, command, obj=cli_state)
+    cli_state.sdk.detectionlists.add_user_cloud_alias.assert_called_once_with(
+        TEST_USER_UID, "alias@example.com"
+    )
+
+
+def test_remove_cloud_alias_calls_remove_cloud_alias_with_correct_parameters(
+    runner, cli_state, get_user_uid_success, remove_alias_success
+):
+    command = ["users", "remove-alias", "test@example.com", "alias@example.com"]
+    runner.invoke(cli, command, obj=cli_state)
+    cli_state.sdk.detectionlists.remove_user_cloud_alias.assert_called_once_with(
+        TEST_USER_UID, "alias@example.com"
+    )
+
+
+def test_bulk_add_alias_uses_expected_arguments(runner, mocker, cli_state):
+    bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
+    with runner.isolated_filesystem():
+        with open("test_add_alias.csv", "w") as csv:
+            csv.writelines(["username,alias\n", f"{TEST_USERNAME},{TEST_ALIAS}\n"])
+        runner.invoke(
+            cli, ["users", "bulk", "add-alias", "test_add_alias.csv"], obj=cli_state,
+        )
+    assert bulk_processor.call_args[0][1] == [
+        {"username": TEST_USERNAME, "alias": TEST_ALIAS, "alias added": "False"}
+    ]
+    bulk_processor.assert_called_once()
+
+
+def test_bulk_add_alias_ignores_blank_lines(runner, mocker, cli_state):
+    bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
+    with runner.isolated_filesystem():
+        with open("test_add_alias.csv", "w") as csv:
+            csv.writelines(
+                ["username,alias\n\n\n", f"{TEST_USERNAME},{TEST_ALIAS}\n\n\n"]
+            )
+        runner.invoke(
+            cli, ["users", "bulk", "add-alias", "test_add_alias.csv"], obj=cli_state,
+        )
+    assert bulk_processor.call_args[0][1] == [
+        {"username": TEST_USERNAME, "alias": TEST_ALIAS, "alias added": "False"}
+    ]
+    bulk_processor.assert_called_once()
+
+
+def test_bulk_add_alias_uses_handler_that_when_encounters_error_increments_total_errors(
+    runner, mocker, cli_state, worker_stats, get_user_response
+):
+    lines = ["username,alias\n", f"{TEST_USERNAME},{TEST_ALIAS}\n"]
+
+    def _get(username, *args, **kwargs):
+        if username == "test@example.com":
+            raise Exception("TEST")
+        return get_user_response
+
+    cli_state.sdk.detectionlists.get_user.side_effect = _get
+    bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
+    with runner.isolated_filesystem():
+        with open("test_add_alias.csv", "w") as csv:
+            csv.writelines(lines)
+        runner.invoke(
+            cli, ["users", "bulk", "add-alias", "test_add_alias.csv"], obj=cli_state,
+        )
+    handler = bulk_processor.call_args[0][0]
+    handler(username="test@example.com", alias=TEST_ALIAS)
+    handler(username="not.test@example.com", alias=TEST_ALIAS)
+    assert worker_stats.increment_total_errors.call_count == 1
+
+
+def test_bulk_remove_alias_uses_expected_arguments(runner, mocker, cli_state):
+    bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
+    with runner.isolated_filesystem():
+        with open("test_remove_alias.csv", "w") as csv:
+            csv.writelines(["username,alias\n", f"{TEST_USERNAME},{TEST_ALIAS}\n"])
+        runner.invoke(
+            cli,
+            ["users", "bulk", "remove-alias", "test_remove_alias.csv"],
+            obj=cli_state,
+        )
+    assert bulk_processor.call_args[0][1] == [
+        {"username": TEST_USERNAME, "alias": TEST_ALIAS, "alias removed": "False"}
+    ]
+    bulk_processor.assert_called_once()
+
+
+def test_bulk_remove_alias_ignores_blank_lines(runner, mocker, cli_state):
+    bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
+    with runner.isolated_filesystem():
+        with open("test_remove_alias.csv", "w") as csv:
+            csv.writelines(
+                ["username,alias\n\n\n", f"{TEST_USERNAME},{TEST_ALIAS}\n\n\n"]
+            )
+        runner.invoke(
+            cli,
+            ["users", "bulk", "remove-alias", "test_remove_alias.csv"],
+            obj=cli_state,
+        )
+    assert bulk_processor.call_args[0][1] == [
+        {"username": TEST_USERNAME, "alias": TEST_ALIAS, "alias removed": "False"}
+    ]
+    bulk_processor.assert_called_once()
+
+
+def test_bulk_remove_alias_uses_handler_that_when_encounters_error_increments_total_errors(
+    runner, mocker, cli_state, worker_stats, get_user_response
+):
+    lines = ["username,alias\n", f"{TEST_USERNAME},{TEST_ALIAS}\n"]
+
+    def _get(username, *args, **kwargs):
+        if username == "test@example.com":
+            raise Exception("TEST")
+        return get_user_response
+
+    cli_state.sdk.detectionlists.get_user.side_effect = _get
+    bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
+    with runner.isolated_filesystem():
+        with open("test_remove_alias.csv", "w") as csv:
+            csv.writelines(lines)
+        runner.invoke(
+            cli,
+            ["users", "bulk", "remove-alias", "test_remove_alias.csv"],
+            obj=cli_state,
+        )
+    handler = bulk_processor.call_args[0][0]
+    handler(username="test@example.com", alias=TEST_ALIAS)
+    handler(username="not.test@example.com", alias=TEST_ALIAS)
+    assert worker_stats.increment_total_errors.call_count == 1

--- a/tests/cmds/test_users.py
+++ b/tests/cmds/test_users.py
@@ -1434,10 +1434,12 @@ def test_list_aliases_calls_get_user_with_expected_parameters(runner, cli_state)
     cli_state.sdk.detectionlists.get_user.assert_called_once_with("alias@example")
 
 
-def test_list_aliases_prints_no_aliases_found_when_empty_list(runner, cli_state, mocker):
-    cli_state.sdk.detectionlists.get_user.return_value = create_mock_response(mocker, data={
-        "cloudUsernames": []
-    })
+def test_list_aliases_prints_no_aliases_found_when_empty_list(
+    runner, cli_state, mocker
+):
+    cli_state.sdk.detectionlists.get_user.return_value = create_mock_response(
+        mocker, data={"cloudUsernames": []}
+    )
     username = "alias@example"
     command = ["users", "list-aliases", username]
     result = runner.invoke(cli, command, obj=cli_state)

--- a/tests/cmds/test_users.py
+++ b/tests/cmds/test_users.py
@@ -1582,6 +1582,7 @@ def test_add_alias_raises_error_when_alias_is_too_long(
     assert result.exit_code == 1
     assert "it is greater than 50 characters" in result.output
 
+
 def test_add_alias_raises_error_when_user_has_two_aliases(
     runner, cli_state, add_alias_failure
 ):


### PR DESCRIPTION
Adds several methods to enable management of user [cloud aliases](https://developer.code42.com/api/#operation/UserControllerV2_AddCloudUsernames):

```
users add-alias <username> <alias>
users remove-alias <username> <alias>
users list-aliases
users bulk add-alias <csv>
users bulk remove-alias <csv>
```

Also updates tests and changelog appropriately.