### PR TITLE
Feature/watchlists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+
+## Unreleased
+
+### Added
+
+- `watchlists` command group for interacting with watchlists.
+  - `watchlists add` for adding users to a watchlist
+  - `watchlists remove` for removing users from a watchlist
+  - `watchlists list` for listing existing watchlists
+  - `watchlists list-members` for listing users who are members of a given watchlist
+  - `watchlist bulk add|remove` for adding/removing multiple users via CSV file
+
+- `users update-start-date` command to add/modify the "start date" property of a User's risk profile.
+- `users update-departure-date` command to add/modify the "end date" property of a User's risk profile.
+- `users update-risk-profile-notes` command to add/modify the "notes" property of a User's risk profile.
+
+### Deprecated
+
+- `departing-employee` and `high-risk-employee` command groups. These actions have been replaced by the `watchlists` command group.
+
 ## 1.13.0 - 2022-04-04
 
 ### Added

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -10,25 +10,27 @@
     Alerts <commands/alerts.rst>
     Audit Logs <commands/auditlogs.rst>
     Cases <commands/cases.rst>
-    Departing Employee <commands/departingemployee.rst>
     Devices <commands/devices.rst>
-    High Risk Employee <commands/highriskemployee.rst>
     Legal Hold <commands/legalhold.rst>
     Profile <commands/profile.rst>
     Security Data <commands/securitydata.rst>
     Trusted Activities <commands/trustedactivities.rst>
     Users <commands/users.rst>
+    Watchlists <commands/watchlists.rst>
+    (DEPRECATED) Departing Employee <commands/departingemployee.rst>
+    (DEPRECATED) High Risk Employee <commands/highriskemployee.rst>
 ```
 
 * [Alert Rules](commands/alertrules.rst)
 * [Alerts](commands/alerts.rst)
 * [Audit Logs](commands/auditlogs.rst)
 * [Cases](commands/cases.rst)
-* [Departing Employee](commands/departingemployee.rst)
 * [Devices](commands/devices.rst)
-* [High Risk Employee](commands/highriskemployee.rst)
 * [Legal Hold](commands/legalhold.rst)
 * [Profile](commands/profile.rst)
 * [Security Data](commands/securitydata.rst)
 * [Trusted Activities](commands/trustedactivities.rst)
 * [Users](commands/users.rst)
+* [Watchlists](commands/watchlists.rst)
+* [(DEPRECATED) Departing Employee](commands/departingemployee.rst)
+* [(DEPRECATED) High Risk Employee](commands/highriskemployee.rst)

--- a/docs/commands/watchlists.rst
+++ b/docs/commands/watchlists.rst
@@ -1,0 +1,3 @@
+.. click:: code42cli.cmds.watchlists:watchlists
+  :prog: watchlists
+  :nested: full

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -9,7 +9,6 @@
     Get started with the Code42 command-line interface (CLI) <userguides/gettingstarted.md>
     Configure a profile <userguides/profile.md>
     Ingest data into a SIEM <userguides/siemexample.md>
-    Manage detection list users <userguides/detectionlists.md>
     Manage legal hold users <userguides/legalhold.md>
     Clean up your environment by deactivating devices <userguides/deactivatedevices.md>
     Write custom extension scripts using the Code42 CLI and Py42 <userguides/extensions.md>
@@ -18,12 +17,13 @@
     Configure alert rules <userguides/alertrules.md>
     Add and manage cases <userguides/cases.md>
     Perform bulk actions <userguides/bulkcommands.md>
+    Manage watchlist members <userguides/watchlists.md>
+    (DEPRECATED) Manage detection list users <userguides/detectionlists.md>
 ```
 
 * [Get started with the Code42 command-line interface (CLI)](userguides/gettingstarted.md)
 * [Configure a profile](userguides/profile.md)
 * [Ingest data into a SIEM](userguides/siemexample.md)
-* [Manage detection list users](userguides/detectionlists.md)
 * [Manage legal hold users](userguides/legalhold.md)
 * [Clean up your environment by deactivating devices](userguides/deactivatedevices.md)
 * [Write custom extension scripts using the Code42 CLI and Py42](userguides/extensions.md)
@@ -32,3 +32,5 @@
 * [Configure alert rules](userguides/alertrules.md)
 * [Add and manage cases](userguides/cases.md)
 * [Perform bulk actions](userguides/bulkcommands.md)
+* [Manage watchlist members](userguides/watchlists.md)
+* [(DEPRECATED) Manage detection list users](userguides/detectionlists.md)

--- a/docs/userguides/detectionlists.md
+++ b/docs/userguides/detectionlists.md
@@ -1,4 +1,14 @@
-# Manage Detection List Users
+# (DEPRECATED) Manage Detection List Users
+
+```{eval-rst}
+.. note::
+
+    Detection Lists have been replaced by Watchlists.
+
+    Functionality for adding users to Departing Employee and High Risk Employee categories has been migrated to the :code:`code42 watchlists` command group.
+
+    Functionality for listing and managing User Risk Profiles (e.g. adding Cloud Aliases, Notes, and Start/End dates to a user profile) has been migrated to the :code:`code42 users` command group.
+```
 
 Use the `departing-employee` commands to add employees to or remove employees from the Departing Employees list. Use the `high-risk-employee` commands to add employees to or remove employees from the High Risk list, or update risk tags for those users.
 

--- a/docs/userguides/users.md
+++ b/docs/userguides/users.md
@@ -34,6 +34,34 @@ code42 users add-role --username "sean.cassidy@example.com" --role-name "Desktop
 
 Similarly, use the `remove-role` command to remove a role from a user.
 
+## Manage User Risk Profile info
+
+To set a start or end/departure date on a User's profile (useful for users on the "New Hire" and "Departing" Watchlists):
+
+```bash
+code42 users update-start-date 2020-03-10 user@example.com
+
+code42 users update-departure-date 2022-06-20 user@example.com
+```
+
+To clear the value of start_date/end_date on a User's profile, use the `--clear` option to the above commands:
+
+```bash
+code42 users update-departure-date --clear user@example.com
+```
+
+To update a User's Risk Profile notes field:
+
+```bash
+code42 users update-risk-profile-notes user@example.com "New note text"
+```
+
+By default, the note text will overwrite notes are already on the profile. To keep existing note data, use the `--append` option:
+
+```bash
+code42 users update-risk-profile-notes user@example.com "Additional note text" --append
+```
+
 ## Deactivate a User
 
 You can deactivate a user with the following command:
@@ -73,17 +101,18 @@ Alternatively, to move multiple users between organizations, fill out the `move`
 code42 users bulk move bulk-command.csv
 ```
 
-## Get CSV Template
+## Get CSV Template for bulk commands
 
-The following command generates a CSV template to either update users' data, or move users between organizations.  The csv file is saved to the current working directory.
+The following command generates a CSV template for each of the available bulk user commands.  The CSV file is saved to the current working directory.
 ```bash
-code42 trusted-activities bulk generate-template [update|move]
+code42 users bulk generate-template [update|move|add-alias|remove-alias|update-risk-profile]
 ```
 
 Once generated, fill out and use each of the CSV templates with their respective bulk commands.
 ```bash
-code42 trusted-activities bulk [update|move|reactivate|deactivate] bulk-command.csv
+code42 users bulk [update|move|deactivate|reactivate|add-alias|remove-alias|update-risk-profile] bulk-command.csv
 ```
+
 A CSV with a `username` column and a single username on each new line is used for the `reactivate` and `deactivate` bulk commands.  These commands are not available as options for `generate-template`.
 
 Learn more about [Managing Users](../commands/users.md).

--- a/docs/userguides/watchlists.md
+++ b/docs/userguides/watchlists.md
@@ -22,6 +22,12 @@ or by their ID (get watchlist IDs from `code42 watchlist list` output):
 code42 watchlists list-members --watchlist-id 6e6c5acc-2568-4e5f-8324-e73f2811fa7c
 ```
 
+A "member" of a watchlist is any user that the watchlist alerting rules apply to. Users can be members of a watchlist
+either by being explicitly added (via console or `code42 watchlists add [USER_ID|USERNAME]`), but they can also be
+implicitly included based on some user profile property (like working in a specific department). To get a list of only
+those "members" who have been explicitly added (and thus can be removed via the `code42 watchlists remove [USER_ID|USERNAME]`
+command), add the `--only-included-users` option to `list-members`.
+
 ## Add or remove a single user from watchlist membership
 
 A user can be added to a watchlist using either the watchlist ID or Type, just like listing watchlists, and the user

--- a/docs/userguides/watchlists.md
+++ b/docs/userguides/watchlists.md
@@ -13,13 +13,13 @@ code42 watchlists list
 You can list watchlists either by their Type:
 
 ```bash
-code42 watchlists list-users --watchlist-type DEPARTING_EMPLOYEE
+code42 watchlists list-members --watchlist-type DEPARTING_EMPLOYEE
 ```
 
 or by their ID (get watchlist IDs from `code42 watchlist list` output):
 
 ```bash
-code42 watchlists list-users --watchlist-id 6e6c5acc-2568-4e5f-8324-e73f2811fa7c
+code42 watchlists list-members --watchlist-id 6e6c5acc-2568-4e5f-8324-e73f2811fa7c
 ```
 
 ## Add or remove a single user from watchlist membership

--- a/docs/userguides/watchlists.md
+++ b/docs/userguides/watchlists.md
@@ -1,0 +1,58 @@
+# Manage watchlist members
+
+## List created watchlists
+
+To list all the watchlists active in your Code42 environment, run:
+
+```bash
+code42 watchlists list
+```
+
+##  List all members of a watchlist
+
+You can list watchlists either by their Type:
+
+```bash
+code42 watchlists list-users --watchlist-type DEPARTING_EMPLOYEE
+```
+
+or by their ID (get watchlist IDs from `code42 watchlist list` output):
+
+```bash
+code42 watchlists list-users --watchlist-id 6e6c5acc-2568-4e5f-8324-e73f2811fa7c
+```
+
+## Add or remove a single user from watchlist membership
+
+A user can be added to a watchlist using either the watchlist ID or Type, just like listing watchlists, and the user
+can be identified either by their user_id or their username:
+
+```bash
+code42 watchlist add --watchlist-type NEW_EMPLOYEE 9871230
+```
+
+```bash
+code42 watchlist add --watchlist-id 6e6c5acc-2568-4e5f-8324-e73f2811fa7c user@example.com
+```
+
+## Bulk adding/removing users from watchlists
+
+The bulk watchlist commands read input from a CSV file.
+
+Like the individual commands, they can take either a user_id/username or watchlist_id/watchlist_type to identify who
+to add to which watchlist. Because of this flexibility, the CSV does require a header row identifying each column.
+
+You can generate a template CSV with the correct header values using the command:
+
+```bash
+code42 watchlists bulk generate-template [add|remove]
+```
+
+If both username and user_id are provided in the CSV row, the user_id value will take precedence. If watchlist_type and watchlist_id columns
+are both provided, the watchlist_id will take precedence.
+
+## Add Watchlist-related metadata to User's Profile
+
+Some Watchlists store related metadata to the watchlist member on the User Risk Profile. For example, when adding a user
+to the Departing Watchlist in the Code42 admin console, you can specify a "departure date" for the user. These values
+can be set/updated from the CLI under the [Users command group](./users.md#manage-user-risk-profile-info)

--- a/src/code42cli/click_ext/groups.py
+++ b/src/code42cli/click_ext/groups.py
@@ -17,6 +17,7 @@ from py42.exceptions import Py42InvalidPasswordError
 from py42.exceptions import Py42InvalidRuleOperationError
 from py42.exceptions import Py42InvalidUsernameError
 from py42.exceptions import Py42LegalHoldNotFoundOrPermissionDeniedError
+from py42.exceptions import Py42NotFoundError
 from py42.exceptions import Py42OrgNotFoundError
 from py42.exceptions import Py42TrustedActivityConflictError
 from py42.exceptions import Py42TrustedActivityIdNotFound
@@ -25,6 +26,8 @@ from py42.exceptions import Py42UpdateClosedCaseError
 from py42.exceptions import Py42UserAlreadyAddedError
 from py42.exceptions import Py42UsernameMustBeEmailError
 from py42.exceptions import Py42UserNotOnListError
+from py42.exceptions import Py42UserRiskProfileNotFound
+from py42.exceptions import Py42WatchlistNotFound
 
 from code42cli.errors import Code42CLIError
 from code42cli.errors import LoggedCLIError
@@ -90,6 +93,9 @@ class ExceptionHandlingGroup(click.Group):
             Py42TrustedActivityIdNotFound,
             Py42CloudAliasLimitExceededError,
             Py42CloudAliasCharacterLimitExceededError,
+            Py42UserRiskProfileNotFound,
+            Py42WatchlistNotFound,
+            Py42NotFoundError,
         ) as err:
             msg = err.args[0]
             self.logger.log_error(msg)

--- a/src/code42cli/cmds/departing_employee.py
+++ b/src/code42cli/cmds/departing_employee.py
@@ -37,23 +37,17 @@ filter_option = click.option(
 )
 
 
-@click.group(cls=OrderedGroup)
+@click.group(cls=OrderedGroup, help=f"{DEPRECATION_TEXT}\n\nAdd and remove employees from the Departing Employees detection list.")
 @sdk_options(hidden=True)
 def departing_employee(state):
-    f"""{DEPRECATION_TEXT}
-
-    Add and remove employees from the Departing Employees detection list."""
     pass
 
 
-@departing_employee.command("list")
+@departing_employee.command("list", help=f"{DEPRECATION_TEXT}\n\nLists the users on the Departing Employees list.")
 @sdk_options()
 @format_option
 @filter_option
 def _list(state, format, filter):
-    f"""{DEPRECATION_TEXT}
-
-    Lists the users on the Departing Employees list."""
     deprecation_warning(DEPRECATION_TEXT)
     employee_generator = _get_departing_employees(state.sdk, filter)
     list_employees(
@@ -63,7 +57,7 @@ def _list(state, format, filter):
     )
 
 
