### PR TITLE
move IPython import into function

### DIFF
--- a/src/code42cli/cmds/shell.py
+++ b/src/code42cli/cmds/shell.py
@@ -1,5 +1,4 @@
 import click
-import IPython
 
 from code42cli import BANNER
 from code42cli.options import sdk_options
@@ -9,4 +8,6 @@ from code42cli.options import sdk_options
 @sdk_options()
 def shell(state):
     """Open an IPython shell with py42 initialized as `sdk`."""
+    import IPython
+
     IPython.embed(colors="Neutral", banner1=BANNER, user_ns={"sdk": state.sdk})


### PR DESCRIPTION
A customer ran into an environment issue where IPython was failing to load a module, so it was causing every CLI command to fail since we import it in every invocation. 

If we move the import into the `shell` function it will only attempt to import when `code42 shell` is actually called, which will allow other commands to work despite the environmental quirk breaking IPython.