### PR TITLE
proxy support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+## Unreleased
+
+### Added
+
+- Proxy support via `HTTPS_PROXY` environment variable.
+
 ## 1.15.0 - 2022-08-23
 
 ### Added

--- a/docs/userguides/gettingstarted.md
+++ b/docs/userguides/gettingstarted.md
@@ -85,13 +85,21 @@ Password (TOTP) must be provided at every invocation of the CLI, either via the 
 The Code42 CLI currently does **not** support SSO login providers or any other identity providers such as Active
 Directory or Okta.
 
+## Proxy Support
+
+```{eval-rst}
+.. note:: Proxy support was added in code42cli version 1.16.0
+```
+
+The Code42 CLI will attempt to connect through a proxy if the `https_proxy`/`HTTPS_PROXY` environment variable is set.
+
 ### Windows and Mac
 
 For Windows and Mac systems, the CLI uses Keyring when storing passwords.
 
 ### Red Hat Enterprise Linux
 
-To use Keyring to store the credentials you enter in the Code42 CLI, enter the following commands before installing.
+To use Keyring to store the credentials you 2enter in the Code42 CLI, enter the following commands before installing.
 ```bash
 yum -y install python-pip python3 dbus-python gnome-keyring libsecret dbus-x11
 pip3 install code42cli

--- a/src/code42cli/sdk_client.py
+++ b/src/code42cli/sdk_client.py
@@ -21,7 +21,7 @@ logger = get_main_cli_logger()
 
 
 def create_sdk(profile, is_debug_mode, password=None, totp=None):
-    proxy = environ.get("HTTPS_PROXY")
+    proxy = environ.get("HTTPS_PROXY") or environ.get("https_proxy")
     if proxy:
         py42.settings.proxies = {"https": proxy}
     if is_debug_mode:

--- a/src/code42cli/sdk_client.py
+++ b/src/code42cli/sdk_client.py
@@ -1,3 +1,5 @@
+from os import environ
+
 import py42.sdk
 import py42.settings
 import py42.settings.debug as debug
@@ -19,6 +21,9 @@ logger = get_main_cli_logger()
 
 
 def create_sdk(profile, is_debug_mode, password=None, totp=None):
+    proxy = environ.get("HTTPS_PROXY")
+    if proxy:
+        py42.settings.proxies = {"https": proxy}
     if is_debug_mode:
         py42.settings.debug.level = debug.DEBUG
     if profile.ignore_ssl_errors == "True":
@@ -46,6 +51,10 @@ def _validate_connection(authority_url, username, password, totp=None):
         )
     except ConnectionError as err:
         logger.log_error(err)
+        if "ProxyError" in str(err):
+            raise LoggedCLIError(
+                f"Unable to connect to proxy! Proxy configuration set by environment variable: HTTPS_PROXY={environ.get('HTTPS_PROXY')}"
+            )
         raise LoggedCLIError(f"Problem connecting to {authority_url}.")
     except Py42UnauthorizedError as err:
         logger.log_error(err)

--- a/tests/test_sdk_client.py
+++ b/tests/test_sdk_client.py
@@ -123,7 +123,7 @@ def test_create_sdk_uses_proxy_when_env_var_set(
     monkeypatch.setenv(proxy_env, "http://test.domain")
     with pytest.raises(LoggedCLIError) as err:
         create_sdk(mock_profile_with_password, False)
-        
+
     assert "Unable to connect to proxy!" in str(err.value)
     assert py42.settings.proxies["https"] == "http://test.domain"
 

--- a/tests/test_sdk_client.py
+++ b/tests/test_sdk_client.py
@@ -116,6 +116,15 @@ def test_create_sdk_uses_given_credentials(
     )
 
 
+def test_create_sdk_uses_proxy_when_env_var_set(
+    mock_profile_with_password, monkeypatch
+):
+    monkeypatch.setenv("HTTPS_PROXY", "http://test.domain")
+    with pytest.raises(LoggedCLIError):
+        create_sdk(mock_profile_with_password, False)
+    assert py42.settings.proxies["https"] == "http://test.domain"
+
+
 def test_create_sdk_connection_when_2FA_login_config_detected_prompts_for_totp(
     mocker, monkeypatch, mock_sdk_factory, capsys, mock_profile_with_password
 ):

--- a/tests/test_sdk_client.py
+++ b/tests/test_sdk_client.py
@@ -116,12 +116,15 @@ def test_create_sdk_uses_given_credentials(
     )
 
 
+@pytest.mark.parametrize("proxy_env", ["HTTPS_PROXY", "https_proxy"])
 def test_create_sdk_uses_proxy_when_env_var_set(
-    mock_profile_with_password, monkeypatch
+    mock_profile_with_password, monkeypatch, proxy_env
 ):
-    monkeypatch.setenv("HTTPS_PROXY", "http://test.domain")
-    with pytest.raises(LoggedCLIError):
+    monkeypatch.setenv(proxy_env, "http://test.domain")
+    with pytest.raises(LoggedCLIError) as err:
         create_sdk(mock_profile_with_password, False)
+        
+    assert "Unable to connect to proxy!" in str(err.value)
     assert py42.settings.proxies["https"] == "http://test.domain"
 
 


### PR DESCRIPTION
Adds support for the `HTTPS_PROXY` environment variable to configure `py42.settings.proxies` within the CLI. 

Resolves #330