-@departing_employee.command()
+@departing_employee.command(help=f"{DEPRECATION_TEXT}\n\nAdd a user to the Departing Employees detection list.")
 @username_arg
 @click.option(
     "--departure-date",
@@ -74,30 +68,22 @@ def _list(state, format, filter):
 @notes_option
 @sdk_options()
 def add(state, username, cloud_alias, departure_date, notes):
-    f"""{DEPRECATION_TEXT}
 
-    Add a user to the Departing Employees detection list."""
     deprecation_warning(DEPRECATION_TEXT)
     _add_departing_employee(state.sdk, username, cloud_alias, departure_date, notes)
 
 
-@departing_employee.command()
+@departing_employee.command(help=f"{DEPRECATION_TEXT}\n\nRemove a user from the Departing Employees detection list.")
 @username_arg
 @sdk_options()
 def remove(state, username):
-    f"""{DEPRECATION_TEXT}
-
-    Remove a user from the Departing Employees detection list."""
     deprecation_warning(DEPRECATION_TEXT)
     _remove_departing_employee(state.sdk, username)
 
 
-@departing_employee.group(cls=OrderedGroup)
+@departing_employee.group(cls=OrderedGroup, help=f"{DEPRECATION_TEXT}\n\nTools for executing bulk departing employee actions.")
 @sdk_options(hidden=True)
 def bulk(state):
-    f"""{DEPRECATION_TEXT}
-
-    Tools for executing bulk departing employee actions."""
     pass
 
 

--- a/src/code42cli/cmds/departing_employee.py
+++ b/src/code42cli/cmds/departing_employee.py
@@ -17,12 +17,14 @@ from code42cli.errors import Code42CLIError
 from code42cli.file_readers import read_csv_arg
 from code42cli.options import format_option
 from code42cli.options import sdk_options
+from code42cli.util import deprecation_warning
 
 
 def _get_filter_choices():
     filters = DepartingEmployeeFilters.choices()
     return get_choices(filters)
 
+DEPRECATION_TEXT = "(DEPRECATED): Use `code42 watchlists` commands instead."
 
 DATE_FORMAT = "%Y-%m-%d"
 filter_option = click.option(
@@ -37,7 +39,9 @@ filter_option = click.option(
 @click.group(cls=OrderedGroup)
 @sdk_options(hidden=True)
 def departing_employee(state):
-    """Add and remove employees from the Departing Employees detection list."""
+    f"""{DEPRECATION_TEXT}
+    
+    Add and remove employees from the Departing Employees detection list."""
     pass
 
 
@@ -46,7 +50,10 @@ def departing_employee(state):
 @format_option
 @filter_option
 def _list(state, format, filter):
-    """Lists the users on the Departing Employees list."""
+    f"""{DEPRECATION_TEXT}
+    
+    Lists the users on the Departing Employees list."""
+    deprecation_warning(DEPRECATION_TEXT)
     employee_generator = _get_departing_employees(state.sdk, filter)
     list_employees(
         employee_generator,
@@ -66,7 +73,10 @@ def _list(state, format, filter):
 @notes_option
 @sdk_options()
 def add(state, username, cloud_alias, departure_date, notes):
-    """Add a user to the Departing Employees detection list."""
+    f"""{DEPRECATION_TEXT}
+    
+    Add a user to the Departing Employees detection list."""
+    deprecation_warning(DEPRECATION_TEXT)
     _add_departing_employee(state.sdk, username, cloud_alias, departure_date, notes)
 
 
@@ -74,14 +84,19 @@ def add(state, username, cloud_alias, departure_date, notes):
 @username_arg
 @sdk_options()
 def remove(state, username):
-    """Remove a user from the Departing Employees detection list."""
+    f"""{DEPRECATION_TEXT}
+    
+    Remove a user from the Departing Employees detection list."""
+    deprecation_warning(DEPRECATION_TEXT)
     _remove_departing_employee(state.sdk, username)
 
 
 @departing_employee.group(cls=OrderedGroup)
 @sdk_options(hidden=True)
 def bulk(state):
-    """Tools for executing bulk departing employee actions."""
+    f"""{DEPRECATION_TEXT}
+    
+    Tools for executing bulk departing employee actions."""
     pass
 
 
@@ -101,12 +116,13 @@ bulk.add_command(departing_employee_generate_template)
 
 @bulk.command(
     name="add",
-    help="Bulk add users to the departing employees detection list using a CSV file with "
-    f"format: {','.join(DEPARTING_EMPLOYEE_CSV_HEADERS)}.",
+    help=f"{DEPRECATION_TEXT}\n\nBulk add users to the departing employees detection list using "
+         f"a CSV file with format: {','.join(DEPARTING_EMPLOYEE_CSV_HEADERS)}.",
 )
 @read_csv_arg(headers=DEPARTING_EMPLOYEE_CSV_HEADERS)
 @sdk_options()
 def bulk_add(state, csv_rows):
+    deprecation_warning(DEPRECATION_TEXT)
     sdk = state.sdk  # Force initialization of py42 to only happen once.
 
     def handle_row(username, cloud_alias, departure_date, notes):
@@ -131,11 +147,13 @@ def bulk_add(state, csv_rows):
 
 @bulk.command(
     name="remove",
-    help=f"Bulk remove users from the departing employees detection list using a CSV file with format {','.join(REMOVE_EMPLOYEE_HEADERS)}.",
+    help=f"{DEPRECATION_TEXT}\n\nBulk remove users from the departing employees detection list "
+         f"using a CSV file with format {','.join(REMOVE_EMPLOYEE_HEADERS)}.",
 )
 @read_csv_arg(headers=REMOVE_EMPLOYEE_HEADERS)
 @sdk_options()
 def bulk_remove(state, csv_rows):
+    deprecation_warning(DEPRECATION_TEXT)
     sdk = state.sdk
 
     def handle_row(username):

--- a/src/code42cli/cmds/departing_employee.py
+++ b/src/code42cli/cmds/departing_employee.py
@@ -24,6 +24,7 @@ def _get_filter_choices():
     filters = DepartingEmployeeFilters.choices()
     return get_choices(filters)
 
+
 DEPRECATION_TEXT = "(DEPRECATED): Use `code42 watchlists` commands instead."
 
 DATE_FORMAT = "%Y-%m-%d"
@@ -40,7 +41,7 @@ filter_option = click.option(
 @sdk_options(hidden=True)
 def departing_employee(state):
     f"""{DEPRECATION_TEXT}
-    
+
     Add and remove employees from the Departing Employees detection list."""
     pass
 
@@ -51,7 +52,7 @@ def departing_employee(state):
 @filter_option
 def _list(state, format, filter):
     f"""{DEPRECATION_TEXT}
-    
+
     Lists the users on the Departing Employees list."""
     deprecation_warning(DEPRECATION_TEXT)
     employee_generator = _get_departing_employees(state.sdk, filter)
@@ -74,7 +75,7 @@ def _list(state, format, filter):
 @sdk_options()
 def add(state, username, cloud_alias, departure_date, notes):
     f"""{DEPRECATION_TEXT}
-    
+
     Add a user to the Departing Employees detection list."""
     deprecation_warning(DEPRECATION_TEXT)
     _add_departing_employee(state.sdk, username, cloud_alias, departure_date, notes)
@@ -85,7 +86,7 @@ def add(state, username, cloud_alias, departure_date, notes):
 @sdk_options()
 def remove(state, username):
     f"""{DEPRECATION_TEXT}
-    
+
     Remove a user from the Departing Employees detection list."""
     deprecation_warning(DEPRECATION_TEXT)
     _remove_departing_employee(state.sdk, username)
@@ -95,7 +96,7 @@ def remove(state, username):
 @sdk_options(hidden=True)
 def bulk(state):
     f"""{DEPRECATION_TEXT}
-    
+
     Tools for executing bulk departing employee actions."""
     pass
 
@@ -117,7 +118,7 @@ bulk.add_command(departing_employee_generate_template)
 @bulk.command(
     name="add",
     help=f"{DEPRECATION_TEXT}\n\nBulk add users to the departing employees detection list using "
-         f"a CSV file with format: {','.join(DEPARTING_EMPLOYEE_CSV_HEADERS)}.",
+    f"a CSV file with format: {','.join(DEPARTING_EMPLOYEE_CSV_HEADERS)}.",
 )
 @read_csv_arg(headers=DEPARTING_EMPLOYEE_CSV_HEADERS)
 @sdk_options()
@@ -148,7 +149,7 @@ def bulk_add(state, csv_rows):
 @bulk.command(
     name="remove",
     help=f"{DEPRECATION_TEXT}\n\nBulk remove users from the departing employees detection list "
-         f"using a CSV file with format {','.join(REMOVE_EMPLOYEE_HEADERS)}.",
+    f"using a CSV file with format {','.join(REMOVE_EMPLOYEE_HEADERS)}.",
 )
 @read_csv_arg(headers=REMOVE_EMPLOYEE_HEADERS)
 @sdk_options()

--- a/src/code42cli/cmds/high_risk_employee.py
+++ b/src/code42cli/cmds/high_risk_employee.py
@@ -48,83 +48,79 @@ risk_tag_option = click.option(
 )
 
 
-@click.group(cls=OrderedGroup)
+@click.group(
+    cls=OrderedGroup,
+    help=f"{DEPRECATION_TEXT}\n\nAdd and remove employees from the High Risk Employees detection list.",
+)
 @sdk_options(hidden=True)
 def high_risk_employee(state):
-    f"""{DEPRECATION_TEXT}
-
-    Add and remove employees from the High Risk Employees detection list."""
     pass
 
 
-@high_risk_employee.command("list")
+@high_risk_employee.command(
+    "list",
+    help=f"{DEPRECATION_TEXT}\n\nLists the employees on the High Risk Employee list.",
+)
 @sdk_options()
 @format_option
 @filter_option
 def _list(state, format, filter):
-    f"""{DEPRECATION_TEXT}
-
-    Lists the employees on the High Risk Employee list."""
     deprecation_warning(DEPRECATION_TEXT)
     employee_generator = _get_high_risk_employees(state.sdk, filter)
     list_employees(employee_generator, format)
 
 
-@high_risk_employee.command()
+@high_risk_employee.command(
+    help=f"{DEPRECATION_TEXT}\n\nAdd a user to the high risk employees detection list."
+)
 @cloud_alias_option
 @notes_option
 @risk_tag_option
 @username_arg
 @sdk_options()
 def add(state, username, cloud_alias, risk_tag, notes):
-    f"""{DEPRECATION_TEXT}
-
-    Add a user to the high risk employees detection list."""
     deprecation_warning(DEPRECATION_TEXT)
     _add_high_risk_employee(state.sdk, username, cloud_alias, risk_tag, notes)
 
 
-@high_risk_employee.command()
+@high_risk_employee.command(
+    help=f"{DEPRECATION_TEXT}\n\nRemove a user from the high risk employees detection list."
+)
 @username_arg
 @sdk_options()
 def remove(state, username):
-    f"""{DEPRECATION_TEXT}
-
-    Remove a user from the high risk employees detection list."""
     deprecation_warning(DEPRECATION_TEXT)
     _remove_high_risk_employee(state.sdk, username)
 
 
-@high_risk_employee.command()
+@high_risk_employee.command(
+    help=f"{DEPRECATION_TEXT}\n\nAssociates risk tags with a user."
+)
 @username_arg
 @risk_tag_option
 @sdk_options()
 def add_risk_tags(state, username, risk_tag):
-    f"""{DEPRECATION_TEXT}
-
-    Associates risk tags with a user."""
     deprecation_warning(DEPRECATION_TEXT)
     _add_risk_tags(state.sdk, username, risk_tag)
 
 
-@high_risk_employee.command()
+@high_risk_employee.command(
+    help=f"{DEPRECATION_TEXT}\n\nDisassociates risk tags from a user."
+)
 @username_arg
 @risk_tag_option
 @sdk_options()
 def remove_risk_tags(state, username, risk_tag):
-    f"""{DEPRECATION_TEXT}
-
-    Disassociates risk tags from a user."""
     deprecation_warning(DEPRECATION_TEXT)
     _remove_risk_tags(state.sdk, username, risk_tag)
 
 
-@high_risk_employee.group(cls=OrderedGroup)
+@high_risk_employee.group(
+    cls=OrderedGroup,
+    help=f"{DEPRECATION_TEXT}\n\nTools for executing high risk employee actions in bulk.",
+)
 @sdk_options(hidden=True)
 def bulk(state):
-    f"""{DEPRECATION_TEXT}
-
-    Tools for executing high risk employee actions in bulk."""
     pass
 
 

--- a/src/code42cli/cmds/high_risk_employee.py
+++ b/src/code42cli/cmds/high_risk_employee.py
@@ -20,7 +20,9 @@ from code42cli.cmds.shared import get_user_id
 from code42cli.file_readers import read_csv_arg
 from code42cli.options import format_option
 from code42cli.options import sdk_options
+from code42cli.util import deprecation_warning
 
+DEPRECATION_TEXT = "(DEPRECATED): Use `code42 watchlists` commands instead."
 
 def _get_filter_choices():
     filters = HighRiskEmployeeFilters.choices()
@@ -48,7 +50,9 @@ risk_tag_option = click.option(
 @click.group(cls=OrderedGroup)
 @sdk_options(hidden=True)
 def high_risk_employee(state):
-    """Add and remove employees from the High Risk Employees detection list."""
+    f"""{DEPRECATION_TEXT}
+    
+    Add and remove employees from the High Risk Employees detection list."""
     pass
 
 
@@ -57,8 +61,10 @@ def high_risk_employee(state):
 @format_option
 @filter_option
 def _list(state, format, filter):
-    """Lists the employees on the High Risk Employee list."""
-
+    f"""{DEPRECATION_TEXT}
+    
+    Lists the employees on the High Risk Employee list."""
+    deprecation_warning(DEPRECATION_TEXT)
     employee_generator = _get_high_risk_employees(state.sdk, filter)
     list_employees(employee_generator, format)
 
@@ -70,7 +76,10 @@ def _list(state, format, filter):
 @username_arg
 @sdk_options()
 def add(state, username, cloud_alias, risk_tag, notes):
-    """Add a user to the high risk employees detection list."""
+    f"""{DEPRECATION_TEXT}
+    
+    Add a user to the high risk employees detection list."""
+    deprecation_warning(DEPRECATION_TEXT)
     _add_high_risk_employee(state.sdk, username, cloud_alias, risk_tag, notes)
 
 
@@ -78,7 +87,10 @@ def add(state, username, cloud_alias, risk_tag, notes):
 @username_arg
 @sdk_options()
 def remove(state, username):
-    """Remove a user from the high risk employees detection list."""
+    f"""{DEPRECATION_TEXT}
+    
+    Remove a user from the high risk employees detection list."""
+    deprecation_warning(DEPRECATION_TEXT)
     _remove_high_risk_employee(state.sdk, username)
 
 
@@ -87,7 +99,10 @@ def remove(state, username):
 @risk_tag_option
 @sdk_options()
 def add_risk_tags(state, username, risk_tag):
-    """Associates risk tags with a user."""
+    f"""{DEPRECATION_TEXT}
+    
+    Associates risk tags with a user."""
+    deprecation_warning(DEPRECATION_TEXT)
     _add_risk_tags(state.sdk, username, risk_tag)
 
 
@@ -96,14 +111,19 @@ def add_risk_tags(state, username, risk_tag):
 @risk_tag_option
 @sdk_options()
 def remove_risk_tags(state, username, risk_tag):
-    """Disassociates risk tags from a user."""
+    f"""{DEPRECATION_TEXT}
+    
+    Disassociates risk tags from a user."""
+    deprecation_warning(DEPRECATION_TEXT)
     _remove_risk_tags(state.sdk, username, risk_tag)
 
 
 @high_risk_employee.group(cls=OrderedGroup)
 @sdk_options(hidden=True)
 def bulk(state):
-    """Tools for executing high risk employee actions in bulk."""
+    f"""{DEPRECATION_TEXT}
+    
+    Tools for executing high risk employee actions in bulk."""
     pass
 
 
@@ -125,12 +145,13 @@ bulk.add_command(high_risk_employee_generate_template)
 
 @bulk.command(
     name="add",
-    help="Bulk add users to the high risk employees detection list using a CSV file with "
-    f"format: {','.join(HIGH_RISK_EMPLOYEE_CSV_HEADERS)}.",
+    help=f"{DEPRECATION_TEXT}\n\nBulk add users to the high risk employees detection list using a "
+         f"CSV file with format: {','.join(HIGH_RISK_EMPLOYEE_CSV_HEADERS)}.",
 )
 @read_csv_arg(headers=HIGH_RISK_EMPLOYEE_CSV_HEADERS)
 @sdk_options()
 def bulk_add(state, csv_rows):
+    deprecation_warning(DEPRECATION_TEXT)
     sdk = state.sdk
 
     def handle_row(username, cloud_alias, risk_tag, notes):
@@ -145,11 +166,13 @@ def bulk_add(state, csv_rows):
 
 @bulk.command(
     name="remove",
-    help=f"Bulk remove users from the high risk employees detection list using a CSV file with format {','.join(REMOVE_EMPLOYEE_HEADERS)}.",
+    help=f"{DEPRECATION_TEXT}\n\nBulk remove users from the high risk employees detection list "
+         f"using a CSV file with format {','.join(REMOVE_EMPLOYEE_HEADERS)}.",
 )
 @read_csv_arg(headers=REMOVE_EMPLOYEE_HEADERS)
 @sdk_options()
 def bulk_remove(state, csv_rows):
+    deprecation_warning(DEPRECATION_TEXT)
     sdk = state.sdk
 
     def handle_row(username):
@@ -164,12 +187,13 @@ def bulk_remove(state, csv_rows):
 
 @bulk.command(
     name="add-risk-tags",
-    help=f"Adds risk tags to users in bulk using a CSV file with format: "
-    f"{','.join(RISK_TAG_CSV_HEADERS)}.",
+    help=f"{DEPRECATION_TEXT}\n\nAdds risk tags to users in bulk using a CSV file with format: "
+         f"{','.join(RISK_TAG_CSV_HEADERS)}.",
 )
 @read_csv_arg(headers=RISK_TAG_CSV_HEADERS)
 @sdk_options()
 def bulk_add_risk_tags(state, csv_rows):
+    deprecation_warning(DEPRECATION_TEXT)
     sdk = state.sdk
 
     def handle_row(username, tag):
@@ -184,12 +208,13 @@ def bulk_add_risk_tags(state, csv_rows):
 
 @bulk.command(
     name="remove-risk-tags",
-    help=f"Removes risk tags from users in bulk using a CSV file with format: "
-    f"{','.join(RISK_TAG_CSV_HEADERS)}.",
+    help=f"{DEPRECATION_TEXT}\n\nRemoves risk tags from users in bulk using a CSV file with "
+         f"format: {','.join(RISK_TAG_CSV_HEADERS)}.",
 )
 @read_csv_arg(headers=RISK_TAG_CSV_HEADERS)
 @sdk_options()
 def bulk_remove_risk_tags(state, csv_rows):
+    deprecation_warning(DEPRECATION_TEXT)
     sdk = state.sdk
 
     def handle_row(username, tag):

--- a/src/code42cli/cmds/high_risk_employee.py
+++ b/src/code42cli/cmds/high_risk_employee.py
@@ -24,6 +24,7 @@ from code42cli.util import deprecation_warning
 
 DEPRECATION_TEXT = "(DEPRECATED): Use `code42 watchlists` commands instead."
 
+
 def _get_filter_choices():
     filters = HighRiskEmployeeFilters.choices()
     return get_choices(filters)
@@ -51,7 +52,7 @@ risk_tag_option = click.option(
 @sdk_options(hidden=True)
 def high_risk_employee(state):
     f"""{DEPRECATION_TEXT}
-    
+
     Add and remove employees from the High Risk Employees detection list."""
     pass
 
@@ -62,7 +63,7 @@ def high_risk_employee(state):
 @filter_option
 def _list(state, format, filter):
     f"""{DEPRECATION_TEXT}
-    
+
     Lists the employees on the High Risk Employee list."""
     deprecation_warning(DEPRECATION_TEXT)
     employee_generator = _get_high_risk_employees(state.sdk, filter)
@@ -77,7 +78,7 @@ def _list(state, format, filter):
 @sdk_options()
 def add(state, username, cloud_alias, risk_tag, notes):
     f"""{DEPRECATION_TEXT}
-    
+
     Add a user to the high risk employees detection list."""
     deprecation_warning(DEPRECATION_TEXT)
     _add_high_risk_employee(state.sdk, username, cloud_alias, risk_tag, notes)
@@ -88,7 +89,7 @@ def add(state, username, cloud_alias, risk_tag, notes):
 @sdk_options()
 def remove(state, username):
     f"""{DEPRECATION_TEXT}
-    
+
     Remove a user from the high risk employees detection list."""
     deprecation_warning(DEPRECATION_TEXT)
     _remove_high_risk_employee(state.sdk, username)
@@ -100,7 +101,7 @@ def remove(state, username):
 @sdk_options()
 def add_risk_tags(state, username, risk_tag):
     f"""{DEPRECATION_TEXT}
-    
+
     Associates risk tags with a user."""
     deprecation_warning(DEPRECATION_TEXT)
     _add_risk_tags(state.sdk, username, risk_tag)
@@ -112,7 +113,7 @@ def add_risk_tags(state, username, risk_tag):
 @sdk_options()
 def remove_risk_tags(state, username, risk_tag):
     f"""{DEPRECATION_TEXT}
-    
+
     Disassociates risk tags from a user."""
     deprecation_warning(DEPRECATION_TEXT)
     _remove_risk_tags(state.sdk, username, risk_tag)
@@ -122,7 +123,7 @@ def remove_risk_tags(state, username, risk_tag):
 @sdk_options(hidden=True)
 def bulk(state):
     f"""{DEPRECATION_TEXT}
-    
+
     Tools for executing high risk employee actions in bulk."""
     pass
 
@@ -146,7 +147,7 @@ bulk.add_command(high_risk_employee_generate_template)
 @bulk.command(
     name="add",
     help=f"{DEPRECATION_TEXT}\n\nBulk add users to the high risk employees detection list using a "
-         f"CSV file with format: {','.join(HIGH_RISK_EMPLOYEE_CSV_HEADERS)}.",
+    f"CSV file with format: {','.join(HIGH_RISK_EMPLOYEE_CSV_HEADERS)}.",
 )
 @read_csv_arg(headers=HIGH_RISK_EMPLOYEE_CSV_HEADERS)
 @sdk_options()
@@ -167,7 +168,7 @@ def bulk_add(state, csv_rows):
 @bulk.command(
     name="remove",
     help=f"{DEPRECATION_TEXT}\n\nBulk remove users from the high risk employees detection list "
-         f"using a CSV file with format {','.join(REMOVE_EMPLOYEE_HEADERS)}.",
+    f"using a CSV file with format {','.join(REMOVE_EMPLOYEE_HEADERS)}.",
 )
 @read_csv_arg(headers=REMOVE_EMPLOYEE_HEADERS)
 @sdk_options()
@@ -188,7 +189,7 @@ def bulk_remove(state, csv_rows):
 @bulk.command(
     name="add-risk-tags",
     help=f"{DEPRECATION_TEXT}\n\nAdds risk tags to users in bulk using a CSV file with format: "
-         f"{','.join(RISK_TAG_CSV_HEADERS)}.",
+    f"{','.join(RISK_TAG_CSV_HEADERS)}.",
 )
 @read_csv_arg(headers=RISK_TAG_CSV_HEADERS)
 @sdk_options()
@@ -209,7 +210,7 @@ def bulk_add_risk_tags(state, csv_rows):
 @bulk.command(
     name="remove-risk-tags",
     help=f"{DEPRECATION_TEXT}\n\nRemoves risk tags from users in bulk using a CSV file with "
-         f"format: {','.join(RISK_TAG_CSV_HEADERS)}.",
+    f"format: {','.join(RISK_TAG_CSV_HEADERS)}.",
 )
 @read_csv_arg(headers=RISK_TAG_CSV_HEADERS)
 @sdk_options()

--- a/src/code42cli/cmds/users.py
+++ b/src/code42cli/cmds/users.py
@@ -904,12 +904,11 @@ def _remove_cloud_alias(sdk, username, alias):
     sdk.userriskprofile.delete_cloud_aliases(user["userId"], alias)
 
 
-def _update_userriskprofile(sdk, append_notes=False, username=None, user_id=None, start_date=None, end_date=None, notes=None):
-    if (username and not user_id) or append_notes:
-        user = _get_user(sdk, username)
-        user_id = user["userId"]
-        if notes != "null":
-            notes = user["notes"] + f"\n\n{notes}"
+def _update_userriskprofile(sdk, append_notes=False, username=None, start_date=None, end_date=None, notes=None):
+    user = _get_user(sdk, username)
+    user_id = user["userId"]
+    if append_notes and notes != "null":
+        notes = user["notes"] + f"\n\n{notes}"
     
     # py42 interprets empty string as "clear this value" for kwarg values. Since empty CSV columns 
     # get parsed as "" we want to have user provide explicit 'null' string to indicate desire to 

--- a/src/code42cli/cmds/users.py
+++ b/src/code42cli/cmds/users.py
@@ -740,7 +740,7 @@ def bulk_update_risk_profile(state, csv_rows, format, append_notes):
     
     def handle_row(**row):
         try:
-            updated_user = _update_userriskprofile(sdk, **row)
+            updated_user = _update_userriskprofile(sdk, append_notes=append_notes, **row)
             row[success_header] = updated_user
         except Exception as err:
             row[success_header] = f"Error: {err}"
@@ -904,9 +904,12 @@ def _remove_cloud_alias(sdk, username, alias):
     sdk.userriskprofile.delete_cloud_aliases(user["userId"], alias)
 
 
-def _update_userriskprofile(sdk, username=None, user_id=None, start_date=None, end_date=None, notes=None):
-    if username:
-        user_id = _get_user(sdk, username)["userId"]
+def _update_userriskprofile(sdk, append_notes=False, username=None, user_id=None, start_date=None, end_date=None, notes=None):
+    if (username and not user_id) or append_notes:
+        user = _get_user(sdk, username)
+        user_id = user["userId"]
+        if notes != "null":
+            notes = user["notes"] + f"\n\n{notes}"
     
     # py42 interprets empty string as "clear this value" for kwarg values. Since empty CSV columns 
     # get parsed as "" we want to have user provide explicit 'null' string to indicate desire to 

--- a/src/code42cli/cmds/users.py
+++ b/src/code42cli/cmds/users.py
@@ -259,8 +259,8 @@ def remove_alias(state, username, alias):
 @click.argument("date", type=click.DateTime(formats=["%Y-%m-%d"]), required=False, metavar="DATE")
 @click.option("--clear", is_flag=True, help="Clears the current `start_date` value.")
 @sdk_options()
-def add_start_date(state, username, date, clear):
-    """Adds a `start_date` to a User's risk profile (useful for users on the New Hire Watchlist). 
+def update_start_date(state, username, date, clear):
+    """Sets the `start_date` on a User's risk profile (useful for users on the New Hire Watchlist). 
     Date format: %Y-%m-%d"""
     if not date and not clear:
         raise Code42CLIError("Must supply DATE argument if --clear is not used.")
@@ -273,8 +273,8 @@ def add_start_date(state, username, date, clear):
 @click.argument("date", type=click.DateTime(formats=["%Y-%m-%d"]), required=False)
 @click.option("--clear", is_flag=True, help="Clears the current `end_date` value.")
 @sdk_options()
-def add_departure_date(state, username, date, clear):
-    """Adds an `end_date` to a User's risk profile (useful for users on the Departing Employee 
+def update_departure_date(state, username, date, clear):
+    """Sets the `end_date` on a User's risk profile (useful for users on the Departing Employee 
     Watchlist). Date format: %Y-%m-%d
     """
     if not date and not clear:
@@ -287,10 +287,10 @@ def add_departure_date(state, username, date, clear):
 @click.argument("username")
 @click.argument("note", required=False)
 @click.option("--clear", is_flag=True, help="Clears the current `notes` value.")
-@click.option("--append", is_flag=True, help="Appends provided string to existing risk profile notes as a new line.")
+@click.option("--append", is_flag=True, help="Appends provided note to existing note text as a new line.")
 @sdk_options()
-def add_risk_profile_note(state, username, note, clear, append):
-    """Adds `notes` to a User's risk profile.
+def update_risk_profile_note(state, username, note, clear, append):
+    """Sets the `notes` value of a User's risk profile.
     
     WARNING: Overwrites any existing note value."""
     if not note and not clear:

--- a/src/code42cli/cmds/users.py
+++ b/src/code42cli/cmds/users.py
@@ -264,6 +264,8 @@ def update_start_date(state, username, date, clear):
     Date format: %Y-%m-%d"""
     if not date and not clear:
         raise Code42CLIError("Must supply DATE argument if --clear is not used.")
+    if clear:
+        date = ""
     user_id = _get_user(state.sdk, username)["userId"]
     state.sdk.userriskprofile.update(user_id, start_date=date)
     
@@ -279,6 +281,8 @@ def update_departure_date(state, username, date, clear):
     """
     if not date and not clear:
         raise Code42CLIError("Must supply DATE argument if --clear is not used.")
+    if clear:
+        date = ""
     user_id = _get_user(state.sdk, username)["userId"]
     state.sdk.userriskprofile.update(user_id, end_date=date)
 
@@ -289,7 +293,7 @@ def update_departure_date(state, username, date, clear):
 @click.option("--clear", is_flag=True, help="Clears the current `notes` value.")
 @click.option("--append", is_flag=True, help="Appends provided note to existing note text as a new line.")
 @sdk_options()
-def update_risk_profile_note(state, username, note, clear, append):
+def update_risk_profile_notes(state, username, note, clear, append):
     """Sets the `notes` value of a User's risk profile.
     
     WARNING: Overwrites any existing note value."""
@@ -299,6 +303,8 @@ def update_risk_profile_note(state, username, note, clear, append):
     user_id = user["userId"]
     if append and user["notes"]:
         note = user["notes"] + f"\n\n{note}"
+    if clear:
+        note = ""
     state.sdk.userriskprofile.update(user_id, notes=note)
     
 

--- a/src/code42cli/cmds/users.py
+++ b/src/code42cli/cmds/users.py
@@ -3,7 +3,7 @@ import functools
 import click
 from pandas import DataFrame
 from pandas import json_normalize
-from py42.exceptions import Py42BadRequestError
+from py42.exceptions import Py42BadRequestError, Py42UserRiskProfileNotFound
 from py42.exceptions import Py42NotFoundError
 
 from code42cli.bulk import generate_template_cmd_factory
@@ -221,6 +221,8 @@ _bulk_user_roles_headers = ["username", "role_name"]
 
 _bulk_user_alias_headers = ["username", "alias"]
 
+_bulk_user_risk_profile_headers = ["username", "start_date", "end_date", "notes"]
+
 
 @users.command(name="move")
 @username_option("The username of the user to move.", required=True)
@@ -254,11 +256,61 @@ def remove_alias(state, username, alias):
 
 @users.command()
 @click.argument("username")
+@click.argument("date", type=click.DateTime(formats=["%Y-%m-%d"]), required=False, metavar="DATE")
+@click.option("--clear", is_flag=True, help="Clears the current `start_date` value.")
+@sdk_options()
+def add_start_date(state, username, date, clear):
+    """Adds a `start_date` to a User's risk profile (useful for users on the New Hire Watchlist). 
+    Date format: %Y-%m-%d"""
+    if not date and not clear:
+        raise Code42CLIError("Must supply DATE argument if --clear is not used.")
+    user_id = _get_user(state.sdk, username)["userId"]
+    state.sdk.userriskprofile.update(user_id, start_date=date)
+    
+
+@users.command()
+@click.argument("username")
+@click.argument("date", type=click.DateTime(formats=["%Y-%m-%d"]), required=False)
+@click.option("--clear", is_flag=True, help="Clears the current `end_date` value.")
+@sdk_options()
+def add_departure_date(state, username, date, clear):
+    """Adds an `end_date` to a User's risk profile (useful for users on the Departing Employee 
+    Watchlist). Date format: %Y-%m-%d
+    """
+    if not date and not clear:
+        raise Code42CLIError("Must supply DATE argument if --clear is not used.")
+    user_id = _get_user(state.sdk, username)["userId"]
+    state.sdk.userriskprofile.update(user_id, end_date=date)
+
+
+@users.command()
+@click.argument("username")
+@click.argument("note", required=False)
+@click.option("--clear", is_flag=True, help="Clears the current `notes` value.")
+@click.option("--append", is_flag=True, help="Appends provided string to existing risk profile notes as a new line.")
+@sdk_options()
+def add_risk_profile_note(state, username, note, clear, append):
+    """Adds `notes` to a User's risk profile.
+    
+    WARNING: Overwrites any existing note value."""
+    if not note and not clear:
+        raise Code42CLIError("Must supply NOTE argument if --clear is not used.")
+    user = _get_user(state.sdk, username)
+    user_id = user["userId"]
+    if append and user["notes"]:
+        note = user["notes"] + f"\n\n{note}"
+    state.sdk.userriskprofile.update(user_id, notes=note)
+    
+
+@users.command()
+@click.argument("username")
 @sdk_options()
 def list_aliases(state, username):
-    """List the cloud aliases for a given user.  Each user has a default cloud alias of their Code42 username with up to one additional alias."""
+    """List the cloud aliases for a given user. 
+    
+    Each user has a default cloud alias of their Code42 username with up to one additional alias."""
     user = _get_user(state.sdk, username)
-    aliases = user["cloudUsernames"]
+    aliases = user["cloudAliases"]
     if aliases:
         click.echo(aliases)
     else:
@@ -336,6 +388,7 @@ users_generate_template = generate_template_cmd_factory(
         "move": _bulk_user_move_headers,
         "add-alias": _bulk_user_alias_headers,
         "remove-alias": _bulk_user_alias_headers,
+        "update-risk-profile": _bulk_user_risk_profile_headers,
     },
     help_message="Generate the CSV template needed for bulk user commands.",
 )
@@ -663,6 +716,41 @@ def bulk_remove_alias(state, csv_rows, format):
     formatter.echo_formatted_list(result_rows)
 
 
+@bulk.command(
+    name="update-risk-profile",
+    help=f"Update user risk profile data from the provided CSV in format: {','.join(_bulk_user_risk_profile_headers)}"
+         "\n\nTo clear a value, set column item to the string: 'null'.")
+@format_option
+@read_csv_arg(headers=_bulk_user_risk_profile_headers)
+@click.option("--append-notes", is_flag=True, help="Append provided note value to already existing note on a new line. Defaults to overwrite.")
+@sdk_options()
+def bulk_update_risk_profile(state, csv_rows, format, append_notes):
+    """Bulk update User Risk Profile data."""
+    sdk = state.sdk
+
+    success_header = "updated_user"
+    formatter = OutputFormatter(format, {key: key for key in [*csv_rows[0].keys(), success_header]})
+    stats = create_worker_stats(len(csv_rows))
+    
+    def handle_row(**row):
+        try:
+            updated_user = _update_userriskprofile(sdk, **row)
+            row[success_header] = updated_user
+        except Exception as err:
+            row[success_header] = f"Error: {err}"
+            stats.increment_total_errors()
+        return row
+            
+    result_rows = run_bulk_process(
+        handle_row,
+        csv_rows,
+        progress_label="Updating user risk profile data:",
+        stats=stats,
+        raise_global_error=False,
+    )
+    formatter.echo_formatted_list(result_rows)
+
+
 def _add_user_role(sdk, username, role_name):
     user_id = _get_legacy_user_id(sdk, username)
     _get_role_id(sdk, role_name)  # function provides role name validation
@@ -793,18 +881,34 @@ def _reactivate_user(sdk, username):
 
 
 def _get_user(sdk, username):
-    # use when retrieving the user information from the detectionlists module
+    # use when retrieving the user risk profile information 
     try:
-        return sdk.detectionlists.get_user(username).data
-    except Py42BadRequestError:
+        return sdk.userriskprofile.get_by_username(username)
+    except Py42UserRiskProfileNotFound:
         raise UserDoesNotExistError(username)
 
 
 def _add_cloud_alias(sdk, username, alias):
     user = _get_user(sdk, username)
-    sdk.detectionlists.add_user_cloud_alias(user["userId"], alias)
+    sdk.userriskprofile.add_cloud_aliases(user["userId"], alias)
 
 
 def _remove_cloud_alias(sdk, username, alias):
     user = _get_user(sdk, username)
-    sdk.detectionlists.remove_user_cloud_alias(user["userId"], alias)
+    sdk.userriskprofile.delete_cloud_aliases(user["userId"], alias)
+
+
+def _update_userriskprofile(sdk, username=None, user_id=None, start_date=None, end_date=None, notes=None):
+    if username:
+        user_id = _get_user(sdk, username)["userId"]
+    
+    # py42 interprets empty string as "clear this value" for kwarg values. Since empty CSV columns 
+    # get parsed as "" we want to have user provide explicit 'null' string to indicate desire to 
+    # clear instead of just not update value
+    start_date = None if start_date == "" else ("" if start_date == "null" else start_date)
+    end_date = None if end_date == "" else ("" if end_date == "null" else end_date)
+    notes = None if notes == "" else ("" if notes == "null" else notes)
+
+    updated_user = sdk.userriskprofile.update(user_id, start_date=start_date, end_date=end_date, notes=notes)
+    return {k: v for k, v in updated_user.data.items() if k in ["username", "userId", "startDate", "endDate", "notes"]}
+    

--- a/src/code42cli/cmds/users.py
+++ b/src/code42cli/cmds/users.py
@@ -3,7 +3,6 @@ import functools
 import click
 from pandas import DataFrame
 from pandas import json_normalize
-from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42NotFoundError
 from py42.exceptions import Py42UserRiskProfileNotFound
 
@@ -223,6 +222,8 @@ _bulk_user_roles_headers = ["username", "role_name"]
 _bulk_user_alias_headers = ["username", "alias"]
 
 _bulk_user_risk_profile_headers = ["username", "start_date", "end_date", "notes"]
+
+_bulk_user_activation_headers = ["username"]
 
 
 @users.command(name="move")
@@ -484,9 +485,6 @@ def bulk_move(state, csv_rows, format):
         raise_global_error=False,
     )
     formatter.echo_formatted_list(result_rows)
-
-
-_bulk_user_activation_headers = ["username"]
 
 
 @bulk.command(

--- a/src/code42cli/cmds/watchlists.py
+++ b/src/code42cli/cmds/watchlists.py
@@ -190,7 +190,7 @@ def bulk_add(state, csv_rows):
         else:
             raise Code42CLIError(
                 f"Row for username={username}, user_id={user_id} "
-                "missing value for `watchlistId` and `watchlistType` columns."
+                "missing value for `watchlist_id` or `watchlist_type` columns."
             )
 
     run_bulk_process(
@@ -215,32 +215,32 @@ def bulk_add(state, csv_rows):
 @sdk_options()
 def bulk_remove(state, csv_rows):
     headers = csv_rows.fieldnames
-    if "userId" not in headers and "username" not in headers:
+    if "user_id" not in headers and "username" not in headers:
         raise Code42CLIError(
-            "CSV requires either a `username` or `userId` "
+            "CSV requires either a `username` or `user_id` "
             "column to identify which users to remove from watchlist."
         )
-    if "watchlistId" not in headers and "watchlistType" not in headers:
+    if "watchlist_id" not in headers and "watchlist_type" not in headers:
         raise Code42CLIError(
-            "CSV requires either a `watchlistId` or `watchlistType` "
+            "CSV requires either a `watchlist_id` or `watchlist_type` "
             "column to identify which watchlist to remove user from."
         )
 
     sdk = state.sdk
 
-    def handle_row(watchlistId=None, watchlistType=None, userId=None, username=None):
-        if username and not userId:
-            userId = sdk.userriskprofile.get_by_username(username)["userId"]
-        if watchlistId:
-            sdk.watchlists.remove_included_users_by_watchlist_id(userId, watchlistId)
-        elif watchlistType:
+    def handle_row(watchlist_id=None, watchlist_type=None, user_id=None, username=None):
+        if username and not user_id:
+            user_id = sdk.userriskprofile.get_by_username(username)["userId"]
+        if watchlist_id:
+            sdk.watchlists.remove_included_users_by_watchlist_id(user_id, watchlist_id)
+        elif watchlist_type:
             sdk.watchlists.remove_included_users_by_watchlist_type(
-                userId, watchlistType
+                user_id, watchlist_type
             )
         else:
             raise Code42CLIError(
-                f"Row for username={username}, userId={userId} "
-                "missing value for `watchlistId` and `watchlistType` columns."
+                f"Row for username={username}, user_id={user_id} "
+                "missing value for `watchlist_id` or `watchlist_type` columns."
             )
 
     run_bulk_process(

--- a/src/code42cli/cmds/watchlists.py
+++ b/src/code42cli/cmds/watchlists.py
@@ -15,6 +15,7 @@ from code42cli.file_readers import read_csv_arg
 from code42cli.options import format_option
 from code42cli.options import sdk_options
 from code42cli.output_formats import DataFrameOutputFormatter
+from code42cli.bulk import generate_template_cmd_factory
 
 
 @click.group(cls=OrderedGroup)
@@ -132,6 +133,16 @@ def remove(state, watchlist_id, watchlist_type, user):
 def bulk(state):
     """Tools for executing bulk watchlist actions."""
     pass
+
+
+watchlists_generate_template = generate_template_cmd_factory(
+    group_name="watchlists",
+    commands_dict={
+        "add": ["watchlist_id", "watchlist_type", "user_id", "username"],
+        "remove": ["watchlist_id", "watchlist_type", "user_id", "username"],
+    },
+)
+bulk.add_command(watchlists_generate_template)
 
 
 @bulk.command(

--- a/src/code42cli/cmds/watchlists.py
+++ b/src/code42cli/cmds/watchlists.py
@@ -48,16 +48,16 @@ def _list(state, format):
 )
 @format_option
 @sdk_options()
-def list_users(state, watchlist_type, watchlist_id, format):
-    """List all users on a given watchlist."""
+def list_members(state, watchlist_type, watchlist_id, format):
+    """List all members on a given watchlist."""
     if not watchlist_id and not watchlist_type:
         raise click.ClickException("--watchlist-id OR --watchlist-type is required.")
     if watchlist_type:
         watchlist_id = state.sdk.watchlists._watchlists_service.watchlist_type_id_map[
             watchlist_type
         ]
-    pages = state.sdk.watchlists.get_all_included_users(watchlist_id)
-    dfs = (DataFrame(page["includedUsers"]) for page in pages)
+    pages = state.sdk.watchlists.get_all_watchlist_members(watchlist_id)
+    dfs = (DataFrame(page["watchlistMembers"]) for page in pages)
     formatter = DataFrameOutputFormatter(format)
     formatter.echo_formatted_dataframes(dfs)
 

--- a/src/code42cli/cmds/watchlists.py
+++ b/src/code42cli/cmds/watchlists.py
@@ -1,0 +1,213 @@
+import csv
+import click
+from pandas import DataFrame
+
+from code42cli.click_ext.groups import OrderedGroup
+from code42cli.click_ext.options import incompatible_with
+from code42cli.click_ext.types import AutoDecodedFile
+from code42cli.bulk import run_bulk_process
+from code42cli.errors import Code42CLIError
+from code42cli.file_readers import read_csv_arg
+from code42cli.options import format_option
+from code42cli.options import sdk_options
+from code42cli.output_formats import DataFrameOutputFormatter
+
+from py42.constants import WatchlistType
+
+
+@click.group(cls=OrderedGroup)
+@sdk_options(hidden=True)
+def watchlists(state):
+    """Manage watchlist user memberships."""
+    pass
+
+
+@watchlists.command("list")
+@format_option
+@sdk_options()
+def _list(state, format):
+    """List all watchlists."""
+    pages = state.sdk.watchlists.get_all()
+    dfs = (DataFrame(page["watchlists"]) for page in pages)
+    formatter = DataFrameOutputFormatter(format)
+    formatter.echo_formatted_dataframes(dfs)
+
+
+@watchlists.command()
+@click.option(
+    "--watchlist-id",
+    help="ID of the watchlist.",
+)
+@click.option(
+    "--watchlist-type",
+    type=click.Choice(WatchlistType.choices()),
+    help="Type of watchlist to remove user from. For CUSTOM watchlists, --watchlist-id is required.",
+    cls=incompatible_with("watchlist_id"),
+)
+@format_option
+@sdk_options()
+def list_users(state, watchlist_type, watchlist_id, format):
+    """List all users on a given watchlist."""
+    if watchlist_type:
+        watchlist_id = state.sdk.watchlists._watchlists_service.watchlist_type_id_map[watchlist_type]
+    pages = state.sdk.watchlists.get_all_included_users(watchlist_id)
+    dfs = (DataFrame(page["includedUsers"]) for page in pages)
+    formatter = DataFrameOutputFormatter(format)
+    formatter.echo_formatted_dataframes(dfs)
+
+
+@watchlists.command()
+@click.option(
+    "--watchlist-id",
+    help="ID of the watchlist.",
+)
+@click.option(
+    "--watchlist-type",
+    type=click.Choice(WatchlistType.choices()),
+    help="Type of watchlist to remove user from. For CUSTOM watchlists, --watchlist-id is required.",
+    cls=incompatible_with("watchlist_id"),
+)
+@click.argument("user", metavar="USER_ID|USERNAME")
+@sdk_options()
+def add(state, watchlist_id, user):
+    try:
+        user = int(user)
+    except ValueError:
+        # assume username if `user` is not an int
+        user = state.sdk.userriskprofile.get_by_username(user)["userId"]
+    state.sdk.watchlists.add_included_users_by_watchlist_id(user, watchlist_id)
+
+
+@watchlists.command()
+@click.option("--watchlist-id", help="ID of the watchlist.")
+@click.option(
+    "--watchlist-type",
+    type=click.Choice(WatchlistType.choices()),
+    help="Type of watchlist to remove user from. For CUSTOM watchlists, --watchlist-id is required.",
+    cls=incompatible_with("watchlist_id"),
+)
+@click.argument("user", metavar="USER_ID|USERNAME")
+@sdk_options()
+def remove(state, watchlist_id, watchlist_type, user):
+    try:
+        user = int(user)
+    except ValueError:
+        # assume username if `user` is not an int
+        user = state.sdk.userriskprofile.get_by_username(user)["userId"]
+    state.sdk.watchlists.remove_included_users_by_watchlist_id(user, watchlist_id)
+
+
+@watchlists.group(cls=OrderedGroup)
+@sdk_options(hidden=True)
+def bulk(state):
+    """Tools for executing bulk watchlist actions."""
+    pass
+
+
+@bulk.command(
+    name="add",
+    help="Bulk add users to watchlists using a CSV file. Requires either a `watchlist_id` or "
+         "`watchlist_type` column header to identify the watchlist, and either a `user_id` or "
+         "`username` column header to identify the user to add."
+)
+@click.argument(
+    "csv_rows",
+    metavar="CSV_FILE",
+    type=AutoDecodedFile("r"),
+    callback=lambda ctx, param, arg: csv.DictReader(arg),
+)
+@sdk_options()
+def bulk_add(state, csv_rows):
+    headers = csv_rows.fieldnames
+    if "userId" not in headers and "username" not in headers:
+        raise Code42CLIError(
+            "CSV requires either a `username` or `userId` "
+            "column to identify which users to add to watchlist."
+        )
+    if "watchlistId" not in headers and "watchlistType" not in headers:
+        raise Code42CLIError(
+            "CSV requires either a `watchlistId` or `watchlistType` "
+            "column to identify which watchlist to add user to."
+        )
+
+    sdk = state.sdk
+
+    def handle_row(
+        watchlist_id=None,
+        watchlist_type=None,
+        user_id=None,
+        username=None
+    ):
+        if username and not user_id:
+            user_id = sdk.userriskprofile.get_by_username(username)["userId"]
+        if watchlist_id:
+            sdk.watchlists.add_included_users_by_watchlist_id(user_id, watchlist_id)
+        elif watchlist_type:
+            choices = WatchlistType.choices()
+            if watchlist_type not in choices:
+                raise Code42CLIError(
+                    f"Provided watchlist_type `{watchlist_type}` for username={username}, "
+                    f"user_id={user_id} row is invalid. Must be one of: {','.join(choices)}"
+                )
+            sdk.watchlists.add_included_users_by_watchlist_type(user_id, watchlist_type)
+        else:
+            raise Code42CLIError(
+                f"Row for username={username}, user_id={user_id} "
+                "missing value for `watchlistId` and `watchlistType` columns."
+            )
+
+    run_bulk_process(
+        handle_row,
+        list(csv_rows),
+        progress_label="Adding users to Watchlists:",
+    )
+
+
+@bulk.command(
+    name="remove",
+    help="Bulk remove users from watchlists using a CSV file. Requires either a `watchlist_id` or "
+         "`watchlist_type` column header to identify the watchlist, and either a `user_id` or "
+         "`username` header to identify the user to remove."
+)
+@click.argument(
+    "csv_rows",
+    metavar="CSV_FILE",
+    type=AutoDecodedFile("r"),
+    callback=lambda ctx, param, arg: csv.DictReader(arg),
+)
+@sdk_options()
+def bulk_remove(state, csv_rows):
+    headers = csv_rows.fieldnames
+    if "userId" not in headers and "username" not in headers:
+        raise Code42CLIError(
+            "CSV requires either a `username` or `userId` "
+            "column to identify which users to remove from watchlist."
+        )
+    if "watchlistId" not in headers and "watchlistType" not in headers:
+        raise Code42CLIError(
+            "CSV requires either a `watchlistId` or `watchlistType` "
+            "column to identify which watchlist to remove user from."
+        )
+
+    sdk = state.sdk
+
+    def handle_row(watchlistId=None, watchlistType=None, userId=None, username=None):
+        if username and not userId:
+            userId = sdk.userriskprofile.get_by_username(username)["userId"]
+        if watchlistId:
+            sdk.watchlists.remove_included_users_by_watchlist_id(userId, watchlistId)
+        elif watchlistType:
+            sdk.watchlists.remove_included_users_by_watchlist_type(
+                userId, watchlistType
+            )
+        else:
+            raise Code42CLIError(
+                f"Row for username={username}, userId={userId} "
+                "missing value for `watchlistId` and `watchlistType` columns."
+            )
+
+    run_bulk_process(
+        handle_row,
+        list(csv_rows),
+        progress_label="Adding users to Watchlists:",
+    )

--- a/src/code42cli/cmds/watchlists.py
+++ b/src/code42cli/cmds/watchlists.py
@@ -6,6 +6,7 @@ from py42.constants import WatchlistType
 from py42.exceptions import Py42NotFoundError
 from py42.exceptions import Py42WatchlistNotFound
 
+from code42cli.bulk import generate_template_cmd_factory
 from code42cli.bulk import run_bulk_process
 from code42cli.click_ext.groups import OrderedGroup
 from code42cli.click_ext.options import incompatible_with
@@ -14,7 +15,6 @@ from code42cli.errors import Code42CLIError
 from code42cli.options import format_option
 from code42cli.options import sdk_options
 from code42cli.output_formats import DataFrameOutputFormatter
-from code42cli.bulk import generate_template_cmd_factory
 
 
 @click.group(cls=OrderedGroup)
@@ -43,7 +43,7 @@ def _list(state, format):
 @click.option(
     "--watchlist-type",
     type=click.Choice(WatchlistType.choices()),
-    help="Type of watchlist to remove user from. For CUSTOM watchlists, --watchlist-id is required.",
+    help="Type of watchlist to list.",
     cls=incompatible_with("watchlist_id"),
 )
 @format_option
@@ -70,12 +70,13 @@ def list_users(state, watchlist_type, watchlist_id, format):
 @click.option(
     "--watchlist-type",
     type=click.Choice(WatchlistType.choices()),
-    help="Type of watchlist to remove user from. For CUSTOM watchlists, --watchlist-id is required.",
+    help="Type of watchlist to add user to.",
     cls=incompatible_with("watchlist_id"),
 )
 @click.argument("user", metavar="USER_ID|USERNAME")
 @sdk_options()
 def add(state, watchlist_id, watchlist_type, user):
+    """Add a user to a watchlist."""
     if not watchlist_id and not watchlist_type:
         raise click.ClickException("--watchlist-id OR --watchlist-type is required.")
     try:
@@ -101,12 +102,13 @@ def add(state, watchlist_id, watchlist_type, user):
 @click.option(
     "--watchlist-type",
     type=click.Choice(WatchlistType.choices()),
-    help="Type of watchlist to remove user from. For CUSTOM watchlists, --watchlist-id is required.",
+    help="Type of watchlist to remove user from.",
     cls=incompatible_with("watchlist_id"),
 )
 @click.argument("user", metavar="USER_ID|USERNAME")
 @sdk_options()
 def remove(state, watchlist_id, watchlist_type, user):
+    """Remove a user from a watchlist."""
     if not watchlist_id and not watchlist_type:
         raise click.ClickException("--watchlist-id OR --watchlist-type is required.")
     try:

--- a/src/code42cli/cmds/watchlists.py
+++ b/src/code42cli/cmds/watchlists.py
@@ -73,7 +73,7 @@ def list_users(state, watchlist_type, watchlist_id, format):
     help="Type of watchlist to add user to.",
     cls=incompatible_with("watchlist_id"),
 )
-@click.argument("user", metavar="USER_ID|USERNAME")
+@click.argument("user", metavar="[USER_ID|USERNAME]")
 @sdk_options()
 def add(state, watchlist_id, watchlist_type, user):
     """Add a user to a watchlist."""
@@ -105,7 +105,7 @@ def add(state, watchlist_id, watchlist_type, user):
     help="Type of watchlist to remove user from.",
     cls=incompatible_with("watchlist_id"),
 )
-@click.argument("user", metavar="USER_ID|USERNAME")
+@click.argument("user", metavar="[USER_ID|USERNAME]")
 @sdk_options()
 def remove(state, watchlist_id, watchlist_type, user):
     """Remove a user from a watchlist."""

--- a/src/code42cli/cmds/watchlists.py
+++ b/src/code42cli/cmds/watchlists.py
@@ -51,6 +51,8 @@ def _list(state, format):
 @sdk_options()
 def list_users(state, watchlist_type, watchlist_id, format):
     """List all users on a given watchlist."""
+    if not watchlist_id and not watchlist_type:
+        raise click.ClickException("--watchlist-id OR --watchlist-type is required.")
     if watchlist_type:
         watchlist_id = state.sdk.watchlists._watchlists_service.watchlist_type_id_map[
             watchlist_type

--- a/src/code42cli/cmds/watchlists.py
+++ b/src/code42cli/cmds/watchlists.py
@@ -11,7 +11,6 @@ from code42cli.click_ext.groups import OrderedGroup
 from code42cli.click_ext.options import incompatible_with
 from code42cli.click_ext.types import AutoDecodedFile
 from code42cli.errors import Code42CLIError
-from code42cli.file_readers import read_csv_arg
 from code42cli.options import format_option
 from code42cli.options import sdk_options
 from code42cli.output_formats import DataFrameOutputFormatter

--- a/src/code42cli/main.py
+++ b/src/code42cli/main.py
@@ -2,6 +2,7 @@ import os
 import signal
 import site
 import sys
+import warnings
 
 import click
 from click_plugins import with_plugins
@@ -26,6 +27,8 @@ from code42cli.cmds.trustedactivities import trusted_activities
 from code42cli.cmds.users import users
 from code42cli.cmds.watchlists import watchlists
 from code42cli.options import sdk_options
+
+warnings.simplefilter("ignore", DeprecationWarning)
 
 
 # Handle KeyboardInterrupts by just exiting instead of printing out a stack

--- a/src/code42cli/main.py
+++ b/src/code42cli/main.py
@@ -24,6 +24,7 @@ from code42cli.cmds.securitydata import security_data
 from code42cli.cmds.shell import shell
 from code42cli.cmds.trustedactivities import trusted_activities
 from code42cli.cmds.users import users
+from code42cli.cmds.watchlists import watchlists
 from code42cli.options import sdk_options
 
 
@@ -93,3 +94,4 @@ cli.add_command(security_data)
 cli.add_command(shell)
 cli.add_command(users)
 cli.add_command(trusted_activities)
+cli.add_command(watchlists)

--- a/src/code42cli/util.py
+++ b/src/code42cli/util.py
@@ -198,3 +198,7 @@ def parse_timestamp(date_str):
     ts = date_str[:-1]
     date = dateutil.parser.parse(ts).replace(tzinfo=timezone.utc)
     return date.timestamp()
+
+
+def deprecation_warning(text):
+    echo(style(text, fg="red"), err=True)

--- a/tests/cmds/test_users.py
+++ b/tests/cmds/test_users.py
@@ -10,6 +10,7 @@ from py42.exceptions import Py42InvalidPasswordError
 from py42.exceptions import Py42InvalidUsernameError
 from py42.exceptions import Py42NotFoundError
 from py42.exceptions import Py42OrgNotFoundError
+from py42.exceptions import Py42UserRiskProfileNotFound
 from tests.conftest import create_mock_http_error
 from tests.conftest import create_mock_response
 
@@ -49,7 +50,7 @@ TEST_USER_RESPONSE = {
     "userName": "Sample.User1@samplecase.com",
     "displayName": "Sample User1",
     "notes": "This is an example of notes about Sample User1.",
-    "cloudUsernames": ["Sample.User1@samplecase.com", "Sample.User1@gmail.com"],
+    "cloudAliases": ["Sample.User1@samplecase.com", "Sample.User1@gmail.com"],
     "managerUid": 12345,
     "managerUsername": "manager.user1@samplecase.com",
     "managerDisplayName": "Manager Name",
@@ -100,7 +101,7 @@ TEST_EMPTY_CUSTODIANS_RESPONSE = {"legalHoldMemberships": []}
 TEST_EMPTY_MATTERS_RESPONSE = {"legalHolds": []}
 TEST_EMPTY_USERS_RESPONSE = {"users": []}
 TEST_USERNAME = TEST_USERS_RESPONSE["users"][0]["username"]
-TEST_ALIAS = TEST_USER_RESPONSE["cloudUsernames"][0]
+TEST_ALIAS = TEST_USER_RESPONSE["cloudAliases"][0]
 TEST_USER_ID = TEST_USERS_RESPONSE["users"][0]["userId"]
 TEST_USER_UID = TEST_USER_RESPONSE["userId"]
 TEST_ROLE_NAME = TEST_ROLE_RETURN_DATA["data"][0]["roleName"]
@@ -159,7 +160,7 @@ def get_user_response(mocker):
 
 @pytest.fixture
 def get_user_failure(mocker):
-    return Py42BadRequestError(
+    return Py42UserRiskProfileNotFound(
         create_mock_http_error(mocker, data=None, status=400),
         "Failure in HTTP call 400 Client Error: Bad Request for url: https://ecm-east.us.code42.com/svc/api/v2/user/getbyusername.",
     )
@@ -212,13 +213,13 @@ def get_user_id_success(cli_state, get_users_response):
 
 @pytest.fixture
 def get_user_uid_success(cli_state, get_user_response):
-    """detectionlists.get_user returns a single user"""
-    cli_state.sdk.detectionlists.get_user.return_value = get_user_response
+    """userriskprofile.get_by_username returns a single user"""
+    cli_state.sdk.userriskprofile.get_by_username.return_value = get_user_response
 
 
 @pytest.fixture
 def get_user_uid_failure(cli_state, get_user_failure):
-    cli_state.sdk.detectionlists.get_user.side_effect = get_user_failure
+    cli_state.sdk.userriskprofile.get_by_username.side_effect = get_user_failure
 
 
 @pytest.fixture
@@ -305,14 +306,14 @@ def add_alias_success(mocker, cli_state):
 
 @pytest.fixture
 def add_alias_limit_failure(mocker, cli_state):
-    cli_state.sdk.detectionlists.add_user_cloud_alias.side_effect = (
+    cli_state.sdk.userriskprofile.add_cloud_aliases.side_effect = (
         Py42CloudAliasLimitExceededError(create_mock_http_error(mocker))
     )
 
 
 @pytest.fixture
 def remove_alias_success(mocker, cli_state):
-    cli_state.sdk.detectionlists.remove_user_cloud_alias.return_value = (
+    cli_state.sdk.userriskprofile.delete_cloud_aliases.return_value = (
         create_mock_response(mocker)
     )
 
@@ -1450,14 +1451,14 @@ def test_list_aliases_calls_get_user_with_expected_parameters(runner, cli_state)
     username = "alias@example"
     command = ["users", "list-aliases", username]
     runner.invoke(cli, command, obj=cli_state)
-    cli_state.sdk.detectionlists.get_user.assert_called_once_with("alias@example")
+    cli_state.sdk.userriskprofile.get_by_username.assert_called_once_with("alias@example")
 
 
 def test_list_aliases_prints_no_aliases_found_when_empty_list(
     runner, cli_state, mocker
 ):
-    cli_state.sdk.detectionlists.get_user.return_value = create_mock_response(
-        mocker, data={"cloudUsernames": []}
+    cli_state.sdk.userriskprofile.get_by_username.return_value = create_mock_response(
+        mocker, data={"cloudAliases": []}
     )
     username = "alias@example"
     command = ["users", "list-aliases", username]
@@ -1492,7 +1493,7 @@ def test_add_cloud_alias_calls_add_cloud_alias_with_correct_parameters(
 ):
     command = ["users", "add-alias", "test@example.com", "alias@example.com"]
     runner.invoke(cli, command, obj=cli_state)
-    cli_state.sdk.detectionlists.add_user_cloud_alias.assert_called_once_with(
+    cli_state.sdk.userriskprofile.add_cloud_aliases.assert_called_once_with(
         TEST_USER_UID, "alias@example.com"
     )
 
@@ -1517,7 +1518,7 @@ def test_add_alias_raises_error_when_alias_is_too_long(runner, cli_state):
         "fake@notreal.com",
         "alias-is-too-long-its-very-long-for-real-more-than-50-characters@example.com",
     ]
-    cli_state.sdk.detectionlists.add_user_cloud_alias.side_effect = (
+    cli_state.sdk.userriskprofile.add_cloud_aliases.side_effect = (
         Py42CloudAliasCharacterLimitExceededError
     )
     result = runner.invoke(cli, command, obj=cli_state)
@@ -1547,7 +1548,7 @@ def test_remove_cloud_alias_calls_remove_cloud_alias_with_correct_parameters(
 ):
     command = ["users", "remove-alias", "test@example.com", "alias@example.com"]
     runner.invoke(cli, command, obj=cli_state)
-    cli_state.sdk.detectionlists.remove_user_cloud_alias.assert_called_once_with(
+    cli_state.sdk.userriskprofile.delete_cloud_aliases.assert_called_once_with(
         TEST_USER_UID, "alias@example.com"
     )
 
@@ -1609,7 +1610,7 @@ def test_bulk_add_alias_uses_handler_that_when_encounters_error_increments_total
             raise Exception("TEST")
         return get_user_response
 
-    cli_state.sdk.detectionlists.get_user.side_effect = _get
+    cli_state.sdk.userriskprofile.get_by_username.side_effect = _get
     bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
     with runner.isolated_filesystem():
         with open("test_add_alias.csv", "w") as csv:
@@ -1669,7 +1670,7 @@ def test_bulk_remove_alias_uses_handler_that_when_encounters_error_increments_to
             raise Exception("TEST")
         return get_user_response
 
-    cli_state.sdk.detectionlists.get_user.side_effect = _get
+    cli_state.sdk.userriskprofile.get_by_username.side_effect = _get
     bulk_processor = mocker.patch(f"{_NAMESPACE}.run_bulk_process")
     with runner.isolated_filesystem():
         with open("test_remove_alias.csv", "w") as csv:

--- a/tests/cmds/test_watchlists.py
+++ b/tests/cmds/test_watchlists.py
@@ -66,8 +66,8 @@ WATCHLISTS_RESPONSE = {
     "totalCount": 9,
 }
 
-WATCHLISTS_INCLUDED_USERS_RESPONSE = {
-    "includedUsers": [
+WATCHLISTS_MEMBERS_RESPONSE = {
+    "watchlistMembers": [
         {
             "userId": "1234",
             "username": "one@example.com",
@@ -94,8 +94,8 @@ def mock_watchlists_response(mocker):
 
 
 @pytest.fixture()
-def mock_included_users_response(mocker):
-    return create_mock_response(mocker, data=WATCHLISTS_INCLUDED_USERS_RESPONSE)
+def mock_members_response(mocker):
+    return create_mock_response(mocker, data=WATCHLISTS_MEMBERS_RESPONSE)
 
 
 class TestWatchlistsListCmd:
@@ -141,14 +141,14 @@ class TestWatchlistsListCmd:
 
 class TestWatchlistsListUsersCmd:
     def test_table_output_contains_expected_properties(
-        self, runner, cli_state, mock_included_users_response
+        self, runner, cli_state, mock_members_response
     ):
-        cli_state.sdk.watchlists.get_all_included_users.return_value = iter(
-            [mock_included_users_response]
+        cli_state.sdk.watchlists.get_all_watchlist_members.return_value = iter(
+            [mock_members_response]
         )
         res = runner.invoke(
             cli,
-            ["watchlists", "list-users", "--watchlist-id", "test-id"],
+            ["watchlists", "list-members", "--watchlist-id", "test-id"],
             obj=cli_state,
         )
         assert "userId" in res.output
@@ -163,14 +163,14 @@ class TestWatchlistsListUsersCmd:
         assert "2022-04-10T23:05:48.096964" in res.output
 
     def test_json_output_contains_expected_properties(
-        self, runner, cli_state, mock_included_users_response
+        self, runner, cli_state, mock_members_response
     ):
-        cli_state.sdk.watchlists.get_all_included_users.return_value = iter(
-            [mock_included_users_response]
+        cli_state.sdk.watchlists.get_all_watchlist_members.return_value = iter(
+            [mock_members_response]
         )
         res = runner.invoke(
             cli,
-            ["watchlists", "list-users", "--watchlist-id", "test-id", "-f", "JSON"],
+            ["watchlists", "list-members", "--watchlist-id", "test-id", "-f", "JSON"],
             obj=cli_state,
         )
         assert "userId" in res.output
@@ -185,14 +185,14 @@ class TestWatchlistsListUsersCmd:
         assert "2022-04-10T23:05:48.096964" in res.output
 
     def test_csv_output_contains_expected_properties(
-        self, runner, cli_state, mock_included_users_response
+        self, runner, cli_state, mock_members_response
     ):
-        cli_state.sdk.watchlists.get_all_included_users.return_value = iter(
-            [mock_included_users_response]
+        cli_state.sdk.watchlists.get_all_watchlist_members.return_value = iter(
+            [mock_members_response]
         )
         res = runner.invoke(
             cli,
-            ["watchlists", "list-users", "--watchlist-id", "test-id", "-f", "CSV"],
+            ["watchlists", "list-members", "--watchlist-id", "test-id", "-f", "CSV"],
             obj=cli_state,
         )
         assert "userId" in res.output
@@ -209,7 +209,7 @@ class TestWatchlistsListUsersCmd:
     def test_invalid_watchlist_type_raises_cli_error(self, runner, cli_state):
         res = runner.invoke(
             cli,
-            ["watchlists", "list-users", "--watchlist-type", "INVALID"],
+            ["watchlists", "list-members", "--watchlist-type", "INVALID"],
             obj=cli_state,
         )
         assert res.exit_code == 2
@@ -220,7 +220,7 @@ class TestWatchlistsListUsersCmd:
     ):
         res = runner.invoke(
             cli,
-            ["watchlists", "list-users"],
+            ["watchlists", "list-members"],
             obj=cli_state,
         )
         assert res.exit_code == 1

--- a/tests/cmds/test_watchlists.py
+++ b/tests/cmds/test_watchlists.py
@@ -249,7 +249,7 @@ class TestWatchlistsAddCmd:
     ):
         mock_user_response = create_mock_response(mocker, data={"userId": 1234})
         cli_state.sdk.userriskprofile.get_by_username.return_value = mock_user_response
-        res = runner.invoke(
+        runner.invoke(
             cli,
             [
                 "watchlists",
@@ -348,7 +348,7 @@ class TestWatchlistsRemoveCmd:
     ):
         mock_user_response = create_mock_response(mocker, data={"userId": 1234})
         cli_state.sdk.userriskprofile.get_by_username.return_value = mock_user_response
-        res = runner.invoke(
+        runner.invoke(
             cli,
             [
                 "watchlists",
@@ -470,9 +470,7 @@ class TestWatchlistBulkAddCmd:
                 file.write(
                     "username,user_id,watchlist_id,watchlist_type\ntest@example.com,1234,abcd,DEPARTING_EMPLOYEE\n"
                 )
-            res = runner.invoke(
-                cli, ["watchlists", "bulk", "add", "csv"], obj=cli_state
-            )
+            runner.invoke(cli, ["watchlists", "bulk", "add", "csv"], obj=cli_state)
             cli_state.sdk.watchlists.add_included_users_by_watchlist_id.assert_called_once_with(
                 "1234", "abcd"
             )
@@ -489,9 +487,7 @@ class TestWatchlistBulkAddCmd:
                 file.write(
                     "username,watchlist_type\ntest@example.com,DEPARTING_EMPLOYEE\n"
                 )
-            res = runner.invoke(
-                cli, ["watchlists", "bulk", "add", "csv"], obj=cli_state
-            )
+            runner.invoke(cli, ["watchlists", "bulk", "add", "csv"], obj=cli_state)
             cli_state.sdk.watchlists.add_included_users_by_watchlist_type.assert_called_once_with(
                 1234, "DEPARTING_EMPLOYEE"
             )
@@ -536,9 +532,7 @@ class TestWatchlistBulkRemoveCmd:
                 file.write(
                     "username,user_id,watchlist_id,watchlist_type\ntest@example.com,1234,abcd,DEPARTING_EMPLOYEE\n"
                 )
-            res = runner.invoke(
-                cli, ["watchlists", "bulk", "remove", "csv"], obj=cli_state
-            )
+            runner.invoke(cli, ["watchlists", "bulk", "remove", "csv"], obj=cli_state)
             cli_state.sdk.watchlists.remove_included_users_by_watchlist_id.assert_called_once_with(
                 "1234", "abcd"
             )
@@ -555,9 +549,7 @@ class TestWatchlistBulkRemoveCmd:
                 file.write(
                     "username,watchlist_type\ntest@example.com,DEPARTING_EMPLOYEE\n"
                 )
-            res = runner.invoke(
-                cli, ["watchlists", "bulk", "remove", "csv"], obj=cli_state
-            )
+            runner.invoke(cli, ["watchlists", "bulk", "remove", "csv"], obj=cli_state)
             cli_state.sdk.watchlists.remove_included_users_by_watchlist_type.assert_called_once_with(
                 1234, "DEPARTING_EMPLOYEE"
             )

--- a/tests/cmds/test_watchlists.py
+++ b/tests/cmds/test_watchlists.py
@@ -1,11 +1,10 @@
 import pytest
-
-from code42cli.main import cli
-from .conftest import create_mock_response
-
-from py42.exceptions import Py42UserRiskProfileNotFound
 from py42.exceptions import Py42NotFoundError
+from py42.exceptions import Py42UserRiskProfileNotFound
 from py42.exceptions import Py42WatchlistNotFound
+
+from .conftest import create_mock_response
+from code42cli.main import cli
 
 WATCHLISTS_RESPONSE = {
     "watchlists": [

--- a/tests/cmds/test_watchlists.py
+++ b/tests/cmds/test_watchlists.py
@@ -1,0 +1,564 @@
+import pytest
+
+from code42cli.main import cli
+from .conftest import create_mock_response
+
+from py42.exceptions import Py42UserRiskProfileNotFound
+from py42.exceptions import Py42NotFoundError
+from py42.exceptions import Py42WatchlistNotFound
+
+WATCHLISTS_RESPONSE = {
+    "watchlists": [
+        {
+            "listType": "DEPARTING_EMPLOYEE",
+            "watchlistId": "departing-id",
+            "tenantId": "tenant-123",
+            "stats": {"includedUsersCount": 50},
+        },
+        {
+            "listType": "HIGH_IMPACT_EMPLOYEE",
+            "watchlistId": "high-impact-id",
+            "tenantId": "tenant-123",
+            "stats": {"includedUsersCount": 3},
+        },
+        {
+            "listType": "POOR_SECURITY_PRACTICES",
+            "watchlistId": "poor-security-id",
+            "tenantId": "tenant-123",
+            "stats": {"includedUsersCount": 2},
+        },
+        {
+            "listType": "FLIGHT_RISK",
+            "watchlistId": "flight-risk-id",
+            "tenantId": "tenant-123",
+            "stats": {"includedUsersCount": 2},
+        },
+        {
+            "listType": "SUSPICIOUS_SYSTEM_ACTIVITY",
+            "watchlistId": "suspicious-id",
+            "tenantId": "tenant-123",
+            "stats": {"includedUsersCount": 2},
+        },
+        {
+            "listType": "CONTRACT_EMPLOYEE",
+            "watchlistId": "contract-id",
+            "tenantId": "tenant-123",
+            "stats": {"includedUsersCount": 2},
+        },
+        {
+            "listType": "NEW_EMPLOYEE",
+            "watchlistId": "new-employee-id",
+            "tenantId": "tenant-123",
+            "stats": {"includedUsersCount": 1},
+        },
+        {
+            "listType": "ELEVATED_ACCESS_PRIVILEGES",
+            "watchlistId": "elevated-id",
+            "tenantId": "tenant-123",
+            "stats": {},
+        },
+        {
+            "listType": "PERFORMANCE_CONCERNS",
+            "watchlistId": "performance-id",
+            "tenantId": "tenant-123",
+            "stats": {},
+        },
+    ],
+    "totalCount": 9,
+}
+
+WATCHLISTS_INCLUDED_USERS_RESPONSE = {
+    "includedUsers": [
+        {
+            "userId": "1234",
+            "username": "one@example.com",
+            "addedTime": "2022-04-10T23:05:48.096964",
+        },
+        {
+            "userId": "2345",
+            "username": "two@example.com",
+            "addedTime": "2022-02-26T18:52:36.805807",
+        },
+        {
+            "userId": "3456",
+            "username": "three@example.com",
+            "addedTime": "2022-02-26T18:52:36.805807",
+        },
+    ],
+    "totalCount": 3,
+}
+
+
+@pytest.fixture()
+def mock_watchlists_response(mocker):
+    return create_mock_response(mocker, data=WATCHLISTS_RESPONSE)
+
+
+@pytest.fixture()
+def mock_included_users_response(mocker):
+    return create_mock_response(mocker, data=WATCHLISTS_INCLUDED_USERS_RESPONSE)
+
+
+class TestWatchlistsListCmd:
+    def test_table_output_contains_expected_properties(
+        self, runner, cli_state, mock_watchlists_response
+    ):
+        cli_state.sdk.watchlists.get_all.return_value = iter([mock_watchlists_response])
+        res = runner.invoke(cli, ["watchlists", "list"], obj=cli_state)
+        assert "listType" in res.output
+        assert "watchlistId" in res.output
+        assert "tenantId" in res.output
+        assert "stats" in res.output
+        assert "DEPARTING_EMPLOYEE" in res.output
+        assert "includedUsersCount" in res.output
+        assert "tenant-123" in res.output
+
+    def test_json_output_contains_expected_properties(
+        self, runner, cli_state, mock_watchlists_response
+    ):
+        cli_state.sdk.watchlists.get_all.return_value = iter([mock_watchlists_response])
+        res = runner.invoke(cli, ["watchlists", "list", "-f", "JSON"], obj=cli_state)
+        assert "listType" in res.output
+        assert "watchlistId" in res.output
+        assert "tenantId" in res.output
+        assert "stats" in res.output
+        assert "DEPARTING_EMPLOYEE" in res.output
+        assert "includedUsersCount" in res.output
+        assert "tenant-123" in res.output
+
+    def test_csv_ouput_contains_expected_properties(
+        self, runner, cli_state, mock_watchlists_response
+    ):
+        cli_state.sdk.watchlists.get_all.return_value = iter([mock_watchlists_response])
+        res = runner.invoke(cli, ["watchlists", "list", "-f", "CSV"], obj=cli_state)
+        assert "listType" in res.output
+        assert "watchlistId" in res.output
+        assert "tenantId" in res.output
+        assert "stats" in res.output
+        assert "DEPARTING_EMPLOYEE" in res.output
+        assert "includedUsersCount" in res.output
+        assert "tenant-123" in res.output
+
+
+class TestWatchlistsListUsersCmd:
+    def test_table_output_contains_expected_properties(
+        self, runner, cli_state, mock_included_users_response
+    ):
+        cli_state.sdk.watchlists.get_all_included_users.return_value = iter(
+            [mock_included_users_response]
+        )
+        res = runner.invoke(
+            cli,
+            ["watchlists", "list-users", "--watchlist-id", "test-id"],
+            obj=cli_state,
+        )
+        assert "userId" in res.output
+        assert "username" in res.output
+        assert "addedTime" in res.output
+        assert "1234" in res.output
+        assert "2345" in res.output
+        assert "3456" in res.output
+        assert "one@example.com" in res.output
+        assert "two@example.com" in res.output
+        assert "three@example.com" in res.output
+        assert "2022-04-10T23:05:48.096964" in res.output
+
+    def test_json_output_contains_expected_properties(
+        self, runner, cli_state, mock_included_users_response
+    ):
+        cli_state.sdk.watchlists.get_all_included_users.return_value = iter(
+            [mock_included_users_response]
+        )
+        res = runner.invoke(
+            cli,
+            ["watchlists", "list-users", "--watchlist-id", "test-id", "-f", "JSON"],
+            obj=cli_state,
+        )
+        assert "userId" in res.output
+        assert "username" in res.output
+        assert "addedTime" in res.output
+        assert "1234" in res.output
+        assert "2345" in res.output
+        assert "3456" in res.output
+        assert "one@example.com" in res.output
+        assert "two@example.com" in res.output
+        assert "three@example.com" in res.output
+        assert "2022-04-10T23:05:48.096964" in res.output
+
+    def test_csv_output_contains_expected_properties(
+        self, runner, cli_state, mock_included_users_response
+    ):
+        cli_state.sdk.watchlists.get_all_included_users.return_value = iter(
+            [mock_included_users_response]
+        )
+        res = runner.invoke(
+            cli,
+            ["watchlists", "list-users", "--watchlist-id", "test-id", "-f", "CSV"],
+            obj=cli_state,
+        )
+        assert "userId" in res.output
+        assert "username" in res.output
+        assert "addedTime" in res.output
+        assert "1234" in res.output
+        assert "2345" in res.output
+        assert "3456" in res.output
+        assert "one@example.com" in res.output
+        assert "two@example.com" in res.output
+        assert "three@example.com" in res.output
+        assert "2022-04-10T23:05:48.096964" in res.output
+
+    def test_invalid_watchlist_type_raises_cli_error(self, runner, cli_state):
+        res = runner.invoke(
+            cli,
+            ["watchlists", "list-users", "--watchlist-type", "INVALID"],
+            obj=cli_state,
+        )
+        assert res.exit_code == 2
+        assert "Invalid value for '--watchlist-type'" in res.output
+
+    def test_missing_watchlist_identifying_option_raises_cli_error(
+        self, runner, cli_state
+    ):
+        res = runner.invoke(
+            cli,
+            ["watchlists", "list-users"],
+            obj=cli_state,
+        )
+        assert res.exit_code == 1
+        assert "Error: --watchlist-id OR --watchlist-type is required" in res.output
+
+
+class TestWatchlistsAddCmd:
+    def test_missing_watchlist_identifying_option_raises_cli_error(
+        self, runner, cli_state
+    ):
+        res = runner.invoke(cli, ["watchlists", "add", "1234"], obj=cli_state)
+        assert res.exit_code == 1
+        assert "Error: --watchlist-id OR --watchlist-type is required" in res.output
+
+    def test_invalid_watchlist_type_raises_cli_error(self, runner, cli_state):
+        res = runner.invoke(
+            cli,
+            ["watchlists", "add", "--watchlist-type", "INVALID", "1234"],
+            obj=cli_state,
+        )
+        assert res.exit_code == 2
+        assert "Invalid value for '--watchlist-type'" in res.output
+
+    def test_non_int_user_arg_calls_get_by_username_and_uses_user_id(
+        self, mocker, runner, cli_state
+    ):
+        mock_user_response = create_mock_response(mocker, data={"userId": 1234})
+        cli_state.sdk.userriskprofile.get_by_username.return_value = mock_user_response
+        res = runner.invoke(
+            cli,
+            [
+                "watchlists",
+                "add",
+                "--watchlist-type",
+                "DEPARTING_EMPLOYEE",
+                "test@example.com",
+            ],
+            obj=cli_state,
+        )
+        cli_state.sdk.userriskprofile.get_by_username.assert_called_once_with(
+            "test@example.com"
+        )
+        cli_state.sdk.watchlists.add_included_users_by_watchlist_type.assert_called_once_with(
+            1234, "DEPARTING_EMPLOYEE"
+        )
+
+    def test_invalid_username_raises_not_found_cli_error(
+        self, custom_error, runner, cli_state
+    ):
+        username = "test@example.com"
+        cli_state.sdk.userriskprofile.get_by_username.side_effect = (
+            Py42UserRiskProfileNotFound(custom_error, username, identifier="username")
+        )
+        res = runner.invoke(
+            cli,
+            ["watchlists", "add", "--watchlist-type", "DEPARTING_EMPLOYEE", username],
+            obj=cli_state,
+        )
+        assert res.exit_code == 1
+        assert (
+            "Error: User risk profile for user with the username 'test@example.com' not found."
+            in res.output
+        )
+
+    def test_invalid_user_id_raises_not_found_cli_error(
+        self, custom_error, runner, cli_state
+    ):
+        cli_state.sdk.watchlists.add_included_users_by_watchlist_type.side_effect = (
+            Py42NotFoundError(custom_error)
+        )
+        cli_state.sdk.watchlists.add_included_users_by_watchlist_id.side_effect = (
+            Py42NotFoundError(custom_error)
+        )
+        res = runner.invoke(
+            cli,
+            ["watchlists", "add", "--watchlist-type", "DEPARTING_EMPLOYEE", "1234"],
+            obj=cli_state,
+        )
+        assert res.exit_code == 1
+        assert "Error: User ID 1234 not found." in res.output
+
+        res = runner.invoke(
+            cli,
+            ["watchlists", "add", "--watchlist-id", "id", "1234"],
+            obj=cli_state,
+        )
+        assert res.exit_code == 1
+        assert "Error: User ID 1234 not found." in res.output
+
+    def test_invalid_watchlist_id_raises_not_found_cli_error(
+        self, custom_error, runner, cli_state
+    ):
+        invalid_watchlist_id = "INVALID"
+        cli_state.sdk.watchlists.add_included_users_by_watchlist_id.side_effect = (
+            Py42WatchlistNotFound(custom_error, invalid_watchlist_id)
+        )
+        res = runner.invoke(
+            cli,
+            ["watchlists", "add", "--watchlist-id", invalid_watchlist_id, "1234"],
+            obj=cli_state,
+        )
+        assert res.exit_code == 1
+        assert "Error: Watchlist ID 'INVALID' not found." in res.output
+
+
+class TestWatchlistsRemoveCmd:
+    def test_missing_watchlist_identifying_option_raises_cli_error(
+        self, runner, cli_state
+    ):
+        res = runner.invoke(cli, ["watchlists", "add", "1234"], obj=cli_state)
+        assert res.exit_code == 1
+        assert "Error: --watchlist-id OR --watchlist-type is required" in res.output
+
+    def test_invalid_watchlist_type_raises_cli_error(self, runner, cli_state):
+        res = runner.invoke(
+            cli,
+            ["watchlists", "remove", "--watchlist-type", "INVALID", "1234"],
+            obj=cli_state,
+        )
+        assert res.exit_code == 2
+        assert "Invalid value for '--watchlist-type'" in res.output
+
+    def test_non_int_user_arg_calls_get_by_username_and_uses_user_id(
+        self, mocker, runner, cli_state
+    ):
+        mock_user_response = create_mock_response(mocker, data={"userId": 1234})
+        cli_state.sdk.userriskprofile.get_by_username.return_value = mock_user_response
+        res = runner.invoke(
+            cli,
+            [
+                "watchlists",
+                "remove",
+                "--watchlist-type",
+                "DEPARTING_EMPLOYEE",
+                "test@example.com",
+            ],
+            obj=cli_state,
+        )
+        cli_state.sdk.userriskprofile.get_by_username.assert_called_once_with(
+            "test@example.com"
+        )
+        cli_state.sdk.watchlists.remove_included_users_by_watchlist_type.assert_called_once_with(
+            1234, "DEPARTING_EMPLOYEE"
+        )
+
+    def test_invalid_username_raises_not_found_cli_error(
+        self, custom_error, runner, cli_state
+    ):
+        username = "test@example.com"
+        cli_state.sdk.userriskprofile.get_by_username.side_effect = (
+            Py42UserRiskProfileNotFound(custom_error, username, identifier="username")
+        )
+        res = runner.invoke(
+            cli,
+            [
+                "watchlists",
+                "remove",
+                "--watchlist-type",
+                "DEPARTING_EMPLOYEE",
+                username,
+            ],
+            obj=cli_state,
+        )
+        assert res.exit_code == 1
+        assert (
+            "Error: User risk profile for user with the username 'test@example.com' not found."
+            in res.output
+        )
+
+    def test_invalid_user_id_raises_not_found_cli_error(
+        self, custom_error, runner, cli_state
+    ):
+        cli_state.sdk.watchlists.remove_included_users_by_watchlist_type.side_effect = (
+            Py42NotFoundError(custom_error)
+        )
+        cli_state.sdk.watchlists.remove_included_users_by_watchlist_id.side_effect = (
+            Py42NotFoundError(custom_error)
+        )
+        res = runner.invoke(
+            cli,
+            ["watchlists", "remove", "--watchlist-type", "DEPARTING_EMPLOYEE", "1234"],
+            obj=cli_state,
+        )
+        assert res.exit_code == 1
+        assert "Error: User ID 1234 not found." in res.output
+
+        res = runner.invoke(
+            cli,
+            ["watchlists", "remove", "--watchlist-id", "id", "1234"],
+            obj=cli_state,
+        )
+        assert res.exit_code == 1
+        assert "Error: User ID 1234 not found." in res.output
+
+    def test_invalid_watchlist_id_raises_not_found_cli_error(
+        self, custom_error, runner, cli_state
+    ):
+        invalid_watchlist_id = "INVALID"
+        cli_state.sdk.watchlists.remove_included_users_by_watchlist_id.side_effect = (
+            Py42WatchlistNotFound(custom_error, invalid_watchlist_id)
+        )
+        res = runner.invoke(
+            cli,
+            ["watchlists", "remove", "--watchlist-id", invalid_watchlist_id, "1234"],
+            obj=cli_state,
+        )
+        assert res.exit_code == 1
+        assert "Error: Watchlist ID 'INVALID' not found." in res.output
+
+
+class TestWatchlistBulkAddCmd:
+    def test_csv_without_either_username_or_user_id_raises_cli_error(
+        self, runner, cli_state
+    ):
+        with runner.isolated_filesystem():
+            with open("csv", "w") as file:
+                file.write("watchlist_id,watchlist_type\n")
+            res = runner.invoke(
+                cli, ["watchlists", "bulk", "add", "csv"], obj=cli_state
+            )
+            assert res.exit_code == 1
+            assert (
+                "Error: CSV requires either a `username` or `user_id` column to identify which users to add to watchlist."
+                in res.output
+            )
+
+    def test_csv_without_either_watchlist_type_or_watchlist_id_raises_cli_error(
+        self, runner, cli_state
+    ):
+        with runner.isolated_filesystem():
+            with open("csv", "w") as file:
+                file.write("username,user_id\n")
+            res = runner.invoke(
+                cli, ["watchlists", "bulk", "add", "csv"], obj=cli_state
+            )
+            assert res.exit_code == 1
+            assert (
+                "Error: CSV requires either a `watchlist_id` or `watchlist_type` column to identify which watchlist to add user to."
+                in res.output
+            )
+
+    def test_handle_row_when_passed_all_headers_uses_user_id_and_watchlist_id(
+        self, runner, cli_state
+    ):
+        with runner.isolated_filesystem():
+            with open("csv", "w") as file:
+                file.write(
+                    "username,user_id,watchlist_id,watchlist_type\ntest@example.com,1234,abcd,DEPARTING_EMPLOYEE\n"
+                )
+            res = runner.invoke(
+                cli, ["watchlists", "bulk", "add", "csv"], obj=cli_state
+            )
+            cli_state.sdk.watchlists.add_included_users_by_watchlist_id.assert_called_once_with(
+                "1234", "abcd"
+            )
+
+    def test_handle_row_when_passed_no_id_headers_uses_username_and_watchlist_type(
+        self, mocker, runner, cli_state
+    ):
+        cli_state.sdk.userriskprofile.get_by_username.return_value = (
+            create_mock_response(mocker, data={"userId": 1234})
+        )
+
+        with runner.isolated_filesystem():
+            with open("csv", "w") as file:
+                file.write(
+                    "username,watchlist_type\ntest@example.com,DEPARTING_EMPLOYEE\n"
+                )
+            res = runner.invoke(
+                cli, ["watchlists", "bulk", "add", "csv"], obj=cli_state
+            )
+            cli_state.sdk.watchlists.add_included_users_by_watchlist_type.assert_called_once_with(
+                1234, "DEPARTING_EMPLOYEE"
+            )
+
+
+class TestWatchlistBulkRemoveCmd:
+    def test_csv_without_either_username_or_user_id_raises_cli_error(
+        self, runner, cli_state
+    ):
+        with runner.isolated_filesystem():
+            with open("csv", "w") as file:
+                file.write("watchlist_id,watchlist_type\n")
+            res = runner.invoke(
+                cli, ["watchlists", "bulk", "remove", "csv"], obj=cli_state
+            )
+            assert res.exit_code == 1
+            assert (
+                "Error: CSV requires either a `username` or `user_id` column to identify which users to remove from watchlist."
+                in res.output
+            )
+
+    def test_csv_without_either_watchlist_type_or_watchlist_id_raises_cli_error(
+        self, runner, cli_state
+    ):
+        with runner.isolated_filesystem():
+            with open("csv", "w") as file:
+                file.write("username,user_id\n")
+            res = runner.invoke(
+                cli, ["watchlists", "bulk", "remove", "csv"], obj=cli_state
+            )
+            assert res.exit_code == 1
+            assert (
+                "Error: CSV requires either a `watchlist_id` or `watchlist_type` column to identify which watchlist to remove user from."
+                in res.output
+            )
+
+    def test_handle_row_when_passed_all_headers_uses_user_id_and_watchlist_id(
+        self, runner, cli_state
+    ):
+        with runner.isolated_filesystem():
+            with open("csv", "w") as file:
+                file.write(
+                    "username,user_id,watchlist_id,watchlist_type\ntest@example.com,1234,abcd,DEPARTING_EMPLOYEE\n"
+                )
+            res = runner.invoke(
+                cli, ["watchlists", "bulk", "remove", "csv"], obj=cli_state
+            )
+            cli_state.sdk.watchlists.remove_included_users_by_watchlist_id.assert_called_once_with(
+                "1234", "abcd"
+            )
+
+    def test_handle_row_when_passed_no_id_headers_uses_username_and_watchlist_type(
+        self, mocker, runner, cli_state
+    ):
+        cli_state.sdk.userriskprofile.get_by_username.return_value = (
+            create_mock_response(mocker, data={"userId": 1234})
+        )
+
+        with runner.isolated_filesystem():
+            with open("csv", "w") as file:
+                file.write(
+                    "username,watchlist_type\ntest@example.com,DEPARTING_EMPLOYEE\n"
+                )
+            res = runner.invoke(
+                cli, ["watchlists", "bulk", "remove", "csv"], obj=cli_state
+            )
+            cli_state.sdk.watchlists.remove_included_users_by_watchlist_type.assert_called_once_with(
+                1234, "DEPARTING_EMPLOYEE"
+            )

--- a/tests/cmds/test_watchlists.py
+++ b/tests/cmds/test_watchlists.py
@@ -87,10 +87,36 @@ WATCHLISTS_MEMBERS_RESPONSE = {
     "totalCount": 3,
 }
 
+WATCHLISTS_INCLUDED_USERS_RESPONSE = {
+    "includedUsers": [
+        {
+            "userId": "1234",
+            "username": "one@example.com",
+            "addedTime": "2022-04-10T23:05:48.096964",
+        },
+        {
+            "userId": "2345",
+            "username": "two@example.com",
+            "addedTime": "2022-02-26T18:52:36.805807",
+        },
+        {
+            "userId": "3456",
+            "username": "three@example.com",
+            "addedTime": "2022-02-26T18:52:36.805807",
+        },
+    ],
+    "totalCount": 3,
+}
+
 
 @pytest.fixture()
 def mock_watchlists_response(mocker):
     return create_mock_response(mocker, data=WATCHLISTS_RESPONSE)
+
+
+@pytest.fixture()
+def mock_included_users_response(mocker):
+    return create_mock_response(mocker, data=WATCHLISTS_INCLUDED_USERS_RESPONSE)
 
 
 @pytest.fixture()
@@ -139,10 +165,11 @@ class TestWatchlistsListCmd:
         assert "tenant-123" in res.output
 
 
-class TestWatchlistsListUsersCmd:
+class TestWatchlistsListMembersCmd:
     def test_table_output_contains_expected_properties(
-        self, runner, cli_state, mock_members_response
+        self, runner, cli_state, mock_members_response, mock_included_users_response
     ):
+        # all members:
         cli_state.sdk.watchlists.get_all_watchlist_members.return_value = iter(
             [mock_members_response]
         )
@@ -162,9 +189,36 @@ class TestWatchlistsListUsersCmd:
         assert "three@example.com" in res.output
         assert "2022-04-10T23:05:48.096964" in res.output
 
+        # only included users:
+        cli_state.sdk.watchlists.get_all_included_users.return_value = iter(
+            [mock_included_users_response]
+        )
+        res = runner.invoke(
+            cli,
+            [
+                "watchlists",
+                "list-members",
+                "--watchlist-id",
+                "test-id",
+                "--only-included-users",
+            ],
+            obj=cli_state,
+        )
+        assert "userId" in res.output
+        assert "username" in res.output
+        assert "addedTime" in res.output
+        assert "1234" in res.output
+        assert "2345" in res.output
+        assert "3456" in res.output
+        assert "one@example.com" in res.output
+        assert "two@example.com" in res.output
+        assert "three@example.com" in res.output
+        assert "2022-04-10T23:05:48.096964" in res.output
+
     def test_json_output_contains_expected_properties(
-        self, runner, cli_state, mock_members_response
+        self, runner, cli_state, mock_members_response, mock_included_users_response
     ):
+        # all members:
         cli_state.sdk.watchlists.get_all_watchlist_members.return_value = iter(
             [mock_members_response]
         )
@@ -184,15 +238,72 @@ class TestWatchlistsListUsersCmd:
         assert "three@example.com" in res.output
         assert "2022-04-10T23:05:48.096964" in res.output
 
+        # only included users:
+        cli_state.sdk.watchlists.get_all_included_users.return_value = iter(
+            [mock_included_users_response]
+        )
+        res = runner.invoke(
+            cli,
+            [
+                "watchlists",
+                "list-members",
+                "--watchlist-id",
+                "test-id",
+                "-f",
+                "JSON",
+                "--only-included-users",
+            ],
+            obj=cli_state,
+        )
+        assert "userId" in res.output
+        assert "username" in res.output
+        assert "addedTime" in res.output
+        assert "1234" in res.output
+        assert "2345" in res.output
+        assert "3456" in res.output
+        assert "one@example.com" in res.output
+        assert "two@example.com" in res.output
+        assert "three@example.com" in res.output
+        assert "2022-04-10T23:05:48.096964" in res.output
+
     def test_csv_output_contains_expected_properties(
-        self, runner, cli_state, mock_members_response
+        self, runner, cli_state, mock_members_response, mock_included_users_response
     ):
+        # all members:
         cli_state.sdk.watchlists.get_all_watchlist_members.return_value = iter(
             [mock_members_response]
         )
         res = runner.invoke(
             cli,
             ["watchlists", "list-members", "--watchlist-id", "test-id", "-f", "CSV"],
+            obj=cli_state,
+        )
+        assert "userId" in res.output
+        assert "username" in res.output
+        assert "addedTime" in res.output
+        assert "1234" in res.output
+        assert "2345" in res.output
+        assert "3456" in res.output
+        assert "one@example.com" in res.output
+        assert "two@example.com" in res.output
+        assert "three@example.com" in res.output
+        assert "2022-04-10T23:05:48.096964" in res.output
+
+        # only included users:
+        cli_state.sdk.watchlists.get_all_included_users.return_value = iter(
+            [mock_included_users_response]
+        )
+        res = runner.invoke(
+            cli,
+            [
+                "watchlists",
+                "list-members",
+                "--watchlist-id",
+                "test-id",
+                "-f",
+                "CSV",
+                "--only-included-users",
+            ],
             obj=cli_state,
         )
         assert "userId" in res.output

--- a/tests/cmds/test_watchlists.py
+++ b/tests/cmds/test_watchlists.py
@@ -441,7 +441,7 @@ class TestWatchlistsRemoveCmd:
     def test_missing_watchlist_identifying_option_raises_cli_error(
         self, runner, cli_state
     ):
-        res = runner.invoke(cli, ["watchlists", "add", "1234"], obj=cli_state)
+        res = runner.invoke(cli, ["watchlists", "remove", "1234"], obj=cli_state)
         assert res.exit_code == 1
         assert "Error: --watchlist-id OR --watchlist-type is required" in res.output
 


### PR DESCRIPTION
- deprecates `code42 departing-employee` and `code42 high-risk-employee` command groups
- adds `code42 watchlists list|list-users|add|remove|bulk-add|bulk-remove` commands
- adds `code42 users update-start-date|update-departure-date|update-risk-profile-notes` commands
- adds `code42 users bulk update-risk-profile` command
- updates `code42 users add-alias|remove-alias|bulk-add-alias|bulk-remove-alias` commands to use new `userriskprofile` methods from py42