### PR TITLE
Bugfix/watchlist csv handle extra headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+## Unreleased
+
+### Fixed
+- `watchlists bulk` commands now accept CSVs with extra headers
 
 ## 1.14.0 - 2022-05-19
 

--- a/docs/userguides/watchlists.md
+++ b/docs/userguides/watchlists.md
@@ -57,6 +57,23 @@ code42 watchlists bulk generate-template [add|remove]
 If both username and user_id are provided in the CSV row, the user_id value will take precedence. If watchlist_type and watchlist_id columns
 are both provided, the watchlist_id will take precedence.
 
+```{eval-rst}
+.. note::
+    For watchlists that track additional metadata for a user (e.g. the "departure date" for a user on the Departing watchlist), that data
+    can be added/updated via the `code42 users bulk update-risk-profile` command.
+
+    You can re-use the same CSV file for both commands, just add the required risk profile columns to the CSV.
+
+    For example, to bulk add users to multiple watchlists, with appropriate `start_date`, `end_date`, and `notes` values, create a CSV (named watchlists.csv) like::
+
+        username,watchlist_type,start_date,end_date,notes
+        user_a@example.com,DEPARTING_EMPLOYEE,,2023-10-10,
+        user_b@example.com,NEW_EMPLOYEE,2022-07-04,,2022 Summer Interns
+
+    Then run `code42 watchlists bulk add watchlists.csv`
+    followed by `code42 users bulk update-risk-profile watchlists.csv`
+```
+
 ## Add Watchlist-related metadata to User's Profile
 
 Some Watchlists store related metadata to the watchlist member on the User Risk Profile. For example, when adding a user

--- a/docs/userguides/watchlists.md
+++ b/docs/userguides/watchlists.md
@@ -59,23 +59,18 @@ are both provided, the watchlist_id will take precedence.
 
 ```{eval-rst}
 .. note::
+
     For watchlists that track additional metadata for a user (e.g. the "departure date" for a user on the Departing watchlist), that data
-    can be added/updated via the `code42 users bulk update-risk-profile` command.
+    can be added/updated via the `code42 users bulk update-risk-profile <../commands/users.html#users-bulk-update-risk-profile>`_ command.
 
     You can re-use the same CSV file for both commands, just add the required risk profile columns to the CSV.
 
-    For example, to bulk add users to multiple watchlists, with appropriate `start_date`, `end_date`, and `notes` values, create a CSV (named watchlists.csv) like::
+    For example, to bulk add users to multiple watchlists, with appropriate ``start_date``, ``end_date``, and ``notes`` values, create a CSV (in this example named ``watchlists.csv``) with the following::
 
         username,watchlist_type,start_date,end_date,notes
         user_a@example.com,DEPARTING_EMPLOYEE,,2023-10-10,
         user_b@example.com,NEW_EMPLOYEE,2022-07-04,,2022 Summer Interns
 
-    Then run `code42 watchlists bulk add watchlists.csv`
-    followed by `code42 users bulk update-risk-profile watchlists.csv`
+    Then run ``code42 watchlists bulk add watchlists.csv``
+    followed by ``code42 users bulk update-risk-profile watchlists.csv``
 ```
-
-## Add Watchlist-related metadata to User's Profile
-
-Some Watchlists store related metadata to the watchlist member on the User Risk Profile. For example, when adding a user
-to the Departing Watchlist in the Code42 admin console, you can specify a "departure date" for the user. These values
-can be set/updated from the CLI under the [Users command group](./users.md#manage-user-risk-profile-info)

--- a/src/code42cli/cmds/watchlists.py
+++ b/src/code42cli/cmds/watchlists.py
@@ -186,7 +186,7 @@ def bulk_add(state, csv_rows):
 
     sdk = state.sdk
 
-    def handle_row(watchlist_id=None, watchlist_type=None, user_id=None, username=None):
+    def handle_row(watchlist_id=None, watchlist_type=None, user_id=None, username=None, **kwargs):
         if username and not user_id:
             user_id = sdk.userriskprofile.get_by_username(username)["userId"]
         if watchlist_id:
@@ -240,7 +240,7 @@ def bulk_remove(state, csv_rows):
 
     sdk = state.sdk
 
-    def handle_row(watchlist_id=None, watchlist_type=None, user_id=None, username=None):
+    def handle_row(watchlist_id=None, watchlist_type=None, user_id=None, username=None, **kwargs):
         if username and not user_id:
             user_id = sdk.userriskprofile.get_by_username(username)["userId"]
         if watchlist_id:

--- a/src/code42cli/cmds/watchlists.py
+++ b/src/code42cli/cmds/watchlists.py
@@ -186,7 +186,9 @@ def bulk_add(state, csv_rows):
 
     sdk = state.sdk
 
-    def handle_row(watchlist_id=None, watchlist_type=None, user_id=None, username=None, **kwargs):
+    def handle_row(
+        watchlist_id=None, watchlist_type=None, user_id=None, username=None, **kwargs
+    ):
         if username and not user_id:
             user_id = sdk.userriskprofile.get_by_username(username)["userId"]
         if watchlist_id:
@@ -240,7 +242,9 @@ def bulk_remove(state, csv_rows):
 
     sdk = state.sdk
 
-    def handle_row(watchlist_id=None, watchlist_type=None, user_id=None, username=None, **kwargs):
+    def handle_row(
+        watchlist_id=None, watchlist_type=None, user_id=None, username=None, **kwargs
+    ):
         if username and not user_id:
             user_id = sdk.userriskprofile.get_by_username(username)["userId"]
         if watchlist_id:

--- a/tests/cmds/test_watchlists.py
+++ b/tests/cmds/test_watchlists.py
@@ -579,7 +579,7 @@ class TestWatchlistBulkAddCmd:
         with runner.isolated_filesystem():
             with open("csv", "w") as file:
                 file.write(
-                    "username,user_id,watchlist_id,watchlist_type\ntest@example.com,1234,abcd,DEPARTING_EMPLOYEE\n"
+                    "username,user_id,watchlist_id,watchlist_type,extra_header\ntest@example.com,1234,abcd,DEPARTING_EMPLOYEE,\n"
                 )
             runner.invoke(cli, ["watchlists", "bulk", "add", "csv"], obj=cli_state)
             cli_state.sdk.watchlists.add_included_users_by_watchlist_id.assert_called_once_with(


### PR DESCRIPTION
Accept extra columns in the CSV passed to bulk watchlist commands, and add clearer documentation for updating user/watchlist metadata. 