### PR TITLE
fix a bug with devices list --include-settings

### DIFF
--- a/src/code42cli/cmds/devices.py
+++ b/src/code42cli/cmds/devices.py
@@ -443,10 +443,10 @@ def _get_device_dataframe(
 
 
 def _add_settings_to_dataframe(sdk, device_dataframe):
-    macos_guids = device_dataframe.loc[
+    macos_guids = [{"guid": value} for value in device_dataframe.loc[
         device_dataframe["osName"] == "mac", "guid"
-    ].values
-
+    ].values]
+    click.echo(macos_guids)
     def handle_row(guid):
         try:
             full_disk_access_status = sdk.devices.get_agent_full_disk_access_state(

--- a/src/code42cli/cmds/devices.py
+++ b/src/code42cli/cmds/devices.py
@@ -443,10 +443,13 @@ def _get_device_dataframe(
 
 
 def _add_settings_to_dataframe(sdk, device_dataframe):
-    macos_guids = [{"guid": value} for value in device_dataframe.loc[
-        device_dataframe["osName"] == "mac", "guid"
-    ].values]
-    click.echo(macos_guids)
+    macos_guids = [
+        {"guid": value}
+        for value in device_dataframe.loc[
+            device_dataframe["osName"] == "mac", "guid"
+        ].values
+    ]
+
     def handle_row(guid):
         try:
             full_disk_access_status = sdk.devices.get_agent_full_disk_access_state(


### PR DESCRIPTION
There's a bug with devices list --include-settings caused by the addition of row.pop() to _process_csv_row. This fixes it by passing in a list of dicts as expected, instead of a list of strings.

I'm not sure if we're passing lists of strings to run_bulk_process() anywhere else, but if we are those should probably be updated as well.